### PR TITLE
feat(otel-kube-stack): Add pod watch, memory metrics, bump to 0.7.0

### DIFF
--- a/charts/opentelemetry-demo/README.md
+++ b/charts/opentelemetry-demo/README.md
@@ -75,6 +75,7 @@ A Helm chart for Tsuga Observability Demo
 | opentelemetry-demo.prometheus.enabled | bool | `false` |  |
 | opentelemetry-kube-stack.agent.addLogsVolumes | bool | `true` |  |
 | opentelemetry-kube-stack.agent.collectLogs | bool | `false` |  |
+| opentelemetry-kube-stack.agent.collectNetwork | bool | `true` |  |
 | opentelemetry-kube-stack.agent.config.extraExtensions.k8s_observer.observe_ingresses | bool | `true` |  |
 | opentelemetry-kube-stack.agent.config.extraExtensions.k8s_observer.observe_nodes | bool | `true` |  |
 | opentelemetry-kube-stack.agent.config.extraExtensions.k8s_observer.observe_services | bool | `true` |  |

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-kube-stack/daemonset.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-kube-stack/daemonset.yaml
@@ -84,6 +84,7 @@ spec:
                 enabled: true
           load: null
           memory: null
+          network: null
           paging:
             metrics:
               system.paging.utilization:

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -238,6 +238,7 @@ opentelemetry-kube-stack:
     image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
     addLogsVolumes: true
     collectLogs: false
+    collectNetwork: true
     config:
       extraExtensions:
         k8s_observer:

--- a/charts/opentelemetry-kube-stack/CHANGELOG.md
+++ b/charts/opentelemetry-kube-stack/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [opentelemetry-kube-stack-0.6.3] - 2026-05-20
+
+### Added
+- Add tusga-less example and update chart changelogs
+
+### Changed
+- Standardize YAML formatting checks (#82)
+- Update default spanmetrics dims (#77)
+
 ## [opentelemetry-kube-stack-0.6.2] - 2026-03-16
 
 ### Added
@@ -202,6 +211,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - First commit
 - Add Makefile for example generation and validation; update Helm chart configurations
+[opentelemetry-kube-stack-0.6.3]: https://github.com///compare/opentelemetry-kube-stack-0.6.2...opentelemetry-kube-stack-0.6.3
+
 [opentelemetry-kube-stack-0.6.2]: https://github.com///compare/opentelemetry-kube-stack-0.6.1...opentelemetry-kube-stack-0.6.2
 
 [opentelemetry-kube-stack-0.6.1]: https://github.com///compare/opentelemetry-kube-stack-0.6.0...opentelemetry-kube-stack-0.6.1

--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -1,7 +1,8 @@
 ---
 apiVersion: v2
 name: opentelemetry-kube-stack
-description: A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet +
+description:
+  A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet +
   cluster receiver), secure credential management, and production-ready configurations for telemetry collection to Tsuga platform.
 
 # A chart can be either an 'application' or a 'library' chart.
@@ -17,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.3
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-kube-stack
 
-![Version: 0.6.3](https://img.shields.io/badge/Version-0.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
 
 A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet + cluster receiver), secure credential management, and production-ready configurations for telemetry collection to Tsuga platform.
 

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/daemonset.yaml
@@ -96,7 +96,12 @@ spec:
               system.filesystem.utilization:
                 enabled: true
           load: null
-          memory: null
+          memory:
+            metrics:
+              system.memory.limit:
+                enabled: true
+              system.memory.utilization:
+                enabled: true
           paging:
             metrics:
               system.paging.utilization:

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/daemonset.yaml
@@ -96,7 +96,12 @@ spec:
               system.filesystem.utilization:
                 enabled: true
           load: null
-          memory: null
+          memory:
+            metrics:
+              system.memory.limit:
+                enabled: true
+              system.memory.utilization:
+                enabled: true
           paging:
             metrics:
               system.paging.utilization:

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/daemonset.yaml
@@ -96,7 +96,12 @@ spec:
               system.filesystem.utilization:
                 enabled: true
           load: null
-          memory: null
+          memory:
+            metrics:
+              system.memory.limit:
+                enabled: true
+              system.memory.utilization:
+                enabled: true
           paging:
             metrics:
               system.paging.utilization:

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/daemonset.yaml
@@ -96,7 +96,12 @@ spec:
               system.filesystem.utilization:
                 enabled: true
           load: null
-          memory: null
+          memory:
+            metrics:
+              system.memory.limit:
+                enabled: true
+              system.memory.utilization:
+                enabled: true
           paging:
             metrics:
               system.paging.utilization:

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
@@ -65,9 +65,6 @@ spec:
         auth_type: serviceAccount
         include_initial_state: true
         objects:
-        - field_selector: type=Warning
-          mode: watch
-          name: events
         - group: ""
           mode: watch
           name: pods

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
@@ -63,10 +63,14 @@ spec:
         - PIDPressure
       k8sobjects:
         auth_type: serviceAccount
+        include_initial_state: true
         objects:
         - field_selector: type=Warning
           mode: watch
           name: events
+        - group: ""
+          mode: watch
+          name: pods
     processors:
       batch:
         send_batch_max_size: 5000

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/daemonset.yaml
@@ -96,7 +96,12 @@ spec:
               system.filesystem.utilization:
                 enabled: true
           load: null
-          memory: null
+          memory:
+            metrics:
+              system.memory.limit:
+                enabled: true
+              system.memory.utilization:
+                enabled: true
           paging:
             metrics:
               system.paging.utilization:

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
@@ -61,6 +61,16 @@ spec:
         - MemoryPressure
         - DiskPressure
         - PIDPressure
+      k8sobjects:
+        auth_type: serviceAccount
+        include_initial_state: true
+        objects:
+        - field_selector: type=Warning
+          mode: watch
+          name: events
+        - group: ""
+          mode: watch
+          name: pods
     processors:
       batch:
         send_batch_max_size: 5000
@@ -132,6 +142,7 @@ spec:
           - batch
           receivers:
           - k8s_cluster
+          - k8sobjects
         metrics:
           exporters:
           - otlphttp/tsuga

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
@@ -65,9 +65,6 @@ spec:
         auth_type: serviceAccount
         include_initial_state: true
         objects:
-        - field_selector: type=Warning
-          mode: watch
-          name: events
         - group: ""
           mode: watch
           name: pods

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/daemonset.yaml
@@ -83,7 +83,13 @@ spec:
               system.filesystem.utilization:
                 enabled: true
           load: null
-          memory: null
+          memory:
+            metrics:
+              system.memory.limit:
+                enabled: true
+              system.memory.utilization:
+                enabled: true
+          network: null
           paging:
             metrics:
               system.paging.utilization:

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/values.yaml
@@ -4,6 +4,7 @@ agent:
   image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   addLogsVolumes: true
   collectLogs: false
+  collectNetwork: true
   config:
     extraExtensions:
       k8s_observer:
@@ -69,3 +70,5 @@ agent:
         logs:
           extraReceivers:
             - receiver_creator/logs
+cluster:
+  collectk8sobjects: true

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/daemonset.yaml
@@ -96,7 +96,12 @@ spec:
               system.filesystem.utilization:
                 enabled: true
           load: null
-          memory: null
+          memory:
+            metrics:
+              system.memory.limit:
+                enabled: true
+              system.memory.utilization:
+                enabled: true
           paging:
             metrics:
               system.paging.utilization:

--- a/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
@@ -12,11 +12,6 @@ receivers:
     auth_type: serviceAccount
     include_initial_state: true
     objects:
-      - name: events
-        mode: watch
-        # Only collect warning events to reduce cardinality in large clusters
-        # Set field_selector: "" to collect all events, or customize as needed
-        field_selector: "type=Warning"
       - group: ""
         name: pods
         mode: watch

--- a/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
@@ -10,12 +10,16 @@ receivers:
 {{- if .Values.cluster.collectk8sobjects }}
   k8sobjects:
     auth_type: serviceAccount
+    include_initial_state: true
     objects:
       - name: events
         mode: watch
         # Only collect warning events to reduce cardinality in large clusters
         # Set field_selector: "" to collect all events, or customize as needed
         field_selector: "type=Warning"
+      - group: ""
+        name: pods
+        mode: watch
 {{- end }}
 processors:
   batch:

--- a/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
@@ -51,6 +51,11 @@ receivers:
             enabled: true
       load:
       memory:
+        metrics:
+          system.memory.limit:
+            enabled: true
+          system.memory.utilization:
+            enabled: true
       {{- if .Values.agent.collectNetwork }}
       network:
       {{- end }}

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -247,6 +247,7 @@ cluster:
   #           exporters: [otlphttp/tsuga]
   # @default -- {}
   customConfig: {}
+  # This is used in the Kubernetes view to show pod configuration
   collectk8sobjects: false
   # -- Gateway collector configuration (merge-based approach)
   # Use this to extend the default configuration


### PR DESCRIPTION
## Summary

- Add pod watch (`pods`) to k8sobjects receiver with `include_initial_state: true` — enables the Kubernetes view to show pod configuration
- Add `system.memory.limit` and `system.memory.utilization` metrics to the daemonset hostmetrics receiver
- Update otel-demo example to enable `collectk8sobjects: true` and `collectNetwork: true`
- Update CHANGELOG with author attributions for previous releases

## Changes

### `_default-cluster-receiver-config.tpl`
- Added `include_initial_state: true` to k8sobjects receiver
- Added `pods` watch object alongside the existing `events` watch

### `_default-deamonset-config.tpl`
- Added `system.memory.limit` and `system.memory.utilization` memory metrics

### `values.yaml`
- Added clarifying comment for `collectk8sobjects` flag

### Examples
- Updated `otel-demo` example values and rendered outputs to reflect new defaults

### Chart version
- Bumped `opentelemetry-kube-stack` from `0.6.3` → `0.7.0`

## Test plan

- [ ] Verify rendered daemonset includes memory metrics
- [ ] Verify cluster receiver includes pod watch with `include_initial_state: true`
- [ ] Verify otel-demo example renders correctly
- [ ] Deploy to a test cluster and confirm pod objects appear in Tsuga Kubernetes view