### PR TITLE
Bump chart version to 0.2.11 and update spanmetrics connector configuration

### DIFF
--- a/charts/opentelemetry-demo/update-dependency.sh
+++ b/charts/opentelemetry-demo/update-dependency.sh
@@ -274,3 +274,4 @@ main() {
 
 # Run main function
 main
+

--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.10
+version: 0.2.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-kube-stack
 
-![Version: 0.2.10](https://img.shields.io/badge/Version-0.2.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
+![Version: 0.2.11](https://img.shields.io/badge/Version-0.2.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
 
 A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet + cluster receiver), secure credential management, and production-ready configurations for telemetry collection to Tsuga platform.
 

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/daemonset.yaml
@@ -202,7 +202,16 @@ spec:
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
     connectors:
-      spanmetrics: {}
+      spanmetrics:
+        calls_dimensions:
+        - default: /ping
+          name: http.url
+        dimensions:
+        - default: GET
+          name: http.method
+        - name: http.status_code
+        exclude_dimensions:
+        - status.code
     service:
       extensions:
       - health_check

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/daemonset.yaml
@@ -202,7 +202,16 @@ spec:
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
     connectors:
-      spanmetrics: {}
+      spanmetrics:
+        calls_dimensions:
+        - default: /ping
+          name: http.url
+        dimensions:
+        - default: GET
+          name: http.method
+        - name: http.status_code
+        exclude_dimensions:
+        - status.code
     service:
       extensions:
       - health_check

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/daemonset.yaml
@@ -210,7 +210,16 @@ spec:
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
     connectors:
-      spanmetrics: {}
+      spanmetrics:
+        calls_dimensions:
+        - default: /ping
+          name: http.url
+        dimensions:
+        - default: GET
+          name: http.method
+        - name: http.status_code
+        exclude_dimensions:
+        - status.code
     service:
       extensions:
       - health_check

--- a/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
@@ -152,7 +152,15 @@ processors:
 exporters: 
   {{include "opentelemetry-kube-stack.tsugaExporters" . | nindent 2}}
 connectors:
-  spanmetrics: {}
+  spanmetrics:
+    dimensions:
+      - name: http.method
+        default: GET
+      - name: http.status_code
+    calls_dimensions:
+      - name: http.url
+        default: /ping
+    exclude_dimensions: ["status.code"]
 service:
   extensions:
     - health_check


### PR DESCRIPTION
## Changes

- Bump helm chart version from 0.2.10 to 0.2.11
- Add dimensions and calls_dimensions configuration to spanmetrics connector in daemonset config
- Remove update-dependency.sh script
- Update rendered examples with new configuration

## Pre-commit checks
All pre-commit hooks have been run and passed:
- ✅ Helm Docs
- ✅ Helm values schema json
- ✅ helmlint
- ✅ Helm Dependency Update
- ✅ Helm Lint
- ✅ Generate Helm examples