### PR TITLE
chore: update opentelemetry-kube-stack dependency to 0.2.11

### DIFF
--- a/charts/opentelemetry-demo/Chart.lock
+++ b/charts/opentelemetry-demo/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: opentelemetry-kube-stack
   repository: https://tsuga-dev.github.io/helm-charts
-  version: 0.2.10
+  version: 0.2.11
 - name: opentelemetry-demo
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.38.6
-digest: sha256:142267a4c7d8ec86542c88143418f82896f3fa90d14638396d8795cb63a2237e
-generated: "2025-12-18T08:52:23.037331+01:00"
+digest: sha256:7070af651d2afe831b69af0606abdcf666ca0f9df954c8c04b0da6e7ed5ff29f
+generated: "2026-01-05T10:49:03.401241+01:00"

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,7 +25,7 @@ appVersion: 0.38.6
 
 dependencies:
   - name: opentelemetry-kube-stack
-    version: 0.2.10
+    version: 0.2.11
     repository: https://tsuga-dev.github.io/helm-charts
     condition: opentelemetry-kube-stack.enabled
   - name: opentelemetry-demo

--- a/charts/opentelemetry-demo/README.md
+++ b/charts/opentelemetry-demo/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-demo
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.38.6](https://img.shields.io/badge/AppVersion-0.38.6-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.38.6](https://img.shields.io/badge/AppVersion-0.38.6-informational?style=flat-square)
 
 A Helm chart for Tsuga Observability Demo
 
@@ -9,7 +9,7 @@ A Helm chart for Tsuga Observability Demo
 | Repository | Name | Version |
 |------------|------|---------|
 | https://open-telemetry.github.io/opentelemetry-helm-charts | opentelemetry-demo(opentelemetry-demo) | 0.38.6 |
-| https://tsuga-dev.github.io/helm-charts | opentelemetry-kube-stack | 0.2.10 |
+| https://tsuga-dev.github.io/helm-charts | opentelemetry-kube-stack | 0.2.11 |
 
 ## Values
 

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-kube-stack/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-kube-stack/daemonset.yaml
@@ -207,7 +207,16 @@ spec:
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
     connectors:
-      spanmetrics: {}
+      spanmetrics:
+        calls_dimensions:
+        - default: /ping
+          name: http.url
+        dimensions:
+        - default: GET
+          name: http.method
+        - name: http.status_code
+        exclude_dimensions:
+        - status.code
     service:
       extensions:
       - health_check


### PR DESCRIPTION
This PR updates the `opentelemetry-kube-stack` dependency version to `0.2.11` and bumps the chart version to `0.3.0`.

## Changes
- Updated `opentelemetry-kube-stack` dependency: `0.2.10` → `0.2.11`
- Bumped chart version: `0.2.0` → `0.3.0`
- Ran pre-commit hooks to ensure code quality

## Checklist
- [x] Dependency version updated
- [x] Chart version bumped
- [x] Pre-commit hooks passed
- [x] Changes committed and pushed