### PR TITLE
Update opentelemetry-kube-stack dependency to version 0.2.8 and add collectLogs option in values.yaml

### DIFF
--- a/charts/opentelemetry-demo/Chart.lock
+++ b/charts/opentelemetry-demo/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: opentelemetry-kube-stack
   repository: https://tsuga-dev.github.io/helm-charts
-  version: 0.2.7
+  version: 0.2.8
 - name: opentelemetry-demo
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.38.6
-digest: sha256:8c2125194c6557990c512af4f759034e907037bd56e196f91e95ff327220cd99
-generated: "2025-12-15T09:46:09.132439+01:00"
+digest: sha256:1785b9e5e7c248e6fb16afd7468687adad83be008fb33a57e5756dcbb8f633d4
+generated: "2025-12-16T13:12:39.673377+01:00"

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: 0.38.6
 
 dependencies:
   - name: opentelemetry-kube-stack
-    version: 0.2.7
+    version: 0.2.8
     repository: https://tsuga-dev.github.io/helm-charts
     condition: opentelemetry-kube-stack.enabled
   - name: opentelemetry-demo

--- a/charts/opentelemetry-demo/README.md
+++ b/charts/opentelemetry-demo/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-demo
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.38.6](https://img.shields.io/badge/AppVersion-0.38.6-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.38.6](https://img.shields.io/badge/AppVersion-0.38.6-informational?style=flat-square)
 
 A Helm chart for Tsuga Observability Demo
 
@@ -9,7 +9,7 @@ A Helm chart for Tsuga Observability Demo
 | Repository | Name | Version |
 |------------|------|---------|
 | https://open-telemetry.github.io/opentelemetry-helm-charts | opentelemetry-demo(opentelemetry-demo) | 0.38.6 |
-| https://tsuga-dev.github.io/helm-charts | opentelemetry-kube-stack | 0.2.7 |
+| https://tsuga-dev.github.io/helm-charts | opentelemetry-kube-stack | 0.2.8 |
 
 ## Values
 
@@ -44,6 +44,7 @@ A Helm chart for Tsuga Observability Demo
 | opentelemetry-demo.opensearch.enabled | bool | `false` |  |
 | opentelemetry-demo.opentelemetry-collector.enabled | bool | `false` |  |
 | opentelemetry-demo.prometheus.enabled | bool | `false` |  |
+| opentelemetry-kube-stack.agent.collectLogs | bool | `false` |  |
 | opentelemetry-kube-stack.agent.config.extraReceivers.nginx.collection_interval | string | `"10s"` |  |
 | opentelemetry-kube-stack.agent.config.extraReceivers.nginx.endpoint | string | `"http://image-provider.default:8081/status"` |  |
 | opentelemetry-kube-stack.agent.config.extraReceivers.postgresql.endpoint | string | `"postgresql.default:5432"` |  |

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-kube-stack/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-kube-stack/daemonset.yaml
@@ -24,20 +24,6 @@ spec:
     requests:
       cpu: 100m
       memory: 128Mi
-  volumeMounts:
-    - name: varlogpods
-      mountPath: /var/log/pods
-      readOnly: true
-    - name: varlibdockercontainers
-      mountPath: /var/lib/docker/containers
-      readOnly: true
-  volumes:
-    - name: varlogpods
-      hostPath:
-        path: /var/log/pods
-    - name: varlibdockercontainers
-      hostPath:
-        path: /var/lib/docker/containers
   serviceAccount: example-opentelemetry-kube-stack
   env:
     - name: TSUGA_OTLP_ENDPOINT
@@ -57,19 +43,6 @@ spec:
           key: TSUGA_API_KEY
   config:
     receivers:
-      filelog:
-        exclude: []
-        include:
-        - /var/log/pods/*/*/*.log
-        include_file_name: false
-        include_file_path: true
-        operators:
-        - id: container-parser
-          max_log_size: 102400
-          type: container
-        retry_on_failure:
-          enabled: true
-        start_at: end
       hostmetrics:
         collection_interval: 10s
         scrapers:
@@ -234,7 +207,6 @@ spec:
           - resource
           receivers:
           - otlp
-          - filelog
         metrics:
           exporters:
           - otlphttp/tsuga

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -88,6 +88,7 @@ opentelemetry-kube-stack:
   enabled: true
   agent:
     image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+    collectLogs: false
     config:
       extraReceivers:
         nginx:


### PR DESCRIPTION
- Bumped opentelemetry-kube-stack version in Chart.lock and Chart.yaml.
- Added collectLogs configuration option to values.yaml for better log collection control.
- Removed unused volume mounts and filelog receiver from daemonset.yaml to streamline configuration.