### PR TITLE
fix(otel-kube-stack): fix tolerations schema type for agent and cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/
 charts/**/charts/*.tgz
 charts/**/values_test.yaml
+.worktrees/

--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -286,7 +286,7 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | agent.image | string | "" | OpenTelemetry Collector image for agent Defaults to: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s |
 | agent.nodeSelector | object | {} | Agent-specific node selector If not set, inherits from global nodeSelector configuration |
 | agent.resources | object | {} | Agent-specific resource limits and requests If not set, inherits from global resources configuration |
-| agent.tolerations | object | {} | Agent-specific tolerations If not set, inherits from global tolerations configuration |
+| agent.tolerations | list | [] | Agent-specific tolerations If not set, inherits from global tolerations configuration |
 | autoInstrumentation.annotations | object | {} | Extra annotations to add to the Instrumentation resource |
 | autoInstrumentation.apiVersion | string | "opentelemetry.io/v1alpha1" | apiVersion for the Instrumentation CR (depends on operator version) Common values: "opentelemetry.io/v1alpha1" |
 | autoInstrumentation.enabled | bool | false | Enable OpenTelemetry Operator auto-instrumentation (Instrumentation CR) Requires the OpenTelemetry Operator to be installed in the cluster. |
@@ -324,7 +324,7 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | cluster.image | string | "" | OpenTelemetry Collector image for cluster receiver Defaults to: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s |
 | cluster.nodeSelector | object | {} | Cluster-specific node selector If not set, inherits from global nodeSelector configuration |
 | cluster.resources | object | {} | Cluster-specific resource limits and requests If not set, inherits from global resources configuration |
-| cluster.tolerations | object | {} | Cluster-specific tolerations If not set, inherits from global tolerations configuration |
+| cluster.tolerations | list | [] | Cluster-specific tolerations If not set, inherits from global tolerations configuration |
 | clusterName | string | "" | The name of the cluster to be used in the resource attributes This value is added to all telemetry data as k8s.cluster.name RECOMMENDED: Set this value to identify your cluster in telemetry data If not set, the k8s.cluster.name attribute will be omitted from telemetry |
 | fullnameOverride | string | "" | Override the full name used in resource naming |
 | image | string | "" | Default OpenTelemetry Collector image Used as fallback when cluster.image or agent.image are not set Format: registry/repository:tag |

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-kube-stack
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
 
 A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet + cluster receiver), secure credential management, and production-ready configurations for telemetry collection to Tsuga platform.
 

--- a/charts/opentelemetry-kube-stack/values.schema.json
+++ b/charts/opentelemetry-kube-stack/values.schema.json
@@ -135,7 +135,7 @@
                     "type": "object"
                 },
                 "tolerations": {
-                    "type": "object"
+                    "type": "array"
                 }
             }
         },
@@ -271,7 +271,7 @@
                     "type": "object"
                 },
                 "tolerations": {
-                    "type": "object"
+                    "type": "array"
                 }
             }
         },

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -360,8 +360,8 @@ cluster:
   nodeSelector: {}
   # -- Cluster-specific tolerations
   # If not set, inherits from global tolerations configuration
-  # @default -- {}
-  tolerations: {}
+  # @default -- []
+  tolerations: []
   # -- Cluster-specific affinity rules
   # If not set, inherits from global affinity configuration
   # @default -- {}
@@ -533,8 +533,8 @@ agent:
   nodeSelector: {}
   # -- Agent-specific tolerations
   # If not set, inherits from global tolerations configuration
-  # @default -- {}
-  tolerations: {}
+  # @default -- []
+  tolerations: []
   # -- Agent-specific affinity rules
   # If not set, inherits from global affinity configuration
   # @default -- {}


### PR DESCRIPTION
## Summary

- `agent.tolerations` and `cluster.tolerations` were defaulting to `{}` (empty object), causing the JSON schema generator to type them as `object`
- The global `tolerations` was correctly typed as an `array`
- This caused a validation error when users tried to set tolerations on the agent or cluster collector:
  ```
  Error: values don't meet the specifications of the schema(s) in the following chart(s):
  opentelemetry-kube-stack:
  - agent.tolerations: Invalid type. Expected: object, given: array
  ```

## Changes

- Changed `agent.tolerations` and `cluster.tolerations` defaults from `{}` to `[]` in `values.yaml`
- Auto-regenerated `values.schema.json` (both now typed as `array`)
- Auto-regenerated `README.md` (both now documented as `list` with default `[]`)

## Test plan

- [ ] Apply a values file with `agent.tolerations: [{operator: "Exists"}]` — should pass validation
- [ ] Apply a values file with `cluster.tolerations: [{operator: "Exists"}]` — should pass validation
- [ ] Verify `helm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)