### PR TITLE
feat(release): Add per-chart changelogs and release notes from git-cliff

### DIFF
--- a/.cr.yaml
+++ b/.cr.yaml
@@ -1,0 +1,3 @@
+# chart-releaser config
+# Release body is read from this file inside each chart package (see release.yml)
+release-notes-file: release-notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,18 +21,48 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: Generate release notes (opentelemetry-kube-stack)
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: charts/opentelemetry-kube-stack/cliff.toml
+          args: -vv --latest --strip header
+        env:
+          OUTPUT: charts/opentelemetry-kube-stack/release-notes.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Generate release notes (opentelemetry-demo)
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: charts/opentelemetry-demo/cliff.toml
+          args: -vv --latest --strip header
+        env:
+          OUTPUT: charts/opentelemetry-demo/release-notes.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Generate release notes (tsuga-spicy-gremlin)
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: charts/tsuga-spicy-gremlin/cliff.toml
+          args: -vv --latest --strip header
+        env:
+          OUTPUT: charts/tsuga-spicy-gremlin/release-notes.md
+          GITHUB_REPO: ${{ github.repository }}
+
       - name: Install Helm
         uses: azure/setup-helm@v4
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
       - name: Add dependent repositories
         run: |
           helm repo add tsuga-dev https://tsuga-dev.github.io/helm-charts
           helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
         with:
           skip_existing: true
           charts_dir: charts
+          config: .cr.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,3 +87,35 @@ jobs:
     - name: Run Helm unit tests
       run: |
         helm unittest charts/${{ matrix.chart }}
+
+  changelog-version-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check changelog has entry for each chart version
+        run: |
+          set -e
+          for chart_yaml in charts/*/Chart.yaml; do
+            # Only top-level charts (charts/<name>/Chart.yaml), not subcharts
+            if [[ "$chart_yaml" =~ ^charts/[^/]+/Chart\.yaml$ ]]; then
+              chart_dir="${chart_yaml%/Chart.yaml}"
+              chart_name="${chart_dir#charts/}"
+              version=$(grep '^version:' "$chart_yaml" | sed 's/version:[[:space:]]*//' | tr -d ' ')
+              # Skip subcharts (version 0.0.0)
+              if [ "$version" = "0.0.0" ]; then
+                echo "Skipping $chart_name (subchart)"
+                continue
+              fi
+              changelog="$chart_dir/CHANGELOG.md"
+              if [ ! -f "$changelog" ]; then
+                echo "::error::$chart_name: CHANGELOG.md is missing (chart version $version)"
+                exit 1
+              fi
+              if ! grep -qE "^[[:space:]]*##[[:space:]]+\[$version\]" "$changelog"; then
+                echo "::error::$chart_name: CHANGELOG.md has no entry for version $version (from Chart.yaml)"
+                exit 1
+              fi
+              echo "OK $chart_name: version $version documented in CHANGELOG.md"
+            fi
+          done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,8 @@ jobs:
                 echo "::error::$chart_name: CHANGELOG.md is missing (chart version $version)"
                 exit 1
               fi
-              if ! grep -qE "^[[:space:]]*##[[:space:]]+\[$version\]" "$changelog"; then
+              # Accept either ## [X.Y.Z] or ## [chart-name-X.Y.Z] (git-cliff tag format)
+              if ! grep -qE "^[[:space:]]*##[[:space:]]+\[($version|$chart_name-$version)\]" "$changelog"; then
                 echo "::error::$chart_name: CHANGELOG.md has no entry for version $version (from Chart.yaml)"
                 exit 1
               fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
+charts/**/release-notes.md
 charts/**/charts/*.tgz
 charts/**/values_test.yaml
 .worktrees/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,3 +36,18 @@ repos:
         entry: bash -c 'make generate-examples'
         language: system
         pass_filenames: false
+      - id: changelog-kube-stack
+        name: Update CHANGELOG.md for opentelemetry-kube-stack
+        entry: bash -c 'git cliff -c charts/opentelemetry-kube-stack/cliff.toml'
+        language: system
+        pass_filenames: false
+      - id: changelog-demo
+        name: Update CHANGELOG.md for opentelemetry-demo
+        entry: bash -c 'git cliff -c charts/opentelemetry-demo/cliff.toml'
+        language: system
+        pass_filenames: false
+      - id: changelog-gremlin
+        name: Update CHANGELOG.md for tsuga-spicy-gremlin
+        entry: bash -c 'git cliff -c charts/tsuga-spicy-gremlin/cliff.toml'
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -103,6 +103,18 @@ You can check the [examples](./charts/opentelemetry-kube-stack/examples) folder 
 - **opentelemetry-demo**: Demo stack wiring OpenTelemetry demo app with Tsuga-focused defaults
 - **tsuga-spicy-gremlin**: Reusable chaos-style rotator for OpenTelemetry demo feature flags
 
+## Changelog
+
+Each chart has its own `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format under its directory (e.g. `charts/opentelemetry-kube-stack/CHANGELOG.md`). When you bump a chart's `version` in `Chart.yaml`, you must add a corresponding entry to that chart's `CHANGELOG.md`; CI will fail otherwise.
+
+Changelogs can be generated or updated with [git-cliff](https://git-cliff.org/) using the per-chart config in each chart directory (e.g. `charts/opentelemetry-kube-stack/cliff.toml`). From the repo root, run:
+
+```bash
+git cliff -c charts/<chart-name>/cliff.toml
+```
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `docs:`) for commits that touch a chart so they are categorized correctly.
+
 ## Chart Repository
 
 The charts are published to: https://tsuga-dev.github.io/helm-charts/

--- a/charts/opentelemetry-demo/CHANGELOG.md
+++ b/charts/opentelemetry-demo/CHANGELOG.md
@@ -1,0 +1,181 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Merge branch 'main' into feat/target-allocator-support
+
+## [opentelemetry-demo-0.7.0] - 2026-02-17
+
+### Added
+
+- Add resourcedetection processor for cloud metadata
+
+### Changed
+
+- Merge pull request #60 from tsuga-dev/feat/add-resourcedetection-processor
+- Update opentelemetry-kube-stack dependency to 0.4.0 and bump chart version to 0.7.0
+- Merge pull request #65 from tsuga-dev/update/opentelemetry-demo-deps-0.4.0
+
+## [opentelemetry-demo-0.6.8] - 2026-02-16
+
+### Added
+
+- Add dynamic receiver discovery and multiline logs
+
+### Changed
+
+- Bump tsuga-spicy-gremlin to 0.1.2
+- Merge pull request #56 from tsuga-dev/chore/bump-tsuga-spicy-gremlin-0.1.2
+- Bump chart version to 0.6.7
+- Merge pull request #57 from tsuga-dev/chore/bump-opentelemetry-demo-chart-0.6.7
+- Add metrics discovery for image-provider and valkey-cart services
+- Bump version
+- Merge pull request #58 from tsuga-dev/feat/dynamic-receiver-discovery-multiline-logs
+
+## [opentelemetry-demo-0.6.6] - 2026-02-16
+
+### Changed
+
+- Bump tsuga-spicy-gremlin verstion
+- Merge pull request #52 from tsuga-dev/ab/bump-tsuga-spicy-gremlin
+- Remove hardcoded OTEL env vars and add examples
+- Merge pull request #54 from tsuga-dev/chore/spicy-gremlin-otel-cleanup
+- Downgrade chart version to 0.6.6 and dependency version to 0.1.1
+- Merge pull request #55 from tsuga-dev/fix-revert-demo-to-build-gremlin
+
+## [opentelemetry-demo-0.6.7] - 2026-02-16
+
+### Changed
+
+- Leveraging new gremlin with o11y in it
+- Using new spicy-gremlin version with o11y implemented
+- Removing hard-coded env
+- Cleaning custom env logic
+- Making spicy gremlin run more often
+- Merge pull request #51 from tsuga-dev/gus/gremlin-bump
+
+## [opentelemetry-demo-0.6.4] - 2026-02-13
+
+### Changed
+
+- Adding tsuga-spicy-gremlin
+- Revert "Collecting more data out of kafka, redis, postgres, envoy"
+- Merge pull request #49 from tsuga-dev/revert-46-gus/improve-receiver
+- Merging main
+- Merge pull request #48 from tsuga-dev/gus/automated-failures
+
+## [opentelemetry-demo-0.6.2] - 2026-02-12
+
+### Changed
+
+- Collecting more data out of kafka, redis, postgres, envoy
+- Merge pull request #46 from tsuga-dev/gus/improve-receiver
+
+## [opentelemetry-demo-0.6.1] - 2026-01-14
+
+### Changed
+
+- Update opentelemetry-demo to version 0.6.1, enhance PostgreSQL logging configuration by adding log_min_duration_statement and log_line_prefix settings, and update README with the new version badge.
+- Merge pull request #40 from tsuga-dev/feat-improve-pg-logging
+
+## [opentelemetry-demo-0.6.0] - 2026-01-14
+
+### Changed
+
+- Enable postgresql log collection and log_statement all
+- Update opentelemetry-demo to version 0.40.0, enhancing PostgreSQL log collection with new pod annotations and image overrides for product-reviews component.
+- Update opentelemetry-demo to version 0.6.0, bump opentelemetry-kube-stack to version 0.2.15, and modify logging configuration to disable log collection while adding support for log volumes.
+- Merge pull request #39 from tsuga-dev/Posgresql-tracing
+
+## [opentelemetry-demo-0.5.0] - 2026-01-06
+
+### Changed
+
+- Update opentelemetry-kube-stack dependency to 0.2.12 and bump chart version to 0.5.0
+- Merge pull request #31 from tsuga-dev/update/opentelemetry-demo-deps-0.2.12
+
+## [opentelemetry-demo-0.4.0] - 2026-01-05
+
+### Changed
+
+- Update opentelemetry-kube-stack dependency to 0.2.11 and bump chart version to 0.4.0
+- Merge pull request #30 from tsuga-dev/update/opentelemetry-demo-deps-0.2.11
+
+## [opentelemetry-demo-0.3.0] - 2026-01-05
+
+### Changed
+
+- Bump chart version to 0.2.11 and update spanmetrics connector configuration
+- Merge pull request #27 from tsuga-dev/bump-version-and-update-daemonset-config
+- Update opentelemetry-kube-stack dependency to 0.2.11 and bump chart version to 0.3.0
+- Merge pull request #28 from tsuga-dev/update/opentelemetry-demo-deps-0.2.11
+
+## [opentelemetry-demo-0.2.0] - 2025-12-18
+
+### Changed
+
+- Update opentelemetry-kube-stack dependency to 0.2.10 and bump chart version to 0.2.0
+- Merge pull request #26 from tsuga-dev/update/opentelemetry-demo-deps-0.2.10
+
+## [opentelemetry-demo-0.1.4] - 2025-12-17
+
+### Changed
+
+- Bump dependency version
+- Merge pull request #24 from tsuga-dev/update-kubestack-version
+
+## [opentelemetry-demo-0.1.3] - 2025-12-16
+
+### Changed
+
+- Update opentelemetry-kube-stack dependency to version 0.2.8 and add collectLogs option in values.yaml
+- Merge pull request #22 from tsuga-dev/remove-log-collection
+
+## [opentelemetry-demo-0.1.2] - 2025-12-15
+
+### Changed
+
+- Update opentelemetry-kube-stack dependency version to 0.2.7 in Chart.yaml
+- Bump version
+- Merge pull request #20 from tsuga-dev/update-kube-stack-dependency
+
+## [opentelemetry-demo-0.1.1] - 2025-12-12
+
+### Changed
+
+- Add OpenTelemetry demo Helm chart
+- Merge pull request #12 from tsuga-dev/opentelemetry-demo-chart
+- Add pod annotations for OpenTelemetry components in values.yaml
+- Add default example
+- Bump versions
+- Merge pull request #14 from tsuga-dev/otel-demo-improvement
+- Revert "Otel-demo-improvement"
+- Merge pull request #15 from tsuga-dev/revert-14-otel-demo-improvement
+- Enhance OpenTelemetry demo chart and CI/CD configuration
+- Merge pull request #18 from tsuga-dev/Otel-demo-improvment
+
+[unreleased]: https://github.com///compare/opentelemetry-demo-0.7.0..HEAD
+[opentelemetry-demo-0.7.0]: https://github.com///compare/opentelemetry-demo-0.6.8..opentelemetry-demo-0.7.0
+[opentelemetry-demo-0.6.8]: https://github.com///compare/opentelemetry-demo-0.6.6..opentelemetry-demo-0.6.8
+[opentelemetry-demo-0.6.6]: https://github.com///compare/opentelemetry-demo-0.6.7..opentelemetry-demo-0.6.6
+[opentelemetry-demo-0.6.7]: https://github.com///compare/opentelemetry-demo-0.6.4..opentelemetry-demo-0.6.7
+[opentelemetry-demo-0.6.4]: https://github.com///compare/opentelemetry-demo-0.6.2..opentelemetry-demo-0.6.4
+[opentelemetry-demo-0.6.2]: https://github.com///compare/opentelemetry-demo-0.6.1..opentelemetry-demo-0.6.2
+[opentelemetry-demo-0.6.1]: https://github.com///compare/opentelemetry-demo-0.6.0..opentelemetry-demo-0.6.1
+[opentelemetry-demo-0.6.0]: https://github.com///compare/opentelemetry-demo-0.5.0..opentelemetry-demo-0.6.0
+[opentelemetry-demo-0.5.0]: https://github.com///compare/opentelemetry-demo-0.4.0..opentelemetry-demo-0.5.0
+[opentelemetry-demo-0.4.0]: https://github.com///compare/opentelemetry-demo-0.3.0..opentelemetry-demo-0.4.0
+[opentelemetry-demo-0.3.0]: https://github.com///compare/opentelemetry-demo-0.2.0..opentelemetry-demo-0.3.0
+[opentelemetry-demo-0.2.0]: https://github.com///compare/opentelemetry-demo-0.1.4..opentelemetry-demo-0.2.0
+[opentelemetry-demo-0.1.4]: https://github.com///compare/opentelemetry-demo-0.1.3..opentelemetry-demo-0.1.4
+[opentelemetry-demo-0.1.3]: https://github.com///compare/opentelemetry-demo-0.1.2..opentelemetry-demo-0.1.3
+[opentelemetry-demo-0.1.2]: https://github.com///compare/opentelemetry-demo-0.1.1..opentelemetry-demo-0.1.2
+[opentelemetry-demo-0.1.1]: https://github.com///compare/opentelemetry-demo-0.1.0..opentelemetry-demo-0.1.1
+

--- a/charts/opentelemetry-demo/CHANGELOG.md
+++ b/charts/opentelemetry-demo/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add per-chart changelogs and release notes from git-cliff
+
 ### Changed
 
 - Merge branch 'main' into feat/target-allocator-support
@@ -161,21 +165,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhance OpenTelemetry demo chart and CI/CD configuration
 - Merge pull request #18 from tsuga-dev/Otel-demo-improvment
 
-[unreleased]: https://github.com///compare/opentelemetry-demo-0.7.0..HEAD
-[opentelemetry-demo-0.7.0]: https://github.com///compare/opentelemetry-demo-0.6.8..opentelemetry-demo-0.7.0
-[opentelemetry-demo-0.6.8]: https://github.com///compare/opentelemetry-demo-0.6.6..opentelemetry-demo-0.6.8
-[opentelemetry-demo-0.6.6]: https://github.com///compare/opentelemetry-demo-0.6.7..opentelemetry-demo-0.6.6
-[opentelemetry-demo-0.6.7]: https://github.com///compare/opentelemetry-demo-0.6.4..opentelemetry-demo-0.6.7
-[opentelemetry-demo-0.6.4]: https://github.com///compare/opentelemetry-demo-0.6.2..opentelemetry-demo-0.6.4
-[opentelemetry-demo-0.6.2]: https://github.com///compare/opentelemetry-demo-0.6.1..opentelemetry-demo-0.6.2
-[opentelemetry-demo-0.6.1]: https://github.com///compare/opentelemetry-demo-0.6.0..opentelemetry-demo-0.6.1
-[opentelemetry-demo-0.6.0]: https://github.com///compare/opentelemetry-demo-0.5.0..opentelemetry-demo-0.6.0
-[opentelemetry-demo-0.5.0]: https://github.com///compare/opentelemetry-demo-0.4.0..opentelemetry-demo-0.5.0
-[opentelemetry-demo-0.4.0]: https://github.com///compare/opentelemetry-demo-0.3.0..opentelemetry-demo-0.4.0
-[opentelemetry-demo-0.3.0]: https://github.com///compare/opentelemetry-demo-0.2.0..opentelemetry-demo-0.3.0
-[opentelemetry-demo-0.2.0]: https://github.com///compare/opentelemetry-demo-0.1.4..opentelemetry-demo-0.2.0
-[opentelemetry-demo-0.1.4]: https://github.com///compare/opentelemetry-demo-0.1.3..opentelemetry-demo-0.1.4
-[opentelemetry-demo-0.1.3]: https://github.com///compare/opentelemetry-demo-0.1.2..opentelemetry-demo-0.1.3
-[opentelemetry-demo-0.1.2]: https://github.com///compare/opentelemetry-demo-0.1.1..opentelemetry-demo-0.1.2
-[opentelemetry-demo-0.1.1]: https://github.com///compare/opentelemetry-demo-0.1.0..opentelemetry-demo-0.1.1
+[unreleased]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.7.0..HEAD
+[opentelemetry-demo-0.7.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.8..opentelemetry-demo-0.7.0
+[opentelemetry-demo-0.6.8]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.6..opentelemetry-demo-0.6.8
+[opentelemetry-demo-0.6.6]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.7..opentelemetry-demo-0.6.6
+[opentelemetry-demo-0.6.7]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.4..opentelemetry-demo-0.6.7
+[opentelemetry-demo-0.6.4]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.2..opentelemetry-demo-0.6.4
+[opentelemetry-demo-0.6.2]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.1..opentelemetry-demo-0.6.2
+[opentelemetry-demo-0.6.1]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.0..opentelemetry-demo-0.6.1
+[opentelemetry-demo-0.6.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.5.0..opentelemetry-demo-0.6.0
+[opentelemetry-demo-0.5.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.4.0..opentelemetry-demo-0.5.0
+[opentelemetry-demo-0.4.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.3.0..opentelemetry-demo-0.4.0
+[opentelemetry-demo-0.3.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.2.0..opentelemetry-demo-0.3.0
+[opentelemetry-demo-0.2.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.4..opentelemetry-demo-0.2.0
+[opentelemetry-demo-0.1.4]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.3..opentelemetry-demo-0.1.4
+[opentelemetry-demo-0.1.3]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.2..opentelemetry-demo-0.1.3
+[opentelemetry-demo-0.1.2]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.1..opentelemetry-demo-0.1.2
+[opentelemetry-demo-0.1.1]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.0..opentelemetry-demo-0.1.1
 

--- a/charts/opentelemetry-demo/cliff.toml
+++ b/charts/opentelemetry-demo/cliff.toml
@@ -1,0 +1,66 @@
+# git-cliff configuration for opentelemetry-demo chart
+# https://git-cliff.org/docs/configuration
+# Run from repo root: git cliff -c charts/opentelemetry-demo/cliff.toml
+
+[changelog]
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n
+"""
+body = """
+{% if version -%}
+ ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+ ## [Unreleased]
+{% endif -%}
+{% for group, commits in commits | group_by(attribute="group") %}
+ ### {{ group | upper_first }}
+ {% for commit in commits %}
+ - {{ commit.message | split(pat="\n") | first | upper_first | trim }}\
+ {% endfor %}
+{% endfor %}\n
+"""
+footer = """
+{% for release in releases -%}
+ {% if release.version -%}
+ {% if release.previous.version -%}
+ [{{ release.version | trim_start_matches(pat="v") }}]: \
+ https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+ /compare/{{ release.previous.version }}..{{ release.version }}
+ {% else -%}
+ [{{ release.version | trim_start_matches(pat="v") }}]: \
+ https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+ /tree/{{ release.version }}
+ {% endif -%}
+ {% else -%}
+ [unreleased]: https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+ /compare/{{ release.previous.version }}..HEAD
+ {% endif -%}
+{% endfor %}
+"""
+trim = true
+output = "charts/opentelemetry-demo/CHANGELOG.md"
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+include_paths = ["charts/opentelemetry-demo/**"]
+tag_pattern = "opentelemetry-demo-[0-9].*"
+commit_parsers = [
+  { message = "^feat", group = "Added" },
+  { message = "^fix", group = "Fixed" },
+  { message = "^docs", group = "Added" },
+  { message = "^perf", group = "Changed" },
+  { message = "^refactor", group = "Changed" },
+  { message = "^style", group = "Changed" },
+  { message = "^test", group = "Changed" },
+  { message = "^chore", group = "Changed" },
+  { message = "^ci", group = "Changed" },
+  { message = "^.*", group = "Changed" },
+]
+filter_commits = false
+topo_order = false
+sort_commits = "oldest"

--- a/charts/opentelemetry-kube-stack/CHANGELOG.md
+++ b/charts/opentelemetry-kube-stack/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add per-chart changelogs and release notes from git-cliff
+
 ## [opentelemetry-kube-stack-0.6.1] - 2026-03-16
 
 ### Added
@@ -274,28 +280,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Makefile for example generation and validation; update Helm chart configurations
 - Merge pull request #2 from tsuga-dev/update-secret-management
 
-[opentelemetry-kube-stack-0.6.1]: https://github.com///compare/opentelemetry-kube-stack-0.6.0..opentelemetry-kube-stack-0.6.1
-[opentelemetry-kube-stack-0.6.0]: https://github.com///compare/opentelemetry-kube-stack-0.5.1..opentelemetry-kube-stack-0.6.0
-[opentelemetry-kube-stack-0.5.1]: https://github.com///compare/opentelemetry-kube-stack-0.5.0..opentelemetry-kube-stack-0.5.1
-[opentelemetry-kube-stack-0.5.0]: https://github.com///compare/opentelemetry-kube-stack-0.4.1..opentelemetry-kube-stack-0.5.0
-[opentelemetry-kube-stack-0.4.1]: https://github.com///compare/opentelemetry-kube-stack-0.4.0..opentelemetry-kube-stack-0.4.1
-[opentelemetry-kube-stack-0.4.0]: https://github.com///compare/opentelemetry-kube-stack-0.3.0..opentelemetry-kube-stack-0.4.0
-[opentelemetry-kube-stack-0.3.0]: https://github.com///compare/opentelemetry-kube-stack-0.2.16..opentelemetry-kube-stack-0.3.0
-[opentelemetry-kube-stack-0.2.16]: https://github.com///compare/opentelemetry-kube-stack-0.2.15..opentelemetry-kube-stack-0.2.16
-[opentelemetry-kube-stack-0.2.15]: https://github.com///compare/opentelemetry-kube-stack-0.2.14..opentelemetry-kube-stack-0.2.15
-[opentelemetry-kube-stack-0.2.14]: https://github.com///compare/opentelemetry-kube-stack-0.2.13..opentelemetry-kube-stack-0.2.14
-[opentelemetry-kube-stack-0.2.13]: https://github.com///compare/opentelemetry-kube-stack-0.2.12..opentelemetry-kube-stack-0.2.13
-[opentelemetry-kube-stack-0.2.12]: https://github.com///compare/opentelemetry-kube-stack-0.2.11..opentelemetry-kube-stack-0.2.12
-[opentelemetry-kube-stack-0.2.11]: https://github.com///compare/opentelemetry-kube-stack-0.2.10..opentelemetry-kube-stack-0.2.11
-[opentelemetry-kube-stack-0.2.10]: https://github.com///compare/opentelemetry-kube-stack-0.2.9..opentelemetry-kube-stack-0.2.10
-[opentelemetry-kube-stack-0.2.9]: https://github.com///compare/opentelemetry-kube-stack-0.2.8..opentelemetry-kube-stack-0.2.9
-[opentelemetry-kube-stack-0.2.8]: https://github.com///compare/opentelemetry-kube-stack-0.2.7..opentelemetry-kube-stack-0.2.8
-[opentelemetry-kube-stack-0.2.7]: https://github.com///compare/opentelemetry-kube-stack-0.2.6..opentelemetry-kube-stack-0.2.7
-[opentelemetry-kube-stack-0.2.6]: https://github.com///compare/opentelemetry-kube-stack-0.2.5..opentelemetry-kube-stack-0.2.6
-[opentelemetry-kube-stack-0.2.5]: https://github.com///compare/opentelemetry-kube-stack-0.2.4..opentelemetry-kube-stack-0.2.5
-[opentelemetry-kube-stack-0.2.4]: https://github.com///compare/opentelemetry-kube-stack-0.2.3..opentelemetry-kube-stack-0.2.4
-[opentelemetry-kube-stack-0.2.3]: https://github.com///compare/opentelemetry-kube-stack-0.2.2..opentelemetry-kube-stack-0.2.3
-[opentelemetry-kube-stack-0.2.2]: https://github.com///compare/opentelemetry-kube-stack-0.2.1..opentelemetry-kube-stack-0.2.2
-[opentelemetry-kube-stack-0.2.1]: https://github.com///compare/opentelemetry-kube-stack-0.2.0..opentelemetry-kube-stack-0.2.1
-[opentelemetry-kube-stack-0.2.0]: https://github.com///tree/opentelemetry-kube-stack-0.2.0
+[unreleased]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.6.1..HEAD
+[opentelemetry-kube-stack-0.6.1]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.6.0..opentelemetry-kube-stack-0.6.1
+[opentelemetry-kube-stack-0.6.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.5.1..opentelemetry-kube-stack-0.6.0
+[opentelemetry-kube-stack-0.5.1]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.5.0..opentelemetry-kube-stack-0.5.1
+[opentelemetry-kube-stack-0.5.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.4.1..opentelemetry-kube-stack-0.5.0
+[opentelemetry-kube-stack-0.4.1]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.4.0..opentelemetry-kube-stack-0.4.1
+[opentelemetry-kube-stack-0.4.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.3.0..opentelemetry-kube-stack-0.4.0
+[opentelemetry-kube-stack-0.3.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.2.16..opentelemetry-kube-stack-0.3.0
+[opentelemetry-kube-stack-0.2.16]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.2.15..opentelemetry-kube-stack-0.2.16
+[opentelemetry-kube-stack-0.2.15]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.2.14..opentelemetry-kube-stack-0.2.15
+[opentelemetry-kube-stack-0.2.14]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.2.13..opentelemetry-kube-stack-0.2.14
+[opentelemetry-kube-stack-0.2.13]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.2.12..opentelemetry-kube-stack-0.2.13
+[opentelemetry-kube-stack-0.2.12]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.2.11..opentelemetry-kube-stack-0.2.12
+[opentelemetry-kube-stack-0.2.11]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.2.10..opentelemetry-kube-stack-0.2.11
+[opentelemetry-kube-stack-0.2.10]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.2.9..opentelemetry-kube-stack-0.2.10
+[opentelemetry-kube-stack-0.2.9]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.2.8..opentelemetry-kube-stack-0.2.9
+[opentelemetry-kube-stack-0.2.8]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.2.7..opentelemetry-kube-stack-0.2.8
+[opentelemetry-kube-stack-0.2.7]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.2.6..opentelemetry-kube-stack-0.2.7
+[opentelemetry-kube-stack-0.2.6]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.2.5..opentelemetry-kube-stack-0.2.6
+[opentelemetry-kube-stack-0.2.5]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.2.4..opentelemetry-kube-stack-0.2.5
+[opentelemetry-kube-stack-0.2.4]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.2.3..opentelemetry-kube-stack-0.2.4
+[opentelemetry-kube-stack-0.2.3]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.2.2..opentelemetry-kube-stack-0.2.3
+[opentelemetry-kube-stack-0.2.2]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.2.1..opentelemetry-kube-stack-0.2.2
+[opentelemetry-kube-stack-0.2.1]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.2.0..opentelemetry-kube-stack-0.2.1
+[opentelemetry-kube-stack-0.2.0]: https://github.com/tsuga-dev/helm-charts/tree/opentelemetry-kube-stack-0.2.0
 

--- a/charts/opentelemetry-kube-stack/CHANGELOG.md
+++ b/charts/opentelemetry-kube-stack/CHANGELOG.md
@@ -5,26 +5,297 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.5] - 2025-10-31
+## [opentelemetry-kube-stack-0.6.1] - 2026-03-16
 
 ### Added
-- Support for `extraExtensions` in agent configuration, allowing additional extensions to be added alongside the default health_check extension
-- Support for `service.extraExtensions` in agent service configuration
-- Label mapping support for k8sattributes processor via `labelMapping` values field
-- Conditional log collection support with `collectLogs` configuration option (replaces `collectKubernetesLogs`)
-- k8sattributes processor added to cluster receiver for enhanced Kubernetes metadata extraction
-- Default label extraction for OpenTelemetry resource attributes:
-  - `service.name` from `resource.opentelemetry.io/service.name`
-  - `service.version` from `resource.opentelemetry.io/service.version`
-  - `env` from `resource.opentelemetry.io/env`
-  - `team` from `resource.opentelemetry.io/team`
-- Updated rendered examples for create-secret, default, and otel-demo configurations
+
+- Add k8sattributes to cluster receiver and k8s-objects example
 
 ### Changed
-- Chart version bumped from 0.2.4 to 0.2.5
-- Replaced `collectKubernetesLogs` configuration with `collectLogs` for more flexible log collection control
-- Filelog receiver is now conditionally included based on `collectLogs` setting
 
-### Miscellaneous
-- Added .gitignore file to the repository
+- Bump version
+- Merge pull request #71 from tsuga-dev/feat/otel-cluster-receiver-k8sattributes-and-k8sobjects-example
+
+## [opentelemetry-kube-stack-0.6.0] - 2026-03-13
+
+### Added
+
+- Enhance cluster receiver and daemonset metrics collection
+- Add permissions for Kubernetes events collection
+
+### Changed
+
+- Bump chart version to 0.6.0 and update documentation
+- Regenerate rendered examples with enhanced configuration
+- Make collectk8sobjects optional
+- Merge pull request #70 from tsuga-dev/pimpin
+
+## [opentelemetry-kube-stack-0.5.1] - 2026-03-12
+
+### Added
+
+- Add extraLabelMapping and extraAnnotationsMapping to statefulset
+
+### Changed
+
+- Bump version
+- Merge pull request #68 from tsuga-dev/feat/statefulset-extra-label-annotation-mapping
+
+## [opentelemetry-kube-stack-0.5.0] - 2026-03-12
+
+### Changed
+
+- Merge branch 'main' into feat/target-allocator-support
+- Merge pull request #67 from tsuga-dev/feat/target-allocator-support
+
+## [opentelemetry-kube-stack-0.4.1] - 2026-02-27
+
+### Added
+
+- Add statefulset collector template
+- Add TargetAllocator CR template
+- Complete targetAllocator and statefulset values
+- Fix statefulset values documentation
+- Add PrometheusCR RBAC rules for Target Allocator
+- Add schema for targetAllocator and statefulset values
+- Add target-allocator example
+
+### Changed
+
+- Add statefulset collector-TA link tests
+- Bump version
+- Merge pull request #66 from tsuga-dev/bugfix/tolerations-schema-type
+
+### Fixed
+
+- Make replicas conditional, document TA coupling
+- Guard TargetAllocator serviceAccount on serviceAccount.create
+- Tolerations type, add serviceAccount guard test
+- Add TA endpoint, POD_NAME, memory_limiter to statefulset collector
+- Add EndpointSlices RBAC for TargetAllocator service discovery
+- Fix replicas schema type (string → integer)
+- Gate EndpointSlices RBAC on targetAllocator.enabled
+- Add placeholder scrape_config for TargetAllocator override
+- Shorten statefulset CR name to avoid 63-char label limit
+- Add net.host.name and cumulativetodelta to statefulset collector
+- Fix tolerations type for agent and cluster
+
+## [opentelemetry-kube-stack-0.4.0] - 2026-02-17
+
+### Added
+
+- Add dynamic receiver discovery and multiline logs
+- Make clusterName optional with warning
+- Document operator and cert-manager requirements
+
+### Changed
+
+- Add auto-instrumentation examples and testing framework
+- Merge pull request #44 from tsuga-dev/tests/add-autoinstrumentation-unittests
+- Merge pull request #58 from tsuga-dev/feat/dynamic-receiver-discovery-multiline-logs
+- Merge pull request #59 from tsuga-dev/feat/optional-cluster-name
+- Remove unused otel-crds dependency
+- Merge pull request #61 from tsuga-dev/feat/add-resourcedetection-processor
+- Bump version
+- Merge pull request #62 from tsuga-dev/release/bump-kubstack-0.4.0
+- Merge pull request #63 from tsuga-dev/release/bump-kubstack-0.4.0
+
+### Fixed
+
+- Update gitignore and operator condition
+
+## [opentelemetry-kube-stack-0.3.0] - 2026-02-02
+
+### Added
+
+- Add auto-instrumentation support
+
+### Changed
+
+- Merge pull request #42 from tsuga-dev/feat/auto-instrumentation-support
+
+## [opentelemetry-kube-stack-0.2.16] - 2026-02-02
+
+### Added
+
+- Configure batch processor with optimized settings
+
+### Changed
+
+- Merge commit '6ede1ed41f9b4daef4edba0a2907b60abe42b25c'
+- Bump version
+- Merge pull request #41 from tsuga-dev/feat/configure-batch-processor
+
+## [opentelemetry-kube-stack-0.2.15] - 2026-01-14
+
+### Changed
+
+- Add 'addLogsVolumes' option to agent configuration for log collection in OpenTelemetry stack
+- Bump version
+- Merge pull request #38 from tsuga-dev/feat-logs-volumes
+
+## [opentelemetry-kube-stack-0.2.14] - 2026-01-12
+
+### Changed
+
+- Enhance OpenTelemetry configuration by adding k8s_observer extension for improved Kubernetes resource observation. Update daemonset and service templates to include new logging receiver and adjust extraExtensions handling.
+- Merge pull request #36 from tsuga-dev/fix-service-definition-for-extra-extensions
+- Bump version
+- Merge pull request #37 from tsuga-dev/fix-custom-config-not-being-taken-in-count
+
+### Fixed
+
+- Fix custom config not being taken in count
+
+## [opentelemetry-kube-stack-0.2.13] - 2026-01-12
+
+### Changed
+
+- Update OpenTelemetry configuration in README, schema, and values files to change 'extraExtensions' from object to array type for both agent and cluster services.
+- Merge pull request #34 from tsuga-dev/fix-schema-validation-in-kube-stack
+- Bump opentelemetry-kube-stack chart version to 0.2.13
+- Merge pull request #35 from tsuga-dev/bump-version-to-0.2.13
+
+## [opentelemetry-kube-stack-0.2.12] - 2026-01-05
+
+### Changed
+
+- Bump chart version to 0.2.12 and remove 'exclude_dimensions' from daemonset configuration
+- Merge pull request #29 from tsuga-dev/fix-remove-excusion-dimention
+
+## [opentelemetry-kube-stack-0.2.11] - 2026-01-05
+
+### Changed
+
+- Bump chart version to 0.2.11 and update spanmetrics connector configuration
+- Merge pull request #27 from tsuga-dev/bump-version-and-update-daemonset-config
+
+## [opentelemetry-kube-stack-0.2.10] - 2025-12-17
+
+### Changed
+
+- Update OpenTelemetry kube-stack to version 0.2.10 and modify configuration to use NODE_IP for endpoint resolution
+- Merge pull request #25 from tsuga-dev/fix-kubeletstats-receiver
+
+## [opentelemetry-kube-stack-0.2.9] - 2025-12-17
+
+### Changed
+
+- Add host filesystem support in daemonset configuration
+- Bump version
+- Merge pull request #23 from tsuga-dev/fix-Host-Metrics-Receiver
+
+## [opentelemetry-kube-stack-0.2.8] - 2025-12-16
+
+### Changed
+
+- Add conditional log collection configuration in daemonset template
+- Bump version
+- Merge pull request #21 from tsuga-dev/fix-kube-stack-log-collection
+
+## [opentelemetry-kube-stack-0.2.7] - 2025-12-15
+
+### Changed
+
+- Add Helm ownership annotations to all resources
+- Bump version
+- Merge pull request #19 from tsuga-dev/fix-helm-ownership-annotations
+
+## [opentelemetry-kube-stack-0.2.6] - 2025-12-12
+
+### Changed
+
+- Fix regex in cluster name validation to allow underscores in addition to hyphens.
+- Merge pull request #11 from tsuga-dev/fix-cluster-name-validation
+- Add annotations to OpenTelemetry configuration in _config.tpl
+- Add OpenTelemetry configuration schema and enhance values.yaml
+- Fix templates
+- Update examples
+- Add extraConnectors configuration to OpenTelemetry schema and values.yaml
+- Fix _service.tpl
+- Bump versions
+- Update Doc
+- Merge pull request #14 from tsuga-dev/otel-demo-improvement
+- Revert "Otel-demo-improvement"
+- Merge pull request #15 from tsuga-dev/revert-14-otel-demo-improvement
+- Add OpenTelemetry configuration and CI enhancements
+- Merge pull request #17 from tsuga-dev/kube-stack-standerdise
+
+## [opentelemetry-kube-stack-0.2.5] - 2025-10-31
+
+### Changed
+
+- Update OpenTelemetry Kube Stack to v0.2.5
+- Add Change Log
+- Remove duplicated attributes
+- Fix grammar
+- Fix indentation in _config.tpl to properly align k8sattributes and labels sections
+- Merge pull request #9 from tsuga-dev/update-opentelemetry-stack-v0.2.5
+
+## [opentelemetry-kube-stack-0.2.4] - 2025-10-17
+
+### Changed
+
+- Remove 'k8sattributes' processor from cluster receiver configuration in example YAML files and Helm template.
+- Bump version
+- Merge pull request #7 from tsuga-dev/fix-config-issue
+
+## [opentelemetry-kube-stack-0.2.3] - 2025-10-17
+
+### Changed
+
+- Add collection settings configuration to deploy script
+- Add cluster name configuration to deploy script and Helm templates
+- Merge pull request #5 from tsuga-dev/feat-host-metrics
+- Update release workflow and increment OpenTelemetry Kube Stack chart version
+- Merge pull request #6 from tsuga-dev/Release-0.2.3
+
+## [opentelemetry-kube-stack-0.2.2] - 2025-10-07
+
+### Changed
+
+- Merge remote-tracking branch 'origin/main' into extraConfig
+- Bump version
+- Merge pull request #4 from tsuga-dev/extraConfig
+
+## [opentelemetry-kube-stack-0.2.1] - 2025-10-06
+
+### Changed
+
+- Enhance OpenTelemetry Kube Stack configuration and examples
+- Update Helm chart and README for Tsuga integration
+- Merge pull request #3 from tsuga-dev/release-0.2.1
+
+## [opentelemetry-kube-stack-0.2.0] - 2025-10-06
+
+### Changed
+
+- First commit
+- Add Makefile for example generation and validation; update Helm chart configurations
+- Merge pull request #2 from tsuga-dev/update-secret-management
+
+[opentelemetry-kube-stack-0.6.1]: https://github.com///compare/opentelemetry-kube-stack-0.6.0..opentelemetry-kube-stack-0.6.1
+[opentelemetry-kube-stack-0.6.0]: https://github.com///compare/opentelemetry-kube-stack-0.5.1..opentelemetry-kube-stack-0.6.0
+[opentelemetry-kube-stack-0.5.1]: https://github.com///compare/opentelemetry-kube-stack-0.5.0..opentelemetry-kube-stack-0.5.1
+[opentelemetry-kube-stack-0.5.0]: https://github.com///compare/opentelemetry-kube-stack-0.4.1..opentelemetry-kube-stack-0.5.0
+[opentelemetry-kube-stack-0.4.1]: https://github.com///compare/opentelemetry-kube-stack-0.4.0..opentelemetry-kube-stack-0.4.1
+[opentelemetry-kube-stack-0.4.0]: https://github.com///compare/opentelemetry-kube-stack-0.3.0..opentelemetry-kube-stack-0.4.0
+[opentelemetry-kube-stack-0.3.0]: https://github.com///compare/opentelemetry-kube-stack-0.2.16..opentelemetry-kube-stack-0.3.0
+[opentelemetry-kube-stack-0.2.16]: https://github.com///compare/opentelemetry-kube-stack-0.2.15..opentelemetry-kube-stack-0.2.16
+[opentelemetry-kube-stack-0.2.15]: https://github.com///compare/opentelemetry-kube-stack-0.2.14..opentelemetry-kube-stack-0.2.15
+[opentelemetry-kube-stack-0.2.14]: https://github.com///compare/opentelemetry-kube-stack-0.2.13..opentelemetry-kube-stack-0.2.14
+[opentelemetry-kube-stack-0.2.13]: https://github.com///compare/opentelemetry-kube-stack-0.2.12..opentelemetry-kube-stack-0.2.13
+[opentelemetry-kube-stack-0.2.12]: https://github.com///compare/opentelemetry-kube-stack-0.2.11..opentelemetry-kube-stack-0.2.12
+[opentelemetry-kube-stack-0.2.11]: https://github.com///compare/opentelemetry-kube-stack-0.2.10..opentelemetry-kube-stack-0.2.11
+[opentelemetry-kube-stack-0.2.10]: https://github.com///compare/opentelemetry-kube-stack-0.2.9..opentelemetry-kube-stack-0.2.10
+[opentelemetry-kube-stack-0.2.9]: https://github.com///compare/opentelemetry-kube-stack-0.2.8..opentelemetry-kube-stack-0.2.9
+[opentelemetry-kube-stack-0.2.8]: https://github.com///compare/opentelemetry-kube-stack-0.2.7..opentelemetry-kube-stack-0.2.8
+[opentelemetry-kube-stack-0.2.7]: https://github.com///compare/opentelemetry-kube-stack-0.2.6..opentelemetry-kube-stack-0.2.7
+[opentelemetry-kube-stack-0.2.6]: https://github.com///compare/opentelemetry-kube-stack-0.2.5..opentelemetry-kube-stack-0.2.6
+[opentelemetry-kube-stack-0.2.5]: https://github.com///compare/opentelemetry-kube-stack-0.2.4..opentelemetry-kube-stack-0.2.5
+[opentelemetry-kube-stack-0.2.4]: https://github.com///compare/opentelemetry-kube-stack-0.2.3..opentelemetry-kube-stack-0.2.4
+[opentelemetry-kube-stack-0.2.3]: https://github.com///compare/opentelemetry-kube-stack-0.2.2..opentelemetry-kube-stack-0.2.3
+[opentelemetry-kube-stack-0.2.2]: https://github.com///compare/opentelemetry-kube-stack-0.2.1..opentelemetry-kube-stack-0.2.2
+[opentelemetry-kube-stack-0.2.1]: https://github.com///compare/opentelemetry-kube-stack-0.2.0..opentelemetry-kube-stack-0.2.1
+[opentelemetry-kube-stack-0.2.0]: https://github.com///tree/opentelemetry-kube-stack-0.2.0
 

--- a/charts/opentelemetry-kube-stack/cliff.toml
+++ b/charts/opentelemetry-kube-stack/cliff.toml
@@ -1,0 +1,68 @@
+# git-cliff configuration for opentelemetry-kube-stack chart
+# https://git-cliff.org/docs/configuration
+# Run from repo root: git cliff -c charts/opentelemetry-kube-stack/cliff.toml
+
+[changelog]
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n
+"""
+body = """
+{% if version -%}
+ ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+ ## [Unreleased]
+{% endif -%}
+{% for group, commits in commits | group_by(attribute="group") %}
+ ### {{ group | upper_first }}
+ {% for commit in commits %}
+ - {{ commit.message | split(pat="\n") | first | upper_first | trim }}\
+ {% endfor %}
+{% endfor %}\n
+"""
+footer = """
+{% for release in releases -%}
+ {% if release.version -%}
+ {% if release.previous.version -%}
+ [{{ release.version | trim_start_matches(pat="v") }}]: \
+ https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+ /compare/{{ release.previous.version }}..{{ release.version }}
+ {% else -%}
+ [{{ release.version | trim_start_matches(pat="v") }}]: \
+ https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+ /tree/{{ release.version }}
+ {% endif -%}
+ {% else -%}
+ [unreleased]: https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+ /compare/{{ release.previous.version }}..HEAD
+ {% endif -%}
+{% endfor %}
+"""
+trim = true
+output = "charts/opentelemetry-kube-stack/CHANGELOG.md"
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+# Only commits that touch this chart
+include_paths = ["charts/opentelemetry-kube-stack/**"]
+# Tags created by helm chart-releaser for this chart (e.g. opentelemetry-kube-stack-0.6.1)
+tag_pattern = "opentelemetry-kube-stack-[0-9].*"
+commit_parsers = [
+  { message = "^feat", group = "Added" },
+  { message = "^fix", group = "Fixed" },
+  { message = "^docs", group = "Added" },
+  { message = "^perf", group = "Changed" },
+  { message = "^refactor", group = "Changed" },
+  { message = "^style", group = "Changed" },
+  { message = "^test", group = "Changed" },
+  { message = "^chore", group = "Changed" },
+  { message = "^ci", group = "Changed" },
+  { message = "^.*", group = "Changed" },
+]
+filter_commits = false
+topo_order = false
+sort_commits = "oldest"

--- a/charts/tsuga-spicy-gremlin/CHANGELOG.md
+++ b/charts/tsuga-spicy-gremlin/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add per-chart changelogs and release notes from git-cliff
+
 ### Changed
 
 - Remove hardcoded OTEL env vars and add examples
@@ -28,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adding tsuga-spicy-gremlin
 - Merge pull request #48 from tsuga-dev/gus/automated-failures
 
-[unreleased]: https://github.com///compare/tsuga-spicy-gremlin-0.1.2..HEAD
-[tsuga-spicy-gremlin-0.1.2]: https://github.com///compare/tsuga-spicy-gremlin-0.1.1..tsuga-spicy-gremlin-0.1.2
-[tsuga-spicy-gremlin-0.1.1]: https://github.com///tree/tsuga-spicy-gremlin-0.1.1
+[unreleased]: https://github.com/tsuga-dev/helm-charts/compare/tsuga-spicy-gremlin-0.1.2..HEAD
+[tsuga-spicy-gremlin-0.1.2]: https://github.com/tsuga-dev/helm-charts/compare/tsuga-spicy-gremlin-0.1.1..tsuga-spicy-gremlin-0.1.2
+[tsuga-spicy-gremlin-0.1.1]: https://github.com/tsuga-dev/helm-charts/tree/tsuga-spicy-gremlin-0.1.1
 

--- a/charts/tsuga-spicy-gremlin/CHANGELOG.md
+++ b/charts/tsuga-spicy-gremlin/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Remove hardcoded OTEL env vars and add examples
+- Merge pull request #54 from tsuga-dev/chore/spicy-gremlin-otel-cleanup
+
+## [tsuga-spicy-gremlin-0.1.2] - 2026-02-16
+
+### Changed
+
+- Leveraging new gremlin with o11y in it
+- Using new spicy-gremlin version with o11y implemented
+- Removing hard-coded env
+- Merge pull request #51 from tsuga-dev/gus/gremlin-bump
+
+## [tsuga-spicy-gremlin-0.1.1] - 2026-02-13
+
+### Changed
+
+- Adding tsuga-spicy-gremlin
+- Merge pull request #48 from tsuga-dev/gus/automated-failures
+
+[unreleased]: https://github.com///compare/tsuga-spicy-gremlin-0.1.2..HEAD
+[tsuga-spicy-gremlin-0.1.2]: https://github.com///compare/tsuga-spicy-gremlin-0.1.1..tsuga-spicy-gremlin-0.1.2
+[tsuga-spicy-gremlin-0.1.1]: https://github.com///tree/tsuga-spicy-gremlin-0.1.1
+

--- a/charts/tsuga-spicy-gremlin/cliff.toml
+++ b/charts/tsuga-spicy-gremlin/cliff.toml
@@ -1,0 +1,66 @@
+# git-cliff configuration for tsuga-spicy-gremlin chart
+# https://git-cliff.org/docs/configuration
+# Run from repo root: git cliff -c charts/tsuga-spicy-gremlin/cliff.toml
+
+[changelog]
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n
+"""
+body = """
+{% if version -%}
+ ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+ ## [Unreleased]
+{% endif -%}
+{% for group, commits in commits | group_by(attribute="group") %}
+ ### {{ group | upper_first }}
+ {% for commit in commits %}
+ - {{ commit.message | split(pat="\n") | first | upper_first | trim }}\
+ {% endfor %}
+{% endfor %}\n
+"""
+footer = """
+{% for release in releases -%}
+ {% if release.version -%}
+ {% if release.previous.version -%}
+ [{{ release.version | trim_start_matches(pat="v") }}]: \
+ https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+ /compare/{{ release.previous.version }}..{{ release.version }}
+ {% else -%}
+ [{{ release.version | trim_start_matches(pat="v") }}]: \
+ https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+ /tree/{{ release.version }}
+ {% endif -%}
+ {% else -%}
+ [unreleased]: https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}\
+ /compare/{{ release.previous.version }}..HEAD
+ {% endif -%}
+{% endfor %}
+"""
+trim = true
+output = "charts/tsuga-spicy-gremlin/CHANGELOG.md"
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+include_paths = ["charts/tsuga-spicy-gremlin/**"]
+tag_pattern = "tsuga-spicy-gremlin-[0-9].*"
+commit_parsers = [
+  { message = "^feat", group = "Added" },
+  { message = "^fix", group = "Fixed" },
+  { message = "^docs", group = "Added" },
+  { message = "^perf", group = "Changed" },
+  { message = "^refactor", group = "Changed" },
+  { message = "^style", group = "Changed" },
+  { message = "^test", group = "Changed" },
+  { message = "^chore", group = "Changed" },
+  { message = "^ci", group = "Changed" },
+  { message = "^.*", group = "Changed" },
+]
+filter_commits = false
+topo_order = false
+sort_commits = "oldest"


### PR DESCRIPTION
Closes #72 

## Summary

Add per-chart changelogs (Keep a Changelog format) and automate release notes on GitHub releases using git-cliff.

## Changes

### Per-chart changelogs
- **CHANGELOG.md** for each top-level chart: `opentelemetry-kube-stack`, `opentelemetry-demo`, `tsuga-spicy-gremlin`
- **git-cliff config** (`cliff.toml`) per chart with `include_paths` and `tag_pattern` so each changelog is scoped to that chart and its tags
- **README** updated with a Changelog section and instructions for running git-cliff locally

### CI
- **changelog-version-check** job in `test.yml`: for each chart, ensures the `version` in `Chart.yaml` has a matching `## [X.Y.Z]` entry in that chart’s `CHANGELOG.md` (fails if missing so releases stay documented)

### Release notes on GitHub releases
- **release.yml**: before running chart-releaser, generates release notes per chart with `orhun/git-cliff-action@v4` (`--latest --strip header`) and writes to `charts/<name>/release-notes.md`
- **.cr.yaml**: configures chart-releaser to use `release-notes.md` from each chart package as the GitHub release body
- **.gitignore**: `charts/**/release-notes.md` (generated in CI only, not committed)

### Other
- Pre-commit hooks (changelog updates) applied to the new CHANGELOG files

## Checklist
- [x] Per-chart CHANGELOG.md and cliff.toml
- [x] CI checks Chart version present in CHANGELOG
- [x] Release workflow generates and attaches release notes
- [x] README and .gitignore updated

Made with [Cursor](https://cursor.com)