### PR TITLE
feat: add k8s metrics and objects for otel demo

### DIFF
--- a/charts/opentelemetry-demo/CHANGELOG.md
+++ b/charts/opentelemetry-demo/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [opentelemetry-demo-0.8.0] - 2026-04-27
+
 ### Added
+- Add k8s objects receiver (pods, events, deployments, nodes, replicasets, daemonsets, statefulsets)
+- Add k8s.container.status.state, k8s.container.status.reason, and k8s.pod.status_reason metrics
 - Add per-chart changelogs and release notes from git-cliff
 - Add per-component Tsuga exporter toggles
 
@@ -122,7 +126,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Revert "Otel-demo-improvement"
 - Enhance OpenTelemetry demo chart and CI/CD configuration
 
-[unreleased]: https://github.com///compare/opentelemetry-demo-0.7.0...HEAD
+[unreleased]: https://github.com///compare/opentelemetry-demo-0.8.0...HEAD
+[opentelemetry-demo-0.8.0]: https://github.com///compare/opentelemetry-demo-0.7.0...opentelemetry-demo-0.8.0
 [opentelemetry-demo-0.7.0]: https://github.com///compare/opentelemetry-demo-0.6.8...opentelemetry-demo-0.7.0
 [opentelemetry-demo-0.6.8]: https://github.com///compare/opentelemetry-demo-0.6.6...opentelemetry-demo-0.6.8
 [opentelemetry-demo-0.6.6]: https://github.com///compare/opentelemetry-demo-0.6.7...opentelemetry-demo-0.6.6

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-kube-stack/cluster-receiver.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-kube-stack/cluster-receiver.yaml
@@ -52,6 +52,38 @@ spec:
         - cpu
         - memory
         collection_interval: 10s
+        metrics:
+          k8s.container.status.reason:
+            enabled: true
+          k8s.container.status.state:
+            enabled: true
+          k8s.pod.status_reason:
+            enabled: true
+      k8sobjects:
+        auth_type: serviceAccount
+        include_initial_state: true
+        objects:
+        - group: ""
+          mode: watch
+          name: pods
+        - group: ""
+          mode: watch
+          name: events
+        - group: apps
+          mode: watch
+          name: deployments
+        - group: ""
+          mode: watch
+          name: nodes
+        - group: apps
+          mode: watch
+          name: replicasets
+        - group: apps
+          mode: watch
+          name: daemonsets
+        - group: apps
+          mode: watch
+          name: statefulsets
     processors:
       batch:
         send_batch_max_size: 5000
@@ -127,6 +159,7 @@ spec:
           - resourcedetection
           receivers:
           - k8s_cluster
+          - k8sobjects
         metrics:
           exporters:
           - otlphttp/tsuga

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -183,6 +183,40 @@ opentelemetry-kube-stack:
   enabled: true
   cluster:
     config:
+      extraReceivers:
+        k8sobjects:
+          auth_type: serviceAccount
+          include_initial_state: true
+          objects:
+            - group: ""
+              name: pods
+              mode: watch
+            - group: ""
+              name: events
+              mode: watch
+            - group: "apps"
+              name: deployments
+              mode: watch
+            - group: ""
+              name: nodes
+              mode: watch
+            - group: "apps"
+              name: replicasets
+              mode: watch
+            - group: "apps"
+              name: daemonsets
+              mode: watch
+            - group: "apps"
+              name: statefulsets
+              mode: watch
+        k8s_cluster:
+          metrics:
+            k8s.container.status.state:
+              enabled: true
+            k8s.pod.status_reason:
+              enabled: true
+            k8s.container.status.reason:
+              enabled: true
       extraProcessors:
         resourcedetection:
           detectors: [env, eks]
@@ -196,6 +230,8 @@ opentelemetry-kube-stack:
           logs:
             extraProcessors:
               - resourcedetection
+            extraReceivers:
+              - k8sobjects
 
   agent:
     image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib


### PR DESCRIPTION
This PR adds metrics and objects for the OTel demo app so that we can see deployments and pod status in telemetry