### PR TITLE
feat(opentelemetry-kube-stack): easy node filesystem monitoring via agent.hostMetrics.filesystem

### DIFF
--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -244,6 +244,50 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 
 ## Configuration
 
+### Node Filesystem Monitoring
+
+The agent DaemonSet already mounts the host filesystem at `/hostfs` (read-only) — no extra volume configuration is needed.
+
+By default (`agent.hostMetrics.filesystem.enabled: true`), the filesystem scraper filters out pseudo-filesystems and container overlay mounts using exclude lists derived from the Prometheus `node_exporter` defaults. This produces clean, low-noise metrics that work out of the box with alerts like `NodeFilesystemAlmostOutOfSpace`.
+
+**Minimal values snippet** — accept all defaults (no action required):
+
+```yaml
+agent:
+  hostMetrics:
+    filesystem:
+      enabled: true   # this is the default
+```
+
+**Custom excludes** — override either list to suit your environment:
+
+```yaml
+agent:
+  hostMetrics:
+    filesystem:
+      enabled: true
+      excludeMountPoints:
+        - ^/dev(/|$)
+        - ^/proc(/|$)
+        - ^/sys(/|$)
+        - ^/var/lib/docker/
+        # add site-specific paths here
+      excludeFsTypes:
+        - tmpfs
+        - overlay
+        - sysfs
+        # add site-specific fs types here
+```
+
+**Disable excludes** — revert to the bare scraper (collects all mount points):
+
+```yaml
+agent:
+  hostMetrics:
+    filesystem:
+      enabled: false
+```
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -282,6 +326,11 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | agent.extraAnnotationsMapping | list | [] | Annotations mapping configuration for agent Maps Kubernetes pod annotations to OpenTelemetry resource attributes These are appended to default annotation mappings Format: List of objects with tag_name, key, and from fields |
 | agent.extraEnvs | list | [] | Extra environment variables for agent These are in addition to automatic secret env vars (TSUGA_API_KEY, TSUGA_OTLP_ENDPOINT, MY_POD_IP) |
 | agent.extraLabelMapping | list | [] | Label mapping configuration for agent Maps Kubernetes pod labels to OpenTelemetry resource attributes These are appended to default label mappings Format: List of objects with tag_name, key, and from fields Example:   extraLabelMapping:     - tag_name: "app.version"       key: "app.version"       from: "pod" |
+| agent.hostMetrics | object | `{"filesystem":{"enabled":true,"excludeFsTypes":["autofs","binfmt_misc","bpf","cgroup","cgroup2","configfs","debugfs","devpts","devtmpfs","fusectl","hugetlbfs","iso9660","mqueue","nsfs","overlay","proc","procfs","pstore","rpc_pipefs","securityfs","selinuxfs","squashfs","sysfs","tracefs","tmpfs"],"excludeMountPoints":["^/dev(/|$)","^/proc(/|$)","^/run/credentials/","^/sys(/|$)","^/var/lib/docker/","^/var/lib/containers/storage/"]}}` | Host metrics configuration Controls advanced scraper settings for the hostmetrics receiver |
+| agent.hostMetrics.filesystem | object | `{"enabled":true,"excludeFsTypes":["autofs","binfmt_misc","bpf","cgroup","cgroup2","configfs","debugfs","devpts","devtmpfs","fusectl","hugetlbfs","iso9660","mqueue","nsfs","overlay","proc","procfs","pstore","rpc_pipefs","securityfs","selinuxfs","squashfs","sysfs","tracefs","tmpfs"],"excludeMountPoints":["^/dev(/|$)","^/proc(/|$)","^/run/credentials/","^/sys(/|$)","^/var/lib/docker/","^/var/lib/containers/storage/"]}` | Filesystem scraper configuration The agent DaemonSet already mounts the host filesystem at /hostfs (read-only), so no extra volume configuration is required to use these settings. |
+| agent.hostMetrics.filesystem.enabled | bool | true | Enable exclude filters on the filesystem scraper When true, filters out pseudo-filesystems and noisy mount points using the lists below, producing clean metrics suitable for disk space alerts (e.g. NodeFilesystemAlmostOutOfSpace). Set to false to revert to the bare scraper with no excludes. |
+| agent.hostMetrics.filesystem.excludeFsTypes | list | see values | Filesystem types to exclude from filesystem metrics Exact string matches. Defaults match the Prometheus node_exporter defaults. |
+| agent.hostMetrics.filesystem.excludeMountPoints | list | see values | Mount point regexp patterns to exclude from filesystem metrics Patterns are Go regexps. Defaults match the Prometheus node_exporter defaults. |
 | agent.hostNetwork | bool | true | Enable host network for agent (recommended for optimal performance) When true, agent uses host networking for better performance |
 | agent.image | string | "" | OpenTelemetry Collector image for agent Defaults to: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s |
 | agent.nodeSelector | object | {} | Agent-specific node selector If not set, inherits from global nodeSelector configuration |

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/daemonset.yaml
@@ -92,6 +92,43 @@ spec:
                 enabled: true
           disk: null
           filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              - tmpfs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - ^/dev(/|$)
+              - ^/proc(/|$)
+              - ^/run/credentials/
+              - ^/sys(/|$)
+              - ^/var/lib/docker/
+              - ^/var/lib/containers/storage/
             metrics:
               system.filesystem.utilization:
                 enabled: true

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/daemonset.yaml
@@ -92,6 +92,43 @@ spec:
                 enabled: true
           disk: null
           filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              - tmpfs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - ^/dev(/|$)
+              - ^/proc(/|$)
+              - ^/run/credentials/
+              - ^/sys(/|$)
+              - ^/var/lib/docker/
+              - ^/var/lib/containers/storage/
             metrics:
               system.filesystem.utilization:
                 enabled: true

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/daemonset.yaml
@@ -92,6 +92,43 @@ spec:
                 enabled: true
           disk: null
           filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              - tmpfs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - ^/dev(/|$)
+              - ^/proc(/|$)
+              - ^/run/credentials/
+              - ^/sys(/|$)
+              - ^/var/lib/docker/
+              - ^/var/lib/containers/storage/
             metrics:
               system.filesystem.utilization:
                 enabled: true

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/daemonset.yaml
@@ -92,6 +92,43 @@ spec:
                 enabled: true
           disk: null
           filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              - tmpfs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - ^/dev(/|$)
+              - ^/proc(/|$)
+              - ^/run/credentials/
+              - ^/sys(/|$)
+              - ^/var/lib/docker/
+              - ^/var/lib/containers/storage/
             metrics:
               system.filesystem.utilization:
                 enabled: true

--- a/charts/opentelemetry-kube-stack/examples/filesystem-monitoring/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/filesystem-monitoring/values.yaml
@@ -1,0 +1,43 @@
+# Node Filesystem Monitoring Example
+#
+# Enables production-ready filesystem metrics suitable for alerts like
+# NodeFilesystemAlmostOutOfSpace.
+#
+# The agent DaemonSet already mounts the host filesystem at /hostfs (read-only),
+# so no extra volume configuration is needed.
+#
+# agent.hostMetrics.filesystem.enabled is true by default — this example shows
+# both the default setup and a customized configuration.
+
+# ── Minimal setup (accept all defaults) ─────────────────────────────────────
+# Nothing to set. Filesystem monitoring with sensible excludes is on by default.
+# The default excludes are derived from Prometheus node_exporter defaults and
+# filter out pseudo-filesystems (proc, sysfs, tmpfs, overlay, etc.) and
+# container storage mount points.
+
+# ── Custom excludes ───────────────────────────────────────────────────────────
+# Override the exclude lists to match your environment.
+#
+# agent:
+#   hostMetrics:
+#     filesystem:
+#       enabled: true
+#       excludeMountPoints:
+#         - ^/dev(/|$)
+#         - ^/proc(/|$)
+#         - ^/sys(/|$)
+#         - ^/var/lib/docker/
+#         - ^/var/lib/containers/storage/
+#         - ^/run/credentials/
+#       excludeFsTypes:
+#         - tmpfs
+#         - overlay
+#         - sysfs
+#         - proc
+#         - devtmpfs
+
+# ── Disable excludes (bare scraper, all mount points) ────────────────────────
+# agent:
+#   hostMetrics:
+#     filesystem:
+#       enabled: false

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/daemonset.yaml
@@ -92,6 +92,43 @@ spec:
                 enabled: true
           disk: null
           filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              - tmpfs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - ^/dev(/|$)
+              - ^/proc(/|$)
+              - ^/run/credentials/
+              - ^/sys(/|$)
+              - ^/var/lib/docker/
+              - ^/var/lib/containers/storage/
             metrics:
               system.filesystem.utilization:
                 enabled: true

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/daemonset.yaml
@@ -79,6 +79,43 @@ spec:
                 enabled: true
           disk: null
           filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              - tmpfs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - ^/dev(/|$)
+              - ^/proc(/|$)
+              - ^/run/credentials/
+              - ^/sys(/|$)
+              - ^/var/lib/docker/
+              - ^/var/lib/containers/storage/
             metrics:
               system.filesystem.utilization:
                 enabled: true

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/daemonset.yaml
@@ -92,6 +92,43 @@ spec:
                 enabled: true
           disk: null
           filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              - tmpfs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - ^/dev(/|$)
+              - ^/proc(/|$)
+              - ^/run/credentials/
+              - ^/sys(/|$)
+              - ^/var/lib/docker/
+              - ^/var/lib/containers/storage/
             metrics:
               system.filesystem.utilization:
                 enabled: true

--- a/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
@@ -57,6 +57,14 @@ receivers:
         metrics:
           system.filesystem.utilization:
             enabled: true
+        {{- if .Values.agent.hostMetrics.filesystem.enabled }}
+        exclude_mount_points:
+          mount_points: {{ toYaml .Values.agent.hostMetrics.filesystem.excludeMountPoints | nindent 12 }}
+          match_type: regexp
+        exclude_fs_types:
+          fs_types: {{ toYaml .Values.agent.hostMetrics.filesystem.excludeFsTypes | nindent 12 }}
+          match_type: strict
+        {{- end }}
       load:
       memory:
       {{- if .Values.agent.collectNetwork }}

--- a/charts/opentelemetry-kube-stack/tests/daemonset_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/daemonset_test.yaml
@@ -36,3 +36,38 @@ tests:
       - equal:
           path: spec.config.service.pipelines.logs.exporters
           value: []
+
+  - it: should include filesystem exclude filters by default
+    set:
+      agent.enabled: true
+      tsuga.otlpEndpoint: "https://test-endpoint.com"
+      tsuga.apiKey: "test-api-key"
+    release:
+      name: "test-release"
+    asserts:
+      - equal:
+          path: spec.config.receivers.hostmetrics.scrapers.filesystem.exclude_mount_points.match_type
+          value: regexp
+      - equal:
+          path: spec.config.receivers.hostmetrics.scrapers.filesystem.exclude_fs_types.match_type
+          value: strict
+      - contains:
+          path: spec.config.receivers.hostmetrics.scrapers.filesystem.exclude_mount_points.mount_points
+          content: "^/proc(/|$)"
+      - contains:
+          path: spec.config.receivers.hostmetrics.scrapers.filesystem.exclude_fs_types.fs_types
+          content: "tmpfs"
+
+  - it: should omit filesystem exclude filters when disabled
+    set:
+      agent.enabled: true
+      tsuga.otlpEndpoint: "https://test-endpoint.com"
+      tsuga.apiKey: "test-api-key"
+      agent.hostMetrics.filesystem.enabled: false
+    release:
+      name: "test-release"
+    asserts:
+      - isNull:
+          path: spec.config.receivers.hostmetrics.scrapers.filesystem.exclude_mount_points
+      - isNull:
+          path: spec.config.receivers.hostmetrics.scrapers.filesystem.exclude_fs_types

--- a/charts/opentelemetry-kube-stack/values.schema.json
+++ b/charts/opentelemetry-kube-stack/values.schema.json
@@ -26,6 +26,27 @@
                 "collectProcesses": {
                     "type": "boolean"
                 },
+                "hostMetrics": {
+                    "type": "object",
+                    "properties": {
+                        "filesystem": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "excludeMountPoints": {
+                                    "type": "array",
+                                    "items": { "type": "string" }
+                                },
+                                "excludeFsTypes": {
+                                    "type": "array",
+                                    "items": { "type": "string" }
+                                }
+                            }
+                        }
+                    }
+                },
                 "config": {
                     "type": "object",
                     "properties": {

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -427,6 +427,60 @@ agent:
   # @default -- false
   collectProcesses: false
 
+  # -- Host metrics configuration
+  # Controls advanced scraper settings for the hostmetrics receiver
+  hostMetrics:
+    # -- Filesystem scraper configuration
+    # The agent DaemonSet already mounts the host filesystem at /hostfs (read-only),
+    # so no extra volume configuration is required to use these settings.
+    filesystem:
+      # -- Enable exclude filters on the filesystem scraper
+      # When true, filters out pseudo-filesystems and noisy mount points using
+      # the lists below, producing clean metrics suitable for disk space alerts
+      # (e.g. NodeFilesystemAlmostOutOfSpace).
+      # Set to false to revert to the bare scraper with no excludes.
+      # @default -- true
+      enabled: true
+      # -- Mount point regexp patterns to exclude from filesystem metrics
+      # Patterns are Go regexps. Defaults match the Prometheus node_exporter defaults.
+      # @default -- see values
+      excludeMountPoints:
+        - ^/dev(/|$)
+        - ^/proc(/|$)
+        - ^/run/credentials/
+        - ^/sys(/|$)
+        - ^/var/lib/docker/
+        - ^/var/lib/containers/storage/
+      # -- Filesystem types to exclude from filesystem metrics
+      # Exact string matches. Defaults match the Prometheus node_exporter defaults.
+      # @default -- see values
+      excludeFsTypes:
+        - autofs
+        - binfmt_misc
+        - bpf
+        - cgroup
+        - cgroup2
+        - configfs
+        - debugfs
+        - devpts
+        - devtmpfs
+        - fusectl
+        - hugetlbfs
+        - iso9660
+        - mqueue
+        - nsfs
+        - overlay
+        - proc
+        - procfs
+        - pstore
+        - rpc_pipefs
+        - securityfs
+        - selinuxfs
+        - squashfs
+        - sysfs
+        - tracefs
+        - tmpfs
+
   # -- Replace default config with complete custom configuration
   # When set, this completely replaces the default collector configuration
   # Use this for full control over the OpenTelemetry Collector config


### PR DESCRIPTION
## Problem

The agent DaemonSet already mounts the host filesystem at `/hostfs` (read-only) and already runs a `filesystem` scraper inside the `hostmetrics` receiver — but the scraper has no exclude configuration. As a result:

- It emits metrics for pseudo-filesystems (`proc`, `sysfs`, `tmpfs`, `overlay`, etc.) and ephemeral container mount points, which are noise for disk space monitoring.

## Solution

Introduce a first-class values interface for the filesystem scraper under `agent.hostMetrics.filesystem`:

| Value | Default | Description |
|-------|---------|-------------|
| `agent.hostMetrics.filesystem.enabled` | `true` | Applies exclude filters to the filesystem scraper |
| `agent.hostMetrics.filesystem.excludeMountPoints` | Prometheus node_exporter defaults | Go regexp list of mount points to exclude |
| `agent.hostMetrics.filesystem.excludeFsTypes` | Prometheus node_exporter defaults | Exact fs type strings to exclude |

The exclude lists default to the [Prometheus `node_exporter` defaults](https://github.com/prometheus/node_exporter) — the de facto standard for node filesystem monitoring — filtering out pseudo-filesystems and container storage overlay mounts.

**No new volumes or privilege changes.** The `/hostfs` read-only host mount already exists in the DaemonSet.

**Backward compatible.** Set `agent.hostMetrics.filesystem.enabled: false` to revert to the pre-change bare scraper.

### Customer copy-paste (nothing to configure — it works by default)

```yaml
# Filesystem monitoring with sensible excludes is on by default.
# To customise the exclude lists:
agent:
  hostMetrics:
    filesystem:
      enabled: true
      excludeMountPoints:
        - ^/dev(/|$)
        - ^/proc(/|$)
        - ^/sys(/|$)
        - ^/var/lib/docker/
      excludeFsTypes:
        - tmpfs
        - overlay
```

## Changes

- `templates/_default-deamonset-config.tpl` — conditionally expands the `filesystem:` scraper block
- `values.yaml` — new `agent.hostMetrics.filesystem` block with defaults
- `values.schema.json` — schema for the new block
- `README.md` — "Node Filesystem Monitoring" section with copy-paste snippets
- `examples/filesystem-monitoring/values.yaml` — new example
- All `examples/*/rendered/daemonset.yaml` re-generated
- `tests/daemonset_test.yaml` — 2 new unit tests (enabled/disabled cases)

## Test plan

- [x] `helm lint` — clean
- [x] `helm unittest` — 34/34 pass (2 new tests covering enabled and disabled cases)
- [x] `helm template` default — `filesystem` scraper includes `exclude_mount_points` and `exclude_fs_types`
- [x] `helm template` with `agent.hostMetrics.filesystem.enabled=false` — bare scraper, no excludes