### PR TITLE
Update OpenTelemetry kube-stack to version 0.2.10 and modify configuration to use NODE_IP for endpoint resolution

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.9
+version: 0.2.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-kube-stack
 
-![Version: 0.2.9](https://img.shields.io/badge/Version-0.2.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
+![Version: 0.2.10](https://img.shields.io/badge/Version-0.2.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
 
 A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet + cluster receiver), secure credential management, and production-ready configurations for telemetry collection to Tsuga platform.
 

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
@@ -40,6 +40,11 @@ spec:
         secretKeyRef:
           name: otel-secret
           key: TSUGA_API_KEY
+    - name: NODE_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
   config:
     receivers:
       k8s_cluster:

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/daemonset.yaml
@@ -62,6 +62,11 @@ spec:
         secretKeyRef:
           name: otel-secret
           key: TSUGA_API_KEY
+    - name: NODE_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
   config:
     receivers:
       filelog:
@@ -107,7 +112,7 @@ spec:
       kubeletstats:
         auth_type: serviceAccount
         collection_interval: 20s
-        endpoint: ${env:K8S_NODE_NAME}:10250
+        endpoint: ${env:NODE_IP}:10250
         insecure_skip_verify: true
       otlp:
         protocols:

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
@@ -40,6 +40,11 @@ spec:
         secretKeyRef:
           name: otel-secret
           key: TSUGA_API_KEY
+    - name: NODE_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
   config:
     receivers:
       k8s_cluster:

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/daemonset.yaml
@@ -62,6 +62,11 @@ spec:
         secretKeyRef:
           name: otel-secret
           key: TSUGA_API_KEY
+    - name: NODE_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
   config:
     receivers:
       filelog:
@@ -107,7 +112,7 @@ spec:
       kubeletstats:
         auth_type: serviceAccount
         collection_interval: 20s
-        endpoint: ${env:K8S_NODE_NAME}:10250
+        endpoint: ${env:NODE_IP}:10250
         insecure_skip_verify: true
       otlp:
         protocols:

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
@@ -40,6 +40,11 @@ spec:
         secretKeyRef:
           name: otel-secret
           key: TSUGA_API_KEY
+    - name: NODE_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
   config:
     receivers:
       k8s_cluster:

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/daemonset.yaml
@@ -50,6 +50,11 @@ spec:
         secretKeyRef:
           name: otel-secret
           key: TSUGA_API_KEY
+    - name: NODE_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
   config:
     receivers:
       hostmetrics:
@@ -82,7 +87,7 @@ spec:
       kubeletstats:
         auth_type: serviceAccount
         collection_interval: 20s
-        endpoint: ${env:K8S_NODE_NAME}:10250
+        endpoint: ${env:NODE_IP}:10250
         insecure_skip_verify: true
       nginx:
         collection_interval: 10s

--- a/charts/opentelemetry-kube-stack/templates/_config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_config.tpl
@@ -21,6 +21,11 @@ Generate environment variables for OpenTelemetry Collector
     secretKeyRef:
       name: {{ include "opentelemetry-kube-stack.secretName" . }}
       key: {{ include "opentelemetry-kube-stack.secretKey" (dict "keyName" "TSUGA_API_KEY" "Values" .Values) }}
+- name: NODE_IP
+  valueFrom:
+    fieldRef:
+      apiVersion: v1
+      fieldPath: status.hostIP
 {{- end }}
 
 {{/*

--- a/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
@@ -34,7 +34,7 @@ receivers:
     insecure_skip_verify: true
     auth_type: serviceAccount
     collection_interval: 20s
-    endpoint: ${env:K8S_NODE_NAME}:10250
+    endpoint: ${env:NODE_IP}:10250
   hostmetrics:
     root_path: /hostfs
     collection_interval: 10s


### PR DESCRIPTION
- Bumped chart version to 0.2.10.
- Added NODE_IP environment variable to the OpenTelemetry Collector configuration.
- Updated kubletstats receiver in the daemonset configuration to reference NODE_IP instead of K8S_NODE_NAME.