### PR TITLE
feat(otel-kube-stack): add k8sattributes to cluster receiver and k8s-objects example

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-kube-stack
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
+![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
 
 A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet + cluster receiver), secure credential management, and production-ready configurations for telemetry collection to Tsuga platform.
 

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
@@ -126,6 +126,7 @@ spec:
           exporters:
           - otlphttp/tsuga
           processors:
+          - k8sattributes
           - batch
           receivers:
           - k8s_cluster
@@ -133,6 +134,7 @@ spec:
           exporters:
           - otlphttp/tsuga
           processors:
+          - k8sattributes
           - batch
           receivers:
           - k8s_cluster

--- a/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
@@ -126,6 +126,7 @@ spec:
           exporters:
           - otlphttp/tsuga
           processors:
+          - k8sattributes
           - batch
           receivers:
           - k8s_cluster
@@ -133,6 +134,7 @@ spec:
           exporters:
           - otlphttp/tsuga
           processors:
+          - k8sattributes
           - batch
           receivers:
           - k8s_cluster

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
@@ -126,6 +126,7 @@ spec:
           exporters:
           - otlphttp/tsuga
           processors:
+          - k8sattributes
           - batch
           receivers:
           - k8s_cluster
@@ -133,6 +134,7 @@ spec:
           exporters:
           - otlphttp/tsuga
           processors:
+          - k8sattributes
           - batch
           receivers:
           - k8s_cluster

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
@@ -126,6 +126,7 @@ spec:
           exporters:
           - otlphttp/tsuga
           processors:
+          - k8sattributes
           - batch
           receivers:
           - k8s_cluster
@@ -133,6 +134,7 @@ spec:
           exporters:
           - otlphttp/tsuga
           processors:
+          - k8sattributes
           - batch
           receivers:
           - k8s_cluster

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
@@ -61,6 +61,12 @@ spec:
         - MemoryPressure
         - DiskPressure
         - PIDPressure
+      k8sobjects:
+        auth_type: serviceAccount
+        objects:
+        - field_selector: type=Warning
+          mode: watch
+          name: events
     processors:
       batch:
         send_batch_max_size: 5000
@@ -130,6 +136,7 @@ spec:
           - batch
           receivers:
           - k8s_cluster
+          - k8sobjects
         metrics:
           exporters:
           - otlphttp/tsuga

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/daemonset.yaml
@@ -1,0 +1,262 @@
+---
+# Source: opentelemetry-kube-stack/templates/daemonset.yaml
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: example-opentelemetry-kube-stack-agent
+  labels:
+    app.kubernetes.io/name: opentelemetry-kube-stack
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: agent
+    app.kubernetes.io/part-of: opentelemetry-kube-stack
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    meta.helm.sh/release-name: "example"
+    meta.helm.sh/release-namespace: "default"
+spec:
+  mode: daemonset
+  hostNetwork: true
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  volumeMounts:
+    - name: hostfs
+      mountPath: /hostfs
+      readOnly: true
+      mountPropagation: HostToContainer
+    - name: varlogpods
+      mountPath: /var/log/pods
+      readOnly: true
+    - name: varlibdockercontainers
+      mountPath: /var/lib/docker/containers
+      readOnly: true
+  volumes:
+    - name: hostfs
+      hostPath:
+        path: /
+    - name: varlogpods
+      hostPath:
+        path: /var/log/pods
+    - name: varlibdockercontainers
+      hostPath:
+        path: /var/lib/docker/containers
+  serviceAccount: example-opentelemetry-kube-stack
+  env:
+    - name: TSUGA_OTLP_ENDPOINT
+      valueFrom:
+        secretKeyRef:
+          name: otel-secret
+          key: TSUGA_OTLP_ENDPOINT
+    - name: MY_POD_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.podIP
+    - name: TSUGA_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: otel-secret
+          key: TSUGA_API_KEY
+    - name: NODE_IP
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: status.hostIP
+  config:
+    receivers:
+      filelog:
+        exclude: []
+        include:
+        - /var/log/pods/*/*/*.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+        - id: container-parser
+          max_log_size: 102400
+          type: container
+        retry_on_failure:
+          enabled: true
+        start_at: end
+      hostmetrics:
+        collection_interval: 10s
+        root_path: /hostfs
+        scrapers:
+          cpu:
+            metrics:
+              system.cpu.utilization:
+                enabled: true
+          disk: null
+          filesystem:
+            metrics:
+              system.filesystem.utilization:
+                enabled: true
+          load: null
+          memory: null
+          paging:
+            metrics:
+              system.paging.utilization:
+                enabled: true
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:14250
+          thrift_compact:
+            endpoint: ${env:MY_POD_IP}:6831
+          thrift_http:
+            endpoint: ${env:MY_POD_IP}:14268
+      kubeletstats:
+        auth_type: serviceAccount
+        collection_interval: 20s
+        endpoint: ${env:NODE_IP}:10250
+        extra_metadata_labels:
+        - k8s.volume.type
+        insecure_skip_verify: true
+        metric_groups:
+        - node
+        - pod
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+          http:
+            endpoint: ${env:MY_POD_IP}:4318
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: opentelemetry-collector
+            scrape_interval: 10s
+            static_configs:
+            - targets:
+              - ${env:MY_POD_IP}:8888
+      zipkin:
+        endpoint: ${env:MY_POD_IP}:9411
+    processors:
+      batch:
+        send_batch_max_size: 5000
+        send_batch_size: 5000
+      cumulativetodelta: {}
+      k8sattributes:
+        extract:
+          annotations:
+          - from: pod
+            key: resource.opentelemetry.io/service.name
+            tag_name: service.name
+          - from: pod
+            key: resource.opentelemetry.io/service.version
+            tag_name: service.version
+          - from: pod
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: pod
+            key: resource.opentelemetry.io/team
+            tag_name: team
+          labels:
+          - from: pod
+            key: resource.opentelemetry.io/service.name
+            tag_name: service.name
+          - from: pod
+            key: resource.opentelemetry.io/service.version
+            tag_name: service.version
+          - from: pod
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: pod
+            key: resource.opentelemetry.io/team
+            tag_name: team
+          metadata:
+          - k8s.namespace.name
+          - k8s.deployment.name
+          - k8s.statefulset.name
+          - k8s.daemonset.name
+          - k8s.cronjob.name
+          - k8s.job.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.pod.start_time
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: connection
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+    exporters:
+      otlphttp/tsuga:
+        endpoint: ${TSUGA_OTLP_ENDPOINT}
+        headers:
+          Authorization: Bearer ${TSUGA_API_KEY}
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+    connectors:
+      spanmetrics:
+        calls_dimensions:
+        - default: /ping
+          name: http.url
+        dimensions:
+        - default: GET
+          name: http.method
+        - name: http.status_code
+    service:
+      extensions:
+      - health_check
+      pipelines:
+        logs:
+          exporters:
+          - otlphttp/tsuga
+          processors:
+          - k8sattributes
+          - memory_limiter
+          - batch
+          receivers:
+          - otlp
+          - filelog
+        metrics:
+          exporters:
+          - otlphttp/tsuga
+          processors:
+          - k8sattributes
+          - memory_limiter
+          - batch
+          - cumulativetodelta
+          receivers:
+          - otlp
+          - prometheus
+          - kubeletstats
+          - spanmetrics
+          - hostmetrics
+        traces:
+          exporters:
+          - otlphttp/tsuga
+          - spanmetrics
+          processors:
+          - k8sattributes
+          - memory_limiter
+          - batch
+          receivers:
+          - otlp
+          - jaeger
+          - zipkin
+      telemetry:
+        metrics:
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/rbac.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/rbac.yaml
@@ -1,0 +1,88 @@
+---
+# Source: opentelemetry-kube-stack/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: example-opentelemetry-kube-stack
+  labels:
+    app.kubernetes.io/name: opentelemetry-kube-stack
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: opentelemetry-kube-stack
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    meta.helm.sh/release-name: "example"
+    meta.helm.sh/release-namespace: "default"
+rules:
+# Core Kubernetes resources for agent collection
+- apiGroups: [""]
+  resources: ["pods", "nodes", "nodes/proxy", "nodes/stats", "services", "endpoints", "namespaces", "replicationcontrollers", "resourcequotas"]
+  verbs: ["get", "list", "watch"]
+# Additional permissions for comprehensive monitoring
+- apiGroups: [""]
+  resources: ["pods/status", "nodes/status"]
+  verbs: ["get", "list", "watch"]
+# ConfigMaps for collector configuration
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# Application workloads
+- apiGroups: ["apps"]
+  resources: ["replicasets", "deployments", "daemonsets", "statefulsets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["extensions"]
+  resources: ["replicasets"]
+  verbs: ["get", "list", "watch"]
+# Batch workloads
+- apiGroups: ["batch"]
+  resources: ["jobs", "cronjobs"]
+  verbs: ["get", "list", "watch"]
+# Autoscaling
+- apiGroups: ["autoscaling"]
+  resources: ["horizontalpodautoscalers"]
+  verbs: ["get", "list", "watch"]
+# Network policies
+- apiGroups: ["networking.k8s.io"]
+  resources: ["networkpolicies", "ingresses"]
+  verbs: ["get", "list", "watch"]
+# Persistent volumes
+- apiGroups: [""]
+  resources: ["persistentvolumes", "persistentvolumeclaims"]
+  verbs: ["get", "list", "watch"]
+# Events (core and events.k8s.io groups for k8sobjects collector)
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["events.k8s.io"]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]
+# Additional API groups for comprehensive monitoring
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["nodes", "pods"]
+  verbs: ["get", "list"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "list", "watch"]
+---
+# Source: opentelemetry-kube-stack/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: example-opentelemetry-kube-stack
+  labels:
+    app.kubernetes.io/name: opentelemetry-kube-stack
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/part-of: opentelemetry-kube-stack
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    meta.helm.sh/release-name: "example"
+    meta.helm.sh/release-namespace: "default"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: example-opentelemetry-kube-stack
+subjects:
+- kind: ServiceAccount
+  name: example-opentelemetry-kube-stack
+  namespace: default

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/serviceaccount.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/serviceaccount.yaml
@@ -1,0 +1,15 @@
+---
+# Source: opentelemetry-kube-stack/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-opentelemetry-kube-stack
+  labels:
+    app.kubernetes.io/name: opentelemetry-kube-stack
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: serviceaccount
+    app.kubernetes.io/part-of: opentelemetry-kube-stack
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    meta.helm.sh/release-name: example
+    meta.helm.sh/release-namespace: default

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/values.yaml
@@ -1,0 +1,2 @@
+cluster:
+  collectk8sobjects: true

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
@@ -126,6 +126,7 @@ spec:
           exporters:
           - otlphttp/tsuga
           processors:
+          - k8sattributes
           - batch
           receivers:
           - k8s_cluster
@@ -133,6 +134,7 @@ spec:
           exporters:
           - otlphttp/tsuga
           processors:
+          - k8sattributes
           - batch
           receivers:
           - k8s_cluster

--- a/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
@@ -100,6 +100,7 @@ service:
         {{- if .Values.clusterName }}
         - resource
         {{- end }}
+        - k8sattributes
         - batch
       exporters:
         - otlphttp/tsuga
@@ -110,6 +111,7 @@ service:
         {{- if .Values.clusterName }}
         - resource
         {{- end }}
+        - k8sattributes
         - batch
       exporters:
         - otlphttp/tsuga


### PR DESCRIPTION
## Summary

- **Cluster receiver pipelines**: Add `k8sattributes` processor to logs and metrics pipelines in the default cluster receiver config so Kubernetes metadata (namespace, deployment, pod, etc.) is attached to telemetry from the cluster receiver.
- **k8s-objects example**: New example `examples/k8s-objects` that enables `cluster.collectk8sobjects: true`, wiring the k8sobjects receiver for Kubernetes events (warning events by default). RBAC is updated to include `events` and `events.k8s.io` so the cluster receiver can watch events.

## Context

Enriches cluster-level metrics and logs with pod/workload metadata via k8sattributes, and provides a ready-to-use example for collecting K8s events when needed.

## Checklist

- [x] Cluster receiver config: k8sattributes in logs + metrics pipelines
- [x] New k8s-objects example with values and rendered manifests
- [x] RBAC includes events for k8sobjects when enabled
- [x] All example renders updated (default, auto-instrumentation, create-secret, custom-config, extra-service, otel-demo)
- [x] Helm lint / pre-commit passed


Made with [Cursor](https://cursor.com)