### PR TITLE
fix(otel-demo): Fix postgresql subPath volume mount conflict

### DIFF
--- a/charts/opentelemetry-demo/CHANGELOG.md
+++ b/charts/opentelemetry-demo/CHANGELOG.md
@@ -5,157 +5,162 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [opentelemetry-demo-0.9.0] - 2026-06-05
+
+### Added
+- Add pod watch, memory metrics, bump to 0.7.0 (#84)
+
+### Changed
+- Standardize YAML formatting checks (#82)
+- Update/opentelemetry demo deps 0.7.0 and pg stats (#85)
+
 ## [opentelemetry-demo-0.8.0] - 2026-04-28
 
 ### Added
-- Add per-chart changelogs and release notes from git-cliff by @abruneau
-- Add k8s metrics and objects for otel demo by @kkontoudi
+- Add per-chart changelogs and release notes from git-cliff
+- Add k8s metrics and objects for otel demo
 
 ### Changed
-- Update changelog templates and enhance validation by @abruneau
-
-### New Contributors
-* @kkontoudi made their first contribution in [#79](https://github.com/tsuga-dev/helm-charts/pull/79)
+- Update changelog templates and enhance validation
 
 ## [opentelemetry-demo-0.7.0] - 2026-02-17
 
 ### Added
-- Add resourcedetection processor for cloud metadata by @abruneau
+- Add resourcedetection processor for cloud metadata
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to 0.4.0 and bump chart version to 0.7.0 by @abruneau
+- Update opentelemetry-kube-stack dependency to 0.4.0 and bump chart version to 0.7.0
 
 ## [opentelemetry-demo-0.6.8] - 2026-02-16
 
 ### Added
-- Add dynamic receiver discovery and multiline logs by @abruneau
+- Add dynamic receiver discovery and multiline logs
 
 ### Changed
-- Bump tsuga-spicy-gremlin to 0.1.2 by @abruneau
-- Bump chart version to 0.6.7 by @abruneau
-- Add metrics discovery for image-provider and valkey-cart services by @abruneau
-- Bump version by @abruneau
+- Bump tsuga-spicy-gremlin to 0.1.2
+- Bump chart version to 0.6.7
+- Add metrics discovery for image-provider and valkey-cart services
+- Bump version
 
 ## [opentelemetry-demo-0.6.6] - 2026-02-16
 
 ### Changed
-- Bump tsuga-spicy-gremlin verstion by @abruneau
-- Remove hardcoded OTEL env vars and add examples by @abruneau
-- Downgrade chart version to 0.6.6 and dependency version to 0.1.1 by @abruneau
+- Bump tsuga-spicy-gremlin verstion
+- Remove hardcoded OTEL env vars and add examples
+- Downgrade chart version to 0.6.6 and dependency version to 0.1.1
 
 ## [opentelemetry-demo-0.6.7] - 2026-02-16
 
 ### Changed
-- Leveraging new gremlin with o11y in it by @gus-tsuga
-- Using new spicy-gremlin version with o11y implemented by @gus-tsuga
-- Removing hard-coded env by @gus-tsuga
-- Cleaning custom env logic by @gus-tsuga
-- Making spicy gremlin run more often by @gus-tsuga
+- Leveraging new gremlin with o11y in it
+- Using new spicy-gremlin version with o11y implemented
+- Removing hard-coded env
+- Cleaning custom env logic
+- Making spicy gremlin run more often
 
 ## [opentelemetry-demo-0.6.4] - 2026-02-13
 
 ### Changed
-- Adding tsuga-spicy-gremlin by @gus-tsuga
-- Revert "Collecting more data out of kafka, redis, postgres, envoy" by @gus-tsuga
+- Adding tsuga-spicy-gremlin
+- Revert "Collecting more data out of kafka, redis, postgres, envoy"
 
 ## [opentelemetry-demo-0.6.2] - 2026-02-12
 
 ### Changed
-- Collecting more data out of kafka, redis, postgres, envoy by @gus-tsuga
-
-### New Contributors
-* @gus-tsuga made their first contribution in [#46](https://github.com/tsuga-dev/helm-charts/pull/46)
+- Collecting more data out of kafka, redis, postgres, envoy
 
 ## [opentelemetry-demo-0.6.1] - 2026-01-14
 
 ### Changed
-- Update opentelemetry-demo to version 0.6.1, enhance PostgreSQL logging configuration by adding log_min_duration_statement and log_line_prefix settings, and update README with the new version badge. by @abruneau
+- Update opentelemetry-demo to version 0.6.1, enhance PostgreSQL logging configuration by adding log_min_duration_statement and log_line_prefix settings, and update README with the new version badge.
 
 ## [opentelemetry-demo-0.6.0] - 2026-01-14
 
 ### Changed
-- Enable postgresql log collection and log_statement all by @abruneau
-- Update opentelemetry-demo to version 0.40.0, enhancing PostgreSQL log collection with new pod annotations and image overrides for product-reviews component. by @abruneau
-- Update opentelemetry-demo to version 0.6.0, bump opentelemetry-kube-stack to version 0.2.15, and modify logging configuration to disable log collection while adding support for log volumes. by @abruneau
+- Enable postgresql log collection and log_statement all
+- Update opentelemetry-demo to version 0.40.0, enhancing PostgreSQL log collection with new pod annotations and image overrides for product-reviews component.
+- Update opentelemetry-demo to version 0.6.0, bump opentelemetry-kube-stack to version 0.2.15, and modify logging configuration to disable log collection while adding support for log volumes.
 
 ## [opentelemetry-demo-0.5.0] - 2026-01-06
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to 0.2.12 and bump chart version to 0.5.0 by @abruneau
+- Update opentelemetry-kube-stack dependency to 0.2.12 and bump chart version to 0.5.0
 
 ## [opentelemetry-demo-0.4.0] - 2026-01-05
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to 0.2.11 and bump chart version to 0.4.0 by @abruneau
+- Update opentelemetry-kube-stack dependency to 0.2.11 and bump chart version to 0.4.0
 
 ## [opentelemetry-demo-0.3.0] - 2026-01-05
 
 ### Changed
-- Bump chart version to 0.2.11 and update spanmetrics connector configuration by @abruneau
-- Update opentelemetry-kube-stack dependency to 0.2.11 and bump chart version to 0.3.0 by @abruneau
+- Bump chart version to 0.2.11 and update spanmetrics connector configuration
+- Update opentelemetry-kube-stack dependency to 0.2.11 and bump chart version to 0.3.0
 
 ## [opentelemetry-demo-0.2.0] - 2025-12-18
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to 0.2.10 and bump chart version to 0.2.0 by @abruneau
+- Update opentelemetry-kube-stack dependency to 0.2.10 and bump chart version to 0.2.0
 
 ## [opentelemetry-demo-0.1.4] - 2025-12-17
 
 ### Changed
-- Bump dependency version by @abruneau
+- Bump dependency version
 
 ## [opentelemetry-demo-0.1.3] - 2025-12-16
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to version 0.2.8 and add collectLogs option in values.yaml by @abruneau
+- Update opentelemetry-kube-stack dependency to version 0.2.8 and add collectLogs option in values.yaml
 
 ## [opentelemetry-demo-0.1.2] - 2025-12-15
 
 ### Changed
-- Update opentelemetry-kube-stack dependency version to 0.2.7 in Chart.yaml by @abruneau
-- Bump version by @abruneau
+- Update opentelemetry-kube-stack dependency version to 0.2.7 in Chart.yaml
+- Bump version
 
 ## [opentelemetry-demo-0.1.1] - 2025-12-12
 
 ### Changed
-- Add OpenTelemetry demo Helm chart by @abruneau
-- Add pod annotations for OpenTelemetry components in values.yaml by @abruneau
-- Add default example by @abruneau
-- Bump versions by @abruneau
-- Revert "Otel-demo-improvement" by @abruneau
-- Enhance OpenTelemetry demo chart and CI/CD configuration by @abruneau
-[opentelemetry-demo-0.8.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.7.0...opentelemetry-demo-0.8.0
+- Add OpenTelemetry demo Helm chart
+- Add pod annotations for OpenTelemetry components in values.yaml
+- Add default example
+- Bump versions
+- Revert "Otel-demo-improvement"
+- Enhance OpenTelemetry demo chart and CI/CD configuration
+[opentelemetry-demo-0.9.0]: https://github.com///compare/opentelemetry-demo-0.8.0...opentelemetry-demo-0.9.0
 
-[opentelemetry-demo-0.7.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.8...opentelemetry-demo-0.7.0
+[opentelemetry-demo-0.8.0]: https://github.com///compare/opentelemetry-demo-0.7.0...opentelemetry-demo-0.8.0
 
-[opentelemetry-demo-0.6.8]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.6...opentelemetry-demo-0.6.8
+[opentelemetry-demo-0.7.0]: https://github.com///compare/opentelemetry-demo-0.6.8...opentelemetry-demo-0.7.0
 
-[opentelemetry-demo-0.6.6]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.7...opentelemetry-demo-0.6.6
+[opentelemetry-demo-0.6.8]: https://github.com///compare/opentelemetry-demo-0.6.6...opentelemetry-demo-0.6.8
 
-[opentelemetry-demo-0.6.7]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.4...opentelemetry-demo-0.6.7
+[opentelemetry-demo-0.6.6]: https://github.com///compare/opentelemetry-demo-0.6.7...opentelemetry-demo-0.6.6
 
-[opentelemetry-demo-0.6.4]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.2...opentelemetry-demo-0.6.4
+[opentelemetry-demo-0.6.7]: https://github.com///compare/opentelemetry-demo-0.6.4...opentelemetry-demo-0.6.7
 
-[opentelemetry-demo-0.6.2]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.1...opentelemetry-demo-0.6.2
+[opentelemetry-demo-0.6.4]: https://github.com///compare/opentelemetry-demo-0.6.2...opentelemetry-demo-0.6.4
 
-[opentelemetry-demo-0.6.1]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.0...opentelemetry-demo-0.6.1
+[opentelemetry-demo-0.6.2]: https://github.com///compare/opentelemetry-demo-0.6.1...opentelemetry-demo-0.6.2
 
-[opentelemetry-demo-0.6.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.5.0...opentelemetry-demo-0.6.0
+[opentelemetry-demo-0.6.1]: https://github.com///compare/opentelemetry-demo-0.6.0...opentelemetry-demo-0.6.1
 
-[opentelemetry-demo-0.5.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.4.0...opentelemetry-demo-0.5.0
+[opentelemetry-demo-0.6.0]: https://github.com///compare/opentelemetry-demo-0.5.0...opentelemetry-demo-0.6.0
 
-[opentelemetry-demo-0.4.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.3.0...opentelemetry-demo-0.4.0
+[opentelemetry-demo-0.5.0]: https://github.com///compare/opentelemetry-demo-0.4.0...opentelemetry-demo-0.5.0
 
-[opentelemetry-demo-0.3.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.2.0...opentelemetry-demo-0.3.0
+[opentelemetry-demo-0.4.0]: https://github.com///compare/opentelemetry-demo-0.3.0...opentelemetry-demo-0.4.0
 
-[opentelemetry-demo-0.2.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.4...opentelemetry-demo-0.2.0
+[opentelemetry-demo-0.3.0]: https://github.com///compare/opentelemetry-demo-0.2.0...opentelemetry-demo-0.3.0
 
-[opentelemetry-demo-0.1.4]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.3...opentelemetry-demo-0.1.4
+[opentelemetry-demo-0.2.0]: https://github.com///compare/opentelemetry-demo-0.1.4...opentelemetry-demo-0.2.0
 
-[opentelemetry-demo-0.1.3]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.2...opentelemetry-demo-0.1.3
+[opentelemetry-demo-0.1.4]: https://github.com///compare/opentelemetry-demo-0.1.3...opentelemetry-demo-0.1.4
 
-[opentelemetry-demo-0.1.2]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.1...opentelemetry-demo-0.1.2
+[opentelemetry-demo-0.1.3]: https://github.com///compare/opentelemetry-demo-0.1.2...opentelemetry-demo-0.1.3
 
-[opentelemetry-demo-0.1.1]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.0...opentelemetry-demo-0.1.1
+[opentelemetry-demo-0.1.2]: https://github.com///compare/opentelemetry-demo-0.1.1...opentelemetry-demo-0.1.2
+
+[opentelemetry-demo-0.1.1]: https://github.com///compare/opentelemetry-demo-0.1.0...opentelemetry-demo-0.1.1
 
 <!-- generated by git-cliff -->

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.9.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-demo/README.md
+++ b/charts/opentelemetry-demo/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-demo
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.0](https://img.shields.io/badge/AppVersion-0.40.0-informational?style=flat-square)
+![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.0](https://img.shields.io/badge/AppVersion-0.40.0-informational?style=flat-square)
 
 A Helm chart for Tsuga Observability Demo
 
@@ -49,8 +49,9 @@ A Helm chart for Tsuga Observability Demo
 | opentelemetry-demo.components.postgresql.command[7] | string | `"-c"` |  |
 | opentelemetry-demo.components.postgresql.command[8] | string | `"shared_preload_libraries=pg_stat_statements"` |  |
 | opentelemetry-demo.components.postgresql.mountedConfigMaps[0].existingConfigMap | string | `"postgresql-init"` |  |
-| opentelemetry-demo.components.postgresql.mountedConfigMaps[0].mountPath | string | `"/docker-entrypoint-initdb.d"` |  |
+| opentelemetry-demo.components.postgresql.mountedConfigMaps[0].mountPath | string | `"/docker-entrypoint-initdb.d/init.sql"` |  |
 | opentelemetry-demo.components.postgresql.mountedConfigMaps[0].name | string | `"postgresql-init"` |  |
+| opentelemetry-demo.components.postgresql.mountedConfigMaps[0].subPath | string | `"init.sql"` |  |
 | opentelemetry-demo.components.postgresql.mountedConfigMaps[1].data."00-extensions.sql" | string | `"CREATE EXTENSION IF NOT EXISTS pg_stat_statements;\\n"` |  |
 | opentelemetry-demo.components.postgresql.mountedConfigMaps[1].mountPath | string | `"/docker-entrypoint-initdb.d/00-extensions.sql"` |  |
 | opentelemetry-demo.components.postgresql.mountedConfigMaps[1].name | string | `"extensions"` |  |

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -123,7 +123,8 @@ opentelemetry-demo:
         - shared_preload_libraries=pg_stat_statements
       mountedConfigMaps:
         - name: "postgresql-init"
-          mountPath: "/docker-entrypoint-initdb.d"
+          mountPath: "/docker-entrypoint-initdb.d/init.sql"
+          subPath: "init.sql"
           existingConfigMap: "postgresql-init"
         - name: "extensions"
           mountPath: "/docker-entrypoint-initdb.d/00-extensions.sql"


### PR DESCRIPTION
## Summary

- Fixes PostgreSQL container start failure caused by conflicting volume mounts
- Added `subPath: "init.sql"` to the `postgresql-init` configmap mount so the file is mounted at a specific path rather than as a directory
- Updated `mountPath` from `/docker-entrypoint-initdb.d` to `/docker-entrypoint-initdb.d/init.sql` to match the subPath pattern
- Bumps chart to version `0.9.1`

**Root cause:** Mounting a ConfigMap to a directory path (`/docker-entrypoint-initdb.d`) while another mount also targets that same path causes an OCI runtime conflict during container creation. Using `subPath` mounts a single file instead of the whole directory, eliminating the conflict.

## Test plan

- [ ] Deploy the opentelemetry-demo chart and verify the PostgreSQL pod starts successfully
- [ ] Confirm `init.sql` is present inside the container at `/docker-entrypoint-initdb.d/init.sql`
- [ ] Verify the extensions configmap mount at `/docker-entrypoint-initdb.d/00-extensions.sql` still works correctly