### PR TITLE
Update Helm chart and README for Tsuga integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Helm's [documentation](https://helm.sh/docs) to get started.
 Once Helm has been set up correctly, add the repo as follows:
 
 ```bash
-helm repo add otel-charts https://tsuga-dev.github.io/helm-charts/
+helm repo add tsuga-charts https://tsuga-dev.github.io/helm-charts/
 ```
 
 If you had already added this repo earlier, run `helm repo update` to retrieve
@@ -20,7 +20,7 @@ otel-charts` to see the charts.
 To install the opentelemetry-kube-stack chart:
 
 ```bash
-helm install my-opentelemetry-kube-stack helm-charts/opentelemetry-kube-stack
+helm install my-opentelemetry-kube-stack tsuga-charts/opentelemetry-kube-stack
 ```
 
 To uninstall the chart:
@@ -28,6 +28,27 @@ To uninstall the chart:
 ```bash
 helm uninstall my-opentelemetry-kube-stack
 ```
+
+## Quick Deployment with Script
+
+For a streamlined deployment experience, you can use the provided deployment script that handles prerequisites and configuration automatically:
+
+```bash
+cd charts/opentelemetry-kube-stack
+./deploy.sh
+```
+
+The script will:
+- Check and install required dependencies (cert-manager, OpenTelemetry operator)
+- Prompt for namespace configuration
+- Configure OpenTelemetry endpoint and API key
+- Deploy the Helm chart with proper settings
+- Verify the deployment
+
+**Prerequisites:**
+- `kubectl` configured and connected to your cluster
+- `helm` installed
+- Appropriate cluster permissions
 
 ## Available Charts
 

--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-kube-stack
-description: A comprehensive Helm chart for OpenTelemetry Kubernetes operator with namespace and secret management
+description: A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet + cluster receiver), secure credential management, and production-ready configurations for telemetry collection to Tsuga platform.
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.88.0"
+appVersion: "v1"
 
 # Chart keywords
 keywords:
@@ -36,14 +36,14 @@ keywords:
 # Chart maintainers
 maintainers:
   - name: OpenTelemetry Team
-    email: opentelemetry@example.com
+    email: antonin@tsuga.com
 
 # Chart home page
-home: https://opentelemetry.io/
+home: https://tsuga-dev.github.io/helm-charts/
 
 # Chart sources
 sources:
-  - https://github.com/open-telemetry/opentelemetry-operator
+  - https://github.com/tsuga-dev/helm-charts
 
 # Chart dependencies
 dependencies: []

--- a/charts/opentelemetry-kube-stack/deploy.sh
+++ b/charts/opentelemetry-kube-stack/deploy.sh
@@ -338,6 +338,10 @@ deploy_helm_chart() {
     if [[ -n "$OTEL_API_KEY" ]]; then
         helm_args="$helm_args --set tsuga.apiKey=\"$OTEL_API_KEY\""
     fi
+
+    if [[ -n "$OTEL_ENDPOINT" && -n "$OTEL_API_KEY" ]]; then
+        helm_args="$helm_args --set secret.create=true"
+    fi
     
     # Check if release already exists
     if helm list -n "$NAMESPACE" | grep -q "$RELEASE_NAME"; then


### PR DESCRIPTION
- Changed repository name from `otel-charts` to `tsuga-charts` in installation instructions.
- Enhanced the chart description to include Tsuga integration details.
- Updated the app version to `v1` and incremented chart version to `0.2.1`.
- Added a deployment script section in the README for streamlined deployment.
- Modified `deploy.sh` to include logic for secret creation based on provided API key and endpoint.
- Removed outdated security considerations and usage examples from the README.