### PR TITLE
feat(otel-kube-stack): add extraLabelMapping and extraAnnotationsMapping to statefulset

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-kube-stack
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
 
 A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet + cluster receiver), secure credential management, and production-ready configurations for telemetry collection to Tsuga platform.
 

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -370,7 +370,9 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | statefulset.config.service.pipelines.metrics.extraProcessors | list | [] | Additional processors to add to the metrics pipeline Added to default processors (k8sattributes, batch) |
 | statefulset.config.service.pipelines.metrics.extraReceivers | list | [] | Additional receivers to add to the metrics pipeline Added to default receiver (prometheus) |
 | statefulset.customConfig | object | {} | Replace default config with complete custom configuration |
+| statefulset.extraAnnotationsMapping | list | [] | Annotations mapping configuration for agent Maps Kubernetes pod annotations to OpenTelemetry resource attributes These are appended to default annotation mappings Format: List of objects with tag_name, key, and from fields |
 | statefulset.extraEnvs | list | [] | Extra environment variables for statefulset collector |
+| statefulset.extraLabelMapping | list | [] | Label mapping configuration for agent Maps Kubernetes pod labels to OpenTelemetry resource attributes These are appended to default label mappings Format: List of objects with tag_name, key, and from fields Example:   extraLabelMapping:     - tag_name: "app.version"       key: "app.version"       from: "pod" |
 | statefulset.image | string | "" | OpenTelemetry Collector image for statefulset collector |
 | statefulset.nodeSelector | object | {} | StatefulSet-specific node selector |
 | statefulset.replicas | int | 1 | Number of StatefulSet collector replicas The Target Allocator distributes targets evenly across replicas. |

--- a/charts/opentelemetry-kube-stack/templates/_default-statefulset-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-statefulset-config.tpl
@@ -48,6 +48,9 @@ processors:
         - tag_name: team
           key: resource.opentelemetry.io/team
           from: pod
+{{- if .Values.statefulset.extraLabelMapping }}
+{{- toYaml .Values.statefulset.extraLabelMapping | nindent 8 }}
+{{- end}}
       annotations:
         - tag_name: service.name
           key: resource.opentelemetry.io/service.name
@@ -61,6 +64,9 @@ processors:
         - tag_name: team
           key: resource.opentelemetry.io/team
           from: pod
+{{- if .Values.statefulset.extraAnnotationsMapping }}
+{{- toYaml .Values.statefulset.extraAnnotationsMapping | nindent 8 }}
+{{- end}}
     passthrough: false
     pod_association:
       - sources:

--- a/charts/opentelemetry-kube-stack/values.schema.json
+++ b/charts/opentelemetry-kube-stack/values.schema.json
@@ -471,7 +471,13 @@
                 "customConfig": {
                     "type": "object"
                 },
+                "extraAnnotationsMapping": {
+                    "type": "array"
+                },
                 "extraEnvs": {
+                    "type": "array"
+                },
+                "extraLabelMapping": {
                     "type": "array"
                 },
                 "image": {

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -699,6 +699,23 @@ statefulset:
         # -- Additional pipelines to add to the service configuration
         # @default -- {}
         extraPipelines: {}
+  # -- Label mapping configuration for agent
+  # Maps Kubernetes pod labels to OpenTelemetry resource attributes
+  # These are appended to default label mappings
+  # Format: List of objects with tag_name, key, and from fields
+  # Example:
+  #   extraLabelMapping:
+  #     - tag_name: "app.version"
+  #       key: "app.version"
+  #       from: "pod"
+  # @default -- []
+  extraLabelMapping: []
+  # -- Annotations mapping configuration for agent
+  # Maps Kubernetes pod annotations to OpenTelemetry resource attributes
+  # These are appended to default annotation mappings
+  # Format: List of objects with tag_name, key, and from fields
+  # @default -- []
+  extraAnnotationsMapping: []
   # -- StatefulSet-specific resource limits and requests
   # @default -- {}
   resources: {}


### PR DESCRIPTION
## Summary
- Adds `extraLabelMapping` to extend default pod label → OTel resource attribute mappings in the statefulset k8sattributes processor
- Adds `extraAnnotationsMapping` to extend default pod annotation → OTel resource attribute mappings in the statefulset k8sattributes processor
- Updates `values.schema.json` and `README.md` accordingly

## Motivation
Users need to map custom pod labels/annotations (e.g. `app.version`) to OTel resource attributes without replacing the entire collector config via `customConfig`.

## Test plan
- [ ] Helm lint passes
- [ ] Template renders correctly with non-empty extraLabelMapping / extraAnnotationsMapping
- [ ] Template renders correctly when both fields are empty (default)
- [ ] Manual testing completed
