### PR TITLE
feat(opentelemetry-database-monitoring): Add initial Helm chart for PostgreSQL database monitoring

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,25 @@ repos:
     rev: v2.3.1
     hooks:
       - id: helm-schema
-        args: ["--values", "./charts/opentelemetry-kube-stack/values.yaml", "-o", "./charts/opentelemetry-kube-stack/values.schema.json"]
+        args:
+          [
+            "--values",
+            "./charts/opentelemetry-kube-stack/values.yaml",
+            "-o",
+            "./charts/opentelemetry-kube-stack/values.schema.json",
+          ]
+
+  - repo: https://github.com/losisin/helm-values-schema-json
+    rev: v2.3.1
+    hooks:
+      - id: helm-schema
+        args:
+          [
+            "--values",
+            "./charts/opentelemetry-database-monitoring/values.yaml",
+            "-o",
+            "./charts/opentelemetry-database-monitoring/values.schema.json",
+          ]
 
   - repo: https://github.com/gruntwork-io/pre-commit
     rev: v0.1.23

--- a/charts/opentelemetry-database-monitoring/.helmignore
+++ b/charts/opentelemetry-database-monitoring/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/opentelemetry-database-monitoring/Chart.yaml
+++ b/charts/opentelemetry-database-monitoring/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: opentelemetry-database-monitoring
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/opentelemetry-database-monitoring/README.md
+++ b/charts/opentelemetry-database-monitoring/README.md
@@ -8,12 +8,12 @@ A Helm chart that deploys OpenTelemetry-based deep monitoring for PostgreSQL usi
 
 ```
 ┌───────────────────────────────────────────┐
-│  Your PostgreSQL Pod                       │
+│  Your PostgreSQL Pod                      │
 │                                           │
-│  ┌─────────────┐   ┌─────────────────┐   │
-│  │  PostgreSQL  │   │  OTel Collector │   │
-│  │  container  │◄──│    (sidecar)    │   │
-│  └─────────────┘   └────────┬────────┘   │
+│  ┌─────────────┐   ┌─────────────────┐    │
+│  │  PostgreSQL │   │  OTel Collector │    │
+│  │  container  │◄──│    (sidecar)    │    │
+│  └─────────────┘   └────────┬────────┘    │
 │                              │ OTLP/gRPC  │
 └──────────────────────────────┼────────────┘
                                ▼

--- a/charts/opentelemetry-database-monitoring/README.md
+++ b/charts/opentelemetry-database-monitoring/README.md
@@ -1,0 +1,205 @@
+# opentelemetry-database-monitoring
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+
+A Helm chart that deploys OpenTelemetry-based deep monitoring for PostgreSQL using a sidecar collector pattern. It installs stored functions on the target database, creates a dedicated monitoring user, and runs an `OpenTelemetryCollector` sidecar that emits metrics via OTLP.
+
+## How it works
+
+```
+┌───────────────────────────────────────────┐
+│  Your PostgreSQL Pod                       │
+│                                           │
+│  ┌─────────────┐   ┌─────────────────┐   │
+│  │  PostgreSQL  │   │  OTel Collector │   │
+│  │  container  │◄──│    (sidecar)    │   │
+│  └─────────────┘   └────────┬────────┘   │
+│                              │ OTLP/gRPC  │
+└──────────────────────────────┼────────────┘
+                               ▼
+                     Node IP :4317
+                 (DaemonSet collector
+                  or any OTLP endpoint)
+```
+
+For each database entry in `values.yaml`, the chart creates:
+
+1. **Secret** — a `<name>-pg-monitor-credentials` Secret holding the auto-generated (or idempotently preserved) password for the `otel_monitor` user.
+2. **ConfigMap** — embeds `pg-monitoring-setup.sql` (the stored functions).
+3. **Job** (post-install/post-upgrade hook) — waits for PostgreSQL to be ready, runs the setup SQL on the `otel` database, and rotates the `otel_monitor` password to match the Secret.
+4. **OpenTelemetryCollector** (sidecar) — an `opentelemetry.io/v1beta1` CR that configures the contrib collector with all receivers and exports metrics to `$K8S_NODE_IP:4317`.
+
+## Prerequisites
+
+- Kubernetes 1.21+
+- [OpenTelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator) installed in the cluster (provides the `OpenTelemetryCollector` CRD and injects sidecars)
+- PostgreSQL 10+ (for `pg_stat_progress_vacuum`)
+- A superuser (or a role with `CREATEROLE` and `CREATEDB`) available to run the setup Job — credentials are passed via `postgres.databases[*].user` / `postgres.databases[*].pwd`
+- An `otel` database must exist on each target PostgreSQL instance before install (the Job connects to it: `psql … -d otel`)
+
+## Installation
+
+```bash
+helm repo add tsuga-charts https://tsuga-dev.github.io/helm-charts/
+helm repo update
+
+helm install pg-monitoring tsuga-charts/opentelemetry-database-monitoring \
+  --set postgres.enabled=true \
+  --set postgres.databases[0].name=postgresql \
+  --set postgres.databases[0].host=postgresql \
+  --set postgres.databases[0].user=root \
+  --set postgres.databases[0].pwd=<superuser-password>
+```
+
+## Examples
+
+### Single database
+
+```yaml
+postgres:
+  enabled: true
+  databases:
+    - name: postgresql
+      sidecar-name: postgres-dbm-sidecar
+      user: root
+      pwd: otel
+      port: 5432
+      host: postgresql
+```
+
+### Multiple databases
+
+Each entry produces an independent set of resources (Secret, Job, sidecar CR).
+
+```yaml
+postgres:
+  enabled: true
+  databases:
+    - name: postgresql
+      sidecar-name: postgres-dbm-sidecar
+      user: root
+      pwd: otel
+      port: 5432
+      host: postgresql
+    - name: postgresql2
+      sidecar-name: postgres2-dbm-sidecar
+      user: root
+      pwd: otel
+      port: 5432
+      host: postgresql2
+```
+
+## Database setup
+
+The setup Job runs `assets/pg-monitoring-setup.sql` idempotently on every install and upgrade. It:
+
+1. Creates the `otel_monitor` user (if absent) and grants it `pg_monitor` + `SELECT` on `pg_stat_database`.
+2. Enables the `pg_stat_statements` extension.
+3. Creates the `otel` schema and grants `USAGE` to `otel_monitor`.
+4. Installs the following stored functions (all `STABLE`, safe for repeated execution):
+
+| Function | Description |
+|----------|-------------|
+| `otel.pg_table_stats()` | Vacuum/analyze ages, autovacuum counts, rows modified since last analyze. Top 50 tables by `n_mod_since_analyze`. |
+| `otel.pg_bloat()` | Table bloat ratio and wasted bytes using the standard check_postgres algorithm. Top 20 tables by wasted bytes. |
+| `otel.pg_connections()` | Connection count and max state age per database per connection state. |
+| `otel.pg_lock_counts()` | Lock counts by type, mode, and granted status. |
+| `otel.pg_blocking_queries()` | Count of queries currently waiting on a lock. |
+| `otel.pg_idle_in_transaction()` | Idle-in-transaction connection count and max age per database. |
+| `otel.pg_replication_slots()` | Replication slot lag in bytes per slot. |
+| `otel.pg_wal()` | WAL segment file count and total WAL directory size. |
+| `otel.pg_vacuum_progress()` | Active vacuum operations with phase and block progress (PG 10+). |
+| `otel.pg_top_queries()` | Top 20 queries by call count from `pg_stat_statements`. Query text truncated to 200 characters. |
+
+5. Grants `EXECUTE` on all `otel` functions to `otel_monitor`.
+6. Rotates the `otel_monitor` password to match the value in the Secret.
+
+> **Note:** The Job connects to the `otel` database (`-d otel`). This database must exist before the chart is installed.
+
+## Metrics
+
+The sidecar collector runs two categories of receivers.
+
+### Built-in `postgresql` receiver
+
+Polls the PostgreSQL stats system views directly. Default collection interval.
+
+| Metric | Unit | Description |
+|--------|------|-------------|
+| `postgresql.bgwriter.buffers.allocated` | `{buffer}` | Buffers allocated by bgwriter |
+| `postgresql.bgwriter.buffers.writes` | `{buffer}` | Buffers written by bgwriter |
+| `postgresql.bgwriter.checkpoint.count` | `{checkpoint}` | Checkpoint count |
+| `postgresql.bgwriter.duration` | `ms` | Checkpoint write/sync duration |
+| `postgresql.bgwriter.maxwritten` | `1` | Times bgwriter stopped a round due to too many buffers written |
+| `postgresql.blks_hit` | `{hit}` | Buffer cache hits |
+| `postgresql.blks_read` | `{read}` | Disk blocks read |
+| `postgresql.connection.max` | `{connection}` | Max connections configured |
+| `postgresql.database.locks` | `{lock}` | Database lock counts |
+| `postgresql.deadlocks` | `{deadlock}` | Deadlocks detected |
+| `postgresql.replication.data_delay` | `By` | Replication data delay |
+| `postgresql.sequential_scans` | `{scan}` | Sequential scans |
+| `postgresql.temp_files` | `{file}` | Temp files created |
+| `postgresql.tup_deleted` / `tup_fetched` / `tup_inserted` / `tup_returned` / `tup_updated` | `{tuple}` | Row operation counters |
+| `postgresql.wal.age` | `s` | WAL archiver age |
+| `postgresql.wal.lag` | `s` | Replication WAL lag |
+
+### `sqlquery` receivers (stored functions)
+
+| Receiver | Interval | Metrics |
+|----------|----------|---------|
+| `sqlquery/postgresql_top_queries` | default | `postgresql.query.calls`, `.rows`, `.exec_time`, `.plan_time`, `.blocks.shared.*`, `.blocks.temp.*` — attributed by `db.namespace`, `db.user.name`, `db.query.text`, `db.version` |
+| `sqlquery/pg_table_stats` | 5 min | `postgresql.table.vacuum.age`, `.autovacuum.age`, `.analyze.age`, `.autoanalyze.age`, `.autovacuum.count`, `.analyze.count`, `.autoanalyze.count`, `.rows.modified.since.analyze` |
+| `sqlquery/pg_bloat` | 1 hour | `postgresql.table.bloat.ratio`, `postgresql.table.bloat.bytes` |
+| `sqlquery/pg_connections` | 30 s | `postgresql.backends` (count), `postgresql.backends.age` (max state age) |
+| `sqlquery/pg_locks` | 30 s | `postgresql.lock.count`, `postgresql.lock.blocking_queries`, `postgresql.connection.idle_in_transaction`, `postgresql.connection.idle_in_transaction.age` |
+| `sqlquery/pg_replication` | 30 s | `postgresql.replication.slot.lag` |
+| `sqlquery/pg_wal` | 60 s | `postgresql.wal.file_count`, `postgresql.wal.bytes` |
+| `sqlquery/pg_vacuum_progress` | 60 s | `postgresql.vacuum.heap_blks_total`, `.heap_blks_scanned`, `.heap_blks_vacuumed`, `postgresql.vacuum.age` |
+
+All metrics are batched (max 5000 per batch) and exported via OTLP/gRPC to `$K8S_NODE_IP:4317`.
+
+## Security notes
+
+- The superuser credentials (`user`/`pwd`) are used only by the setup Job and are not stored in any long-lived secret.
+- The sidecar uses the auto-generated `otel_monitor` password from the Secret, rotated on every `helm upgrade`.
+- The Secret is created with `lookup` to preserve the existing password across upgrades — a new random 24-character password is only generated on first install.
+- The `otel_monitor` user holds `pg_monitor` (read-only system views) and `EXECUTE` on the `otel.*` functions. It has no write access to application data.
+- All SQL connections from the sidecar use `sslmode=disable`. Enable TLS by overriding `assets/pg-monitoring-config.yaml` if your PostgreSQL requires it.
+
+## Upgrading
+
+The setup Job runs on both `post-install` and `post-upgrade` hooks with `before-hook-creation` deletion policy, so it re-runs on every `helm upgrade`. This is safe: all SQL statements are idempotent and the password rotation uses the existing Secret value.
+
+## Troubleshooting
+
+**Job fails immediately**
+
+Check that the `otel` database exists and the superuser credentials are correct:
+```bash
+kubectl logs job/<name>-postgresql-monitoring-setup
+```
+
+**No metrics in the collector**
+
+Verify the `OpenTelemetryCollector` CR was injected as a sidecar into the target Pod. The OTel Operator must be running and the Pod must have the `sidecar.opentelemetry.io/inject` annotation or the operator must be configured for namespace-wide injection.
+
+**`pg_stat_statements` not available**
+
+The extension must be listed in `shared_preload_libraries` in `postgresql.conf` and PostgreSQL must be restarted before it can be created. Add `shared_preload_libraries = 'pg_stat_statements'` to your PostgreSQL configuration and restart the server before installing the chart.
+
+**Top queries missing**
+
+Queries run by the collector itself are excluded via the `/* otel-collector-ignore */` comment prefix. If `otel.pg_top_queries()` returns no rows, check that `pg_stat_statements.track` is not set to `none`.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| postgres.databases[0].host | string | `""` |  |
+| postgres.databases[0].name | string | `"postgresql"` |  |
+| postgres.databases[0].port | int | `5432` |  |
+| postgres.databases[0].pwd | string | `""` |  |
+| postgres.databases[0].sidecar-name | string | `"postgres-dbm-sidecar"` |  |
+| postgres.databases[0].user | string | `""` |  |
+| postgres.enabled | bool | `false` |  |
+| postgres.image | string | `"ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib"` |  |

--- a/charts/opentelemetry-database-monitoring/README.md.gotmpl
+++ b/charts/opentelemetry-database-monitoring/README.md.gotmpl
@@ -18,12 +18,12 @@ A Helm chart that deploys OpenTelemetry-based deep monitoring for PostgreSQL usi
 
 ```
 ┌───────────────────────────────────────────┐
-│  Your PostgreSQL Pod                       │
+│  Your PostgreSQL Pod                      │
 │                                           │
-│  ┌─────────────┐   ┌─────────────────┐   │
-│  │  PostgreSQL  │   │  OTel Collector │   │
-│  │  container  │◄──│    (sidecar)    │   │
-│  └─────────────┘   └────────┬────────┘   │
+│  ┌─────────────┐   ┌─────────────────┐    │
+│  │  PostgreSQL │   │  OTel Collector │    │
+│  │  container  │◄──│    (sidecar)    │    │
+│  └─────────────┘   └────────┬────────┘    │
 │                              │ OTLP/gRPC  │
 └──────────────────────────────┼────────────┘
                                ▼

--- a/charts/opentelemetry-database-monitoring/README.md.gotmpl
+++ b/charts/opentelemetry-database-monitoring/README.md.gotmpl
@@ -1,0 +1,204 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+A Helm chart that deploys OpenTelemetry-based deep monitoring for PostgreSQL using a sidecar collector pattern. It installs stored functions on the target database, creates a dedicated monitoring user, and runs an `OpenTelemetryCollector` sidecar that emits metrics via OTLP.
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## How it works
+
+```
+┌───────────────────────────────────────────┐
+│  Your PostgreSQL Pod                       │
+│                                           │
+│  ┌─────────────┐   ┌─────────────────┐   │
+│  │  PostgreSQL  │   │  OTel Collector │   │
+│  │  container  │◄──│    (sidecar)    │   │
+│  └─────────────┘   └────────┬────────┘   │
+│                              │ OTLP/gRPC  │
+└──────────────────────────────┼────────────┘
+                               ▼
+                     Node IP :4317
+                 (DaemonSet collector
+                  or any OTLP endpoint)
+```
+
+For each database entry in `values.yaml`, the chart creates:
+
+1. **Secret** — a `<name>-pg-monitor-credentials` Secret holding the auto-generated (or idempotently preserved) password for the `otel_monitor` user.
+2. **ConfigMap** — embeds `pg-monitoring-setup.sql` (the stored functions).
+3. **Job** (post-install/post-upgrade hook) — waits for PostgreSQL to be ready, runs the setup SQL on the `otel` database, and rotates the `otel_monitor` password to match the Secret.
+4. **OpenTelemetryCollector** (sidecar) — an `opentelemetry.io/v1beta1` CR that configures the contrib collector with all receivers and exports metrics to `$K8S_NODE_IP:4317`.
+
+## Prerequisites
+
+- Kubernetes 1.21+
+- [OpenTelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator) installed in the cluster (provides the `OpenTelemetryCollector` CRD and injects sidecars)
+- PostgreSQL 10+ (for `pg_stat_progress_vacuum`)
+- A superuser (or a role with `CREATEROLE` and `CREATEDB`) available to run the setup Job — credentials are passed via `postgres.databases[*].user` / `postgres.databases[*].pwd`
+- An `otel` database must exist on each target PostgreSQL instance before install (the Job connects to it: `psql … -d otel`)
+
+## Installation
+
+```bash
+helm repo add tsuga-charts https://tsuga-dev.github.io/helm-charts/
+helm repo update
+
+helm install pg-monitoring tsuga-charts/opentelemetry-database-monitoring \
+  --set postgres.enabled=true \
+  --set postgres.databases[0].name=postgresql \
+  --set postgres.databases[0].host=postgresql \
+  --set postgres.databases[0].user=root \
+  --set postgres.databases[0].pwd=<superuser-password>
+```
+
+## Examples
+
+### Single database
+
+```yaml
+postgres:
+  enabled: true
+  databases:
+    - name: postgresql
+      sidecar-name: postgres-dbm-sidecar
+      user: root
+      pwd: otel
+      port: 5432
+      host: postgresql
+```
+
+### Multiple databases
+
+Each entry produces an independent set of resources (Secret, Job, sidecar CR).
+
+```yaml
+postgres:
+  enabled: true
+  databases:
+    - name: postgresql
+      sidecar-name: postgres-dbm-sidecar
+      user: root
+      pwd: otel
+      port: 5432
+      host: postgresql
+    - name: postgresql2
+      sidecar-name: postgres2-dbm-sidecar
+      user: root
+      pwd: otel
+      port: 5432
+      host: postgresql2
+```
+
+## Database setup
+
+The setup Job runs `assets/pg-monitoring-setup.sql` idempotently on every install and upgrade. It:
+
+1. Creates the `otel_monitor` user (if absent) and grants it `pg_monitor` + `SELECT` on `pg_stat_database`.
+2. Enables the `pg_stat_statements` extension.
+3. Creates the `otel` schema and grants `USAGE` to `otel_monitor`.
+4. Installs the following stored functions (all `STABLE`, safe for repeated execution):
+
+| Function | Description |
+|----------|-------------|
+| `otel.pg_table_stats()` | Vacuum/analyze ages, autovacuum counts, rows modified since last analyze. Top 50 tables by `n_mod_since_analyze`. |
+| `otel.pg_bloat()` | Table bloat ratio and wasted bytes using the standard check_postgres algorithm. Top 20 tables by wasted bytes. |
+| `otel.pg_connections()` | Connection count and max state age per database per connection state. |
+| `otel.pg_lock_counts()` | Lock counts by type, mode, and granted status. |
+| `otel.pg_blocking_queries()` | Count of queries currently waiting on a lock. |
+| `otel.pg_idle_in_transaction()` | Idle-in-transaction connection count and max age per database. |
+| `otel.pg_replication_slots()` | Replication slot lag in bytes per slot. |
+| `otel.pg_wal()` | WAL segment file count and total WAL directory size. |
+| `otel.pg_vacuum_progress()` | Active vacuum operations with phase and block progress (PG 10+). |
+| `otel.pg_top_queries()` | Top 20 queries by call count from `pg_stat_statements`. Query text truncated to 200 characters. |
+
+5. Grants `EXECUTE` on all `otel` functions to `otel_monitor`.
+6. Rotates the `otel_monitor` password to match the value in the Secret.
+
+> **Note:** The Job connects to the `otel` database (`-d otel`). This database must exist before the chart is installed.
+
+## Metrics
+
+The sidecar collector runs two categories of receivers.
+
+### Built-in `postgresql` receiver
+
+Polls the PostgreSQL stats system views directly. Default collection interval.
+
+| Metric | Unit | Description |
+|--------|------|-------------|
+| `postgresql.bgwriter.buffers.allocated` | `{buffer}` | Buffers allocated by bgwriter |
+| `postgresql.bgwriter.buffers.writes` | `{buffer}` | Buffers written by bgwriter |
+| `postgresql.bgwriter.checkpoint.count` | `{checkpoint}` | Checkpoint count |
+| `postgresql.bgwriter.duration` | `ms` | Checkpoint write/sync duration |
+| `postgresql.bgwriter.maxwritten` | `1` | Times bgwriter stopped a round due to too many buffers written |
+| `postgresql.blks_hit` | `{hit}` | Buffer cache hits |
+| `postgresql.blks_read` | `{read}` | Disk blocks read |
+| `postgresql.connection.max` | `{connection}` | Max connections configured |
+| `postgresql.database.locks` | `{lock}` | Database lock counts |
+| `postgresql.deadlocks` | `{deadlock}` | Deadlocks detected |
+| `postgresql.replication.data_delay` | `By` | Replication data delay |
+| `postgresql.sequential_scans` | `{scan}` | Sequential scans |
+| `postgresql.temp_files` | `{file}` | Temp files created |
+| `postgresql.tup_deleted` / `tup_fetched` / `tup_inserted` / `tup_returned` / `tup_updated` | `{tuple}` | Row operation counters |
+| `postgresql.wal.age` | `s` | WAL archiver age |
+| `postgresql.wal.lag` | `s` | Replication WAL lag |
+
+### `sqlquery` receivers (stored functions)
+
+| Receiver | Interval | Metrics |
+|----------|----------|---------|
+| `sqlquery/postgresql_top_queries` | default | `postgresql.query.calls`, `.rows`, `.exec_time`, `.plan_time`, `.blocks.shared.*`, `.blocks.temp.*` — attributed by `db.namespace`, `db.user.name`, `db.query.text`, `db.version` |
+| `sqlquery/pg_table_stats` | 5 min | `postgresql.table.vacuum.age`, `.autovacuum.age`, `.analyze.age`, `.autoanalyze.age`, `.autovacuum.count`, `.analyze.count`, `.autoanalyze.count`, `.rows.modified.since.analyze` |
+| `sqlquery/pg_bloat` | 1 hour | `postgresql.table.bloat.ratio`, `postgresql.table.bloat.bytes` |
+| `sqlquery/pg_connections` | 30 s | `postgresql.backends` (count), `postgresql.backends.age` (max state age) |
+| `sqlquery/pg_locks` | 30 s | `postgresql.lock.count`, `postgresql.lock.blocking_queries`, `postgresql.connection.idle_in_transaction`, `postgresql.connection.idle_in_transaction.age` |
+| `sqlquery/pg_replication` | 30 s | `postgresql.replication.slot.lag` |
+| `sqlquery/pg_wal` | 60 s | `postgresql.wal.file_count`, `postgresql.wal.bytes` |
+| `sqlquery/pg_vacuum_progress` | 60 s | `postgresql.vacuum.heap_blks_total`, `.heap_blks_scanned`, `.heap_blks_vacuumed`, `postgresql.vacuum.age` |
+
+All metrics are batched (max 5000 per batch) and exported via OTLP/gRPC to `$K8S_NODE_IP:4317`.
+
+## Security notes
+
+- The superuser credentials (`user`/`pwd`) are used only by the setup Job and are not stored in any long-lived secret.
+- The sidecar uses the auto-generated `otel_monitor` password from the Secret, rotated on every `helm upgrade`.
+- The Secret is created with `lookup` to preserve the existing password across upgrades — a new random 24-character password is only generated on first install.
+- The `otel_monitor` user holds `pg_monitor` (read-only system views) and `EXECUTE` on the `otel.*` functions. It has no write access to application data.
+- All SQL connections from the sidecar use `sslmode=disable`. Enable TLS by overriding `assets/pg-monitoring-config.yaml` if your PostgreSQL requires it.
+
+## Upgrading
+
+The setup Job runs on both `post-install` and `post-upgrade` hooks with `before-hook-creation` deletion policy, so it re-runs on every `helm upgrade`. This is safe: all SQL statements are idempotent and the password rotation uses the existing Secret value.
+
+## Troubleshooting
+
+**Job fails immediately**
+
+Check that the `otel` database exists and the superuser credentials are correct:
+```bash
+kubectl logs job/<name>-postgresql-monitoring-setup
+```
+
+**No metrics in the collector**
+
+Verify the `OpenTelemetryCollector` CR was injected as a sidecar into the target Pod. The OTel Operator must be running and the Pod must have the `sidecar.opentelemetry.io/inject` annotation or the operator must be configured for namespace-wide injection.
+
+**`pg_stat_statements` not available**
+
+The extension must be listed in `shared_preload_libraries` in `postgresql.conf` and PostgreSQL must be restarted before it can be created. Add `shared_preload_libraries = 'pg_stat_statements'` to your PostgreSQL configuration and restart the server before installing the chart.
+
+**Top queries missing**
+
+Queries run by the collector itself are excluded via the `/* otel-collector-ignore */` comment prefix. If `otel.pg_top_queries()` returns no rows, check that `pg_stat_statements.track` is not set to `none`.
+
+{{ template "chart.valuesSection" . }}

--- a/charts/opentelemetry-database-monitoring/assets/pg-monitoring-config.yaml
+++ b/charts/opentelemetry-database-monitoring/assets/pg-monitoring-config.yaml
@@ -1,0 +1,438 @@
+receivers:
+  postgresql:
+    endpoint: ${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME}:5432
+    metrics:
+      postgresql.bgwriter.buffers.allocated:
+        enabled: true
+      postgresql.bgwriter.buffers.writes:
+        enabled: true
+      postgresql.bgwriter.checkpoint.count:
+        enabled: true
+      postgresql.bgwriter.duration:
+        enabled: true
+      postgresql.bgwriter.maxwritten:
+        enabled: true
+      postgresql.blks_hit:
+        enabled: true
+      postgresql.blks_read:
+        enabled: true
+      postgresql.connection.max:
+        enabled: true
+      postgresql.database.locks:
+        enabled: true
+      postgresql.deadlocks:
+        enabled: true
+      postgresql.replication.data_delay:
+        enabled: true
+      postgresql.sequential_scans:
+        enabled: true
+      postgresql.temp_files:
+        enabled: true
+      postgresql.tup_deleted:
+        enabled: true
+      postgresql.tup_fetched:
+        enabled: true
+      postgresql.tup_inserted:
+        enabled: true
+      postgresql.tup_returned:
+        enabled: true
+      postgresql.tup_updated:
+        enabled: true
+      postgresql.wal.age:
+        enabled: true
+      postgresql.wal.lag:
+        enabled: true
+    password: ${env:OTEL_MONITOR_PASSWORD}
+    tls:
+      insecure: true
+    username: otel_monitor
+  sqlquery/pg_bloat:
+    collection_interval: 3600s
+    datasource:
+      host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+      sslmode=disable
+    driver: postgres
+    queries:
+      - metrics:
+          - attribute_columns:
+              - db.schema
+              - db.collection.name
+            data_type: gauge
+            metric_name: postgresql.table.bloat.ratio
+            unit: "1"
+            value_column: tbloat
+            value_type: double
+          - attribute_columns:
+              - db.schema
+              - db.collection.name
+            data_type: gauge
+            metric_name: postgresql.table.bloat.bytes
+            unit: By
+            value_column: wastedbytes
+            value_type: int
+        sql: SELECT * FROM otel.pg_bloat()
+  sqlquery/pg_connections:
+    collection_interval: 30s
+    datasource:
+      host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+      sslmode=disable
+    driver: postgres
+    queries:
+      - metrics:
+          - attribute_columns:
+              - db.namespace
+              - db.client.connection.state
+            data_type: gauge
+            metric_name: postgresql.backends
+            unit: "{connection}"
+            value_column: connection_count
+            value_type: int
+          - attribute_columns:
+              - db.namespace
+              - db.client.connection.state
+            data_type: gauge
+            metric_name: postgresql.backends.age
+            unit: s
+            value_column: max_state_age_seconds
+            value_type: int
+        sql: SELECT * FROM otel.pg_connections()
+  sqlquery/pg_locks:
+    collection_interval: 30s
+    datasource:
+      host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+      sslmode=disable
+    driver: postgres
+    queries:
+      - metrics:
+          - attribute_columns:
+              - db.postgresql.lock.type
+              - db.postgresql.lock.mode
+              - db.postgresql.lock.granted
+            data_type: gauge
+            metric_name: postgresql.lock.count
+            unit: "{lock}"
+            value_column: lock_count
+            value_type: int
+        sql: SELECT * FROM otel.pg_lock_counts()
+      - metrics:
+          - data_type: gauge
+            metric_name: postgresql.lock.blocking_queries
+            unit: "{query}"
+            value_column: blocking_count
+            value_type: int
+        sql: SELECT * FROM otel.pg_blocking_queries()
+      - metrics:
+          - attribute_columns:
+              - db.namespace
+            data_type: gauge
+            metric_name: postgresql.connection.idle_in_transaction
+            unit: "{connection}"
+            value_column: idle_in_transaction_count
+            value_type: int
+          - attribute_columns:
+              - db.namespace
+            data_type: gauge
+            metric_name: postgresql.connection.idle_in_transaction.age
+            unit: s
+            value_column: max_idle_tx_age_seconds
+            value_type: int
+        sql: SELECT * FROM otel.pg_idle_in_transaction()
+  sqlquery/pg_replication:
+    collection_interval: 30s
+    datasource:
+      host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+      sslmode=disable
+    driver: postgres
+    queries:
+      - metrics:
+          - attribute_columns:
+              - db.postgresql.replication.slot.name
+              - db.postgresql.replication.slot.type
+              - db.postgresql.replication.slot.active
+            data_type: gauge
+            metric_name: postgresql.replication.slot.lag
+            unit: By
+            value_column: replication_lag_bytes
+            value_type: int
+        sql: SELECT * FROM otel.pg_replication_slots()
+  sqlquery/pg_table_stats:
+    collection_interval: 300s
+    datasource:
+      host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+      sslmode=disable
+    driver: postgres
+    queries:
+      - metrics:
+          - attribute_columns:
+              - db.schema
+              - db.collection.name
+            data_type: gauge
+            metric_name: postgresql.table.vacuum.age
+            unit: s
+            value_column: seconds_since_last_vacuum
+            value_type: int
+          - attribute_columns:
+              - db.schema
+              - db.collection.name
+            data_type: gauge
+            metric_name: postgresql.table.autovacuum.age
+            unit: s
+            value_column: seconds_since_last_autovacuum
+            value_type: int
+          - attribute_columns:
+              - db.schema
+              - db.collection.name
+            data_type: gauge
+            metric_name: postgresql.table.analyze.age
+            unit: s
+            value_column: seconds_since_last_analyze
+            value_type: int
+          - attribute_columns:
+              - db.schema
+              - db.collection.name
+            data_type: gauge
+            metric_name: postgresql.table.autoanalyze.age
+            unit: s
+            value_column: seconds_since_last_autoanalyze
+            value_type: int
+          - attribute_columns:
+              - db.schema
+              - db.collection.name
+            data_type: gauge
+            metric_name: postgresql.table.autovacuum.count
+            unit: "{operation}"
+            value_column: autovacuum_count
+            value_type: int
+          - attribute_columns:
+              - db.schema
+              - db.collection.name
+            data_type: gauge
+            metric_name: postgresql.table.analyze.count
+            unit: "{operation}"
+            value_column: analyze_count
+            value_type: int
+          - attribute_columns:
+              - db.schema
+              - db.collection.name
+            data_type: gauge
+            metric_name: postgresql.table.autoanalyze.count
+            unit: "{operation}"
+            value_column: autoanalyze_count
+            value_type: int
+          - attribute_columns:
+              - db.schema
+              - db.collection.name
+            data_type: gauge
+            metric_name: postgresql.table.rows.modified.since.analyze
+            unit: "{row}"
+            value_column: n_mod_since_analyze
+            value_type: int
+        sql: SELECT * FROM otel.pg_table_stats()
+  sqlquery/pg_vacuum_progress:
+    collection_interval: 60s
+    datasource:
+      host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+      sslmode=disable
+    driver: postgres
+    queries:
+      - metrics:
+          - attribute_columns:
+              - db.schema
+              - db.collection.name
+              - db.postgresql.vacuum.phase
+            data_type: gauge
+            metric_name: postgresql.vacuum.heap_blks_total
+            unit: "{block}"
+            value_column: heap_blks_total
+            value_type: int
+          - attribute_columns:
+              - db.schema
+              - db.collection.name
+              - db.postgresql.vacuum.phase
+            data_type: gauge
+            metric_name: postgresql.vacuum.heap_blks_scanned
+            unit: "{block}"
+            value_column: heap_blks_scanned
+            value_type: int
+          - attribute_columns:
+              - db.schema
+              - db.collection.name
+              - db.postgresql.vacuum.phase
+            data_type: gauge
+            metric_name: postgresql.vacuum.heap_blks_vacuumed
+            unit: "{block}"
+            value_column: heap_blks_vacuumed
+            value_type: int
+          - attribute_columns:
+              - db.schema
+              - db.collection.name
+            data_type: gauge
+            metric_name: postgresql.vacuum.age
+            unit: s
+            value_column: vacuum_age_seconds
+            value_type: int
+        sql: SELECT * FROM otel.pg_vacuum_progress()
+  sqlquery/pg_wal:
+    collection_interval: 60s
+    datasource:
+      host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+      sslmode=disable
+    driver: postgres
+    queries:
+      - metrics:
+          - data_type: gauge
+            metric_name: postgresql.wal.file_count
+            unit: "{file}"
+            value_column: wal_file_count
+            value_type: int
+          - data_type: gauge
+            metric_name: postgresql.wal.bytes
+            unit: By
+            value_column: wal_bytes
+            value_type: int
+        sql: SELECT * FROM otel.pg_wal()
+  sqlquery/postgresql_top_queries:
+    datasource:
+      host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+      sslmode=disable
+    driver: postgres
+    queries:
+      - metrics:
+          - attribute_columns:
+              - db.namespace
+              - db.user.name
+              - server.address
+              - db.version
+              - db.query.text
+            data_type: gauge
+            metric_name: postgresql.query.calls
+            unit: "{query}"
+            value_column: calls
+            value_type: int
+          - attribute_columns:
+              - db.namespace
+              - db.user.name
+              - server.address
+              - db.version
+              - db.query.text
+            data_type: gauge
+            metric_name: postgresql.query.rows
+            unit: "{row}"
+            value_column: rows
+            value_type: int
+          - attribute_columns:
+              - db.namespace
+              - db.user.name
+              - server.address
+              - db.version
+              - db.query.text
+            data_type: gauge
+            metric_name: postgresql.query.exec_time
+            unit: ms
+            value_column: total_exec_time
+            value_type: double
+          - attribute_columns:
+              - db.namespace
+              - db.user.name
+              - server.address
+              - db.version
+              - db.query.text
+            data_type: gauge
+            metric_name: postgresql.query.plan_time
+            unit: ms
+            value_column: total_plan_time
+            value_type: double
+          - attribute_columns:
+              - db.namespace
+              - db.user.name
+              - server.address
+              - db.version
+              - db.query.text
+            data_type: gauge
+            metric_name: postgresql.query.blocks.shared.hit
+            unit: "{block}"
+            value_column: shared_blks_hit
+            value_type: int
+          - attribute_columns:
+              - db.namespace
+              - db.user.name
+              - server.address
+              - db.version
+              - db.query.text
+            data_type: gauge
+            metric_name: postgresql.query.blocks.shared.read
+            unit: "{block}"
+            value_column: shared_blks_read
+            value_type: int
+          - attribute_columns:
+              - db.namespace
+              - db.user.name
+              - server.address
+              - db.version
+              - db.query.text
+            data_type: gauge
+            metric_name: postgresql.query.blocks.shared.dirtied
+            unit: "{block}"
+            value_column: shared_blks_dirtied
+            value_type: int
+          - attribute_columns:
+              - db.namespace
+              - db.user.name
+              - server.address
+              - db.version
+              - db.query.text
+            data_type: gauge
+            metric_name: postgresql.query.blocks.shared.written
+            unit: "{block}"
+            value_column: shared_blks_written
+            value_type: int
+          - attribute_columns:
+              - db.namespace
+              - db.user.name
+              - server.address
+              - db.version
+              - db.query.text
+            data_type: gauge
+            metric_name: postgresql.query.blocks.temp.read
+            unit: "{block}"
+            value_column: temp_blks_read
+            value_type: int
+          - attribute_columns:
+              - db.namespace
+              - db.user.name
+              - server.address
+              - db.version
+              - db.query.text
+            data_type: gauge
+            metric_name: postgresql.query.blocks.temp.written
+            unit: "{block}"
+            value_column: temp_blks_written
+            value_type: int
+        sql: SELECT * FROM otel.pg_top_queries()
+processors:
+  batch:
+    send_batch_max_size: 5000
+    send_batch_size: 5000
+exporters:
+  otlp:
+    compression: gzip
+    endpoint: ${env:K8S_NODE_IP}:4317
+    tls:
+      insecure: true
+service:
+  pipelines:
+    metrics:
+      exporters:
+        - otlp
+      processors:
+        - batch
+      receivers:
+        - postgresql
+        - sqlquery/postgresql_top_queries
+        - sqlquery/pg_table_stats
+        - sqlquery/pg_bloat
+        - sqlquery/pg_connections
+        - sqlquery/pg_locks
+        - sqlquery/pg_replication
+        - sqlquery/pg_wal
+        - sqlquery/pg_vacuum_progress

--- a/charts/opentelemetry-database-monitoring/assets/pg-monitoring-setup.sql
+++ b/charts/opentelemetry-database-monitoring/assets/pg-monitoring-setup.sql
@@ -1,0 +1,311 @@
+-- PostgreSQL monitoring setup for OpenTelemetry
+-- Run this as a superuser (or a role with CREATEROLE and CREATEDB).
+-- Safe to re-run (all statements are idempotent).
+
+-- ---------------------------------------------------------------------------
+-- 1. Monitoring user
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'otel_monitor') THEN
+    CREATE USER otel_monitor WITH PASSWORD 'your-password';
+    END IF;
+END;
+$$;
+
+GRANT pg_monitor TO otel_monitor;
+GRANT SELECT ON pg_stat_database TO otel_monitor;
+
+-- ---------------------------------------------------------------------------
+-- 2. Extension
+-- ---------------------------------------------------------------------------
+
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+
+-- ---------------------------------------------------------------------------
+-- 3. Schema
+-- ---------------------------------------------------------------------------
+
+CREATE SCHEMA IF NOT EXISTS otel;
+GRANT USAGE ON SCHEMA otel TO otel_monitor;
+
+-- ---------------------------------------------------------------------------
+-- 4. Monitoring functions
+--
+-- Attribute columns use OTel semconv names where defined:
+--   db.namespace           → database name  (stable semconv)
+--   db.collection.name     → table name     (stable semconv)
+--   db.schema              → schema name    (experimental; no stable equivalent yet)
+--   db.client.connection.state → connection state (development semconv)
+-- PostgreSQL-specific attributes use the db.postgresql.* prefix.
+-- ---------------------------------------------------------------------------
+
+-- Vacuum/analyze ages, autovacuum counts, and scan row counts.
+-- The built-in postgresql receiver already covers live/dead tuples,
+-- row operations, manual vacuum count, and sequential/index scan counts.
+CREATE OR REPLACE FUNCTION otel.pg_table_stats()
+RETURNS TABLE(
+    "db.schema"                     text,
+    "db.collection.name"            text,
+    seq_tup_read                    bigint,
+    idx_tup_fetch                   bigint,
+    n_mod_since_analyze             bigint,
+    seconds_since_last_vacuum       bigint,
+    seconds_since_last_autovacuum   bigint,
+    seconds_since_last_analyze      bigint,
+    seconds_since_last_autoanalyze  bigint,
+    autovacuum_count                bigint,
+    analyze_count                   bigint,
+    autoanalyze_count               bigint
+) LANGUAGE sql STABLE AS $$
+    SELECT
+    schemaname::text                                                       AS "db.schema",
+    relname::text                                                          AS "db.collection.name",
+    seq_tup_read,
+    idx_tup_fetch,
+    n_mod_since_analyze,
+    COALESCE(EXTRACT(EPOCH FROM (now() - last_vacuum))::bigint,      -1),
+    COALESCE(EXTRACT(EPOCH FROM (now() - last_autovacuum))::bigint,  -1),
+    COALESCE(EXTRACT(EPOCH FROM (now() - last_analyze))::bigint,     -1),
+    COALESCE(EXTRACT(EPOCH FROM (now() - last_autoanalyze))::bigint, -1),
+    autovacuum_count::bigint,
+    analyze_count::bigint,
+    autoanalyze_count::bigint
+    FROM pg_stat_user_tables
+    ORDER BY n_mod_since_analyze DESC NULLS LAST
+    LIMIT 50;
+$$;
+
+-- Table bloat estimation (standard check_postgres algorithm).
+CREATE OR REPLACE FUNCTION otel.pg_bloat()
+RETURNS TABLE(
+    "db.schema"          text,
+    "db.collection.name" text,
+    tbloat               numeric,
+    wastedbytes          bigint
+) LANGUAGE sql STABLE AS $$
+    SELECT
+    schemaname::text  AS "db.schema",
+    tablename::text   AS "db.collection.name",
+    ROUND((CASE WHEN otta = 0 THEN 0.0 ELSE sml.relpages::float / otta END)::numeric, 1) AS tbloat,
+    CASE WHEN relpages < otta THEN 0 ELSE (bs * (sml.relpages - otta)::bigint) END        AS wastedbytes
+    FROM (
+    SELECT
+        schemaname, tablename, bs,
+        CEIL((cc.reltuples * ((datahdr + ma -
+        (CASE WHEN datahdr % ma = 0 THEN ma ELSE datahdr % ma END)) + nullhdr2 + 4)) / (bs - 20::float)) AS otta,
+        cc.relpages
+    FROM (
+        SELECT
+        ma, bs, schemaname, tablename,
+        (datawidth + (hdr + ma - (CASE WHEN hdr % ma = 0 THEN ma ELSE hdr % ma END)))::numeric AS datahdr,
+        (maxfracsum * (nullhdr + ma - (CASE WHEN nullhdr % ma = 0 THEN ma ELSE nullhdr % ma END)))        AS nullhdr2
+        FROM (
+        SELECT
+            schemaname, tablename, hdr, ma, bs,
+            SUM((1 - null_frac) * avg_width) AS datawidth,
+            MAX(null_frac)                   AS maxfracsum,
+            hdr + (
+            SELECT 1 + COUNT(*) / 8
+            FROM pg_stats s2
+            WHERE null_frac <> 0
+                AND s2.schemaname = s.schemaname
+                AND s2.tablename  = s.tablename
+            ) AS nullhdr
+        FROM pg_stats s, (
+            SELECT
+            current_setting('block_size')::numeric                                AS bs,
+            CASE WHEN substring(v, 12, 3) IN ('8.0','8.1','8.2') THEN 27 ELSE 23 END AS hdr,
+            CASE WHEN v ~ 'mingw32' THEN 8 ELSE 4 END                            AS ma
+            FROM (SELECT version() AS v) AS foo
+        ) AS constants
+        GROUP BY 1, 2, 3, 4, 5
+        ) AS foo
+    ) AS rs
+    JOIN pg_class cc     ON cc.relname      = tablename
+    JOIN pg_namespace nn ON cc.relnamespace = nn.oid
+                        AND nn.nspname      = schemaname
+                        AND nn.nspname     <> 'information_schema'
+    ) AS sml
+    WHERE schemaname NOT IN ('pg_catalog', 'information_schema')
+    ORDER BY wastedbytes DESC NULLS LAST
+    LIMIT 20;
+$$;
+
+-- Per-state, per-database connection breakdown.
+-- Total and max are covered by postgresql.backends and postgresql.connection.max.
+-- Note: db.client.connection.state values in pg_stat_activity ('active', 'idle',
+-- 'idle in transaction', etc.) are more granular than the semconv enum (idle/used).
+CREATE OR REPLACE FUNCTION otel.pg_connections()
+RETURNS TABLE(
+    "db.namespace"               text,
+    "db.client.connection.state" text,
+    connection_count             bigint,
+    max_state_age_seconds        bigint
+) LANGUAGE sql STABLE AS $$
+    SELECT
+    datname::text AS "db.namespace",
+    state::text   AS "db.client.connection.state",
+    COUNT(*)::bigint,
+    MAX(EXTRACT(EPOCH FROM (now() - state_change)))::bigint
+    FROM pg_stat_activity
+    WHERE pid <> pg_backend_pid()
+      AND datname IS NOT NULL
+      AND state IS NOT NULL
+    GROUP BY datname, state;
+$$;
+
+-- Lock counts by type/mode/granted.
+-- postgresql.database.locks (opt-in) covers lock counts by relation/mode;
+-- this adds the granted status breakdown.
+CREATE OR REPLACE FUNCTION otel.pg_lock_counts()
+RETURNS TABLE(
+  "db.postgresql.lock.type"    text,
+  "db.postgresql.lock.mode"    text,
+  "db.postgresql.lock.granted" text,
+  lock_count                   bigint
+) LANGUAGE sql STABLE AS $$
+  SELECT
+    l.locktype::text AS "db.postgresql.lock.type",
+    l.mode::text     AS "db.postgresql.lock.mode",
+    l.granted::text  AS "db.postgresql.lock.granted",
+    COUNT(*)::bigint AS lock_count
+  FROM pg_locks l
+  GROUP BY l.locktype, l.mode, l.granted;
+$$;
+
+-- Number of queries currently waiting on a lock.
+CREATE OR REPLACE FUNCTION otel.pg_blocking_queries()
+RETURNS TABLE(
+  blocking_count bigint
+) LANGUAGE sql STABLE AS $$
+  SELECT COUNT(*)::bigint
+  FROM pg_stat_activity
+  WHERE wait_event_type = 'Lock';
+$$;
+
+-- Idle-in-transaction connections per database with max age.
+CREATE OR REPLACE FUNCTION otel.pg_idle_in_transaction()
+RETURNS TABLE(
+  "db.namespace"             text,
+  idle_in_transaction_count  bigint,
+  max_idle_tx_age_seconds    bigint
+) LANGUAGE sql STABLE AS $$
+  SELECT
+    datname::text                                             AS "db.namespace",
+    COUNT(*)::bigint,
+    MAX(EXTRACT(EPOCH FROM (now() - xact_start)))::bigint
+  FROM pg_stat_activity
+  WHERE state = 'idle in transaction'
+  GROUP BY datname;
+$$;
+
+-- Replication slot lag.
+-- Per-replica write/flush/replay lag is covered by postgresql.wal.lag
+-- and postgresql.replication.data_delay.
+CREATE OR REPLACE FUNCTION otel.pg_replication_slots()
+RETURNS TABLE(
+    "db.postgresql.replication.slot.name"   text,
+    "db.postgresql.replication.slot.type"   text,
+    "db.postgresql.replication.slot.active" text,
+    replication_lag_bytes                   bigint
+) LANGUAGE sql STABLE AS $$
+    SELECT
+    slot_name::text  AS "db.postgresql.replication.slot.name",
+    slot_type::text  AS "db.postgresql.replication.slot.type",
+    active::text     AS "db.postgresql.replication.slot.active",
+    pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)::bigint
+    FROM pg_replication_slots;
+$$;
+
+-- WAL segment file count and total directory size.
+-- Distinct from postgresql.wal.age (archiver) and postgresql.wal.lag (replication).
+CREATE OR REPLACE FUNCTION otel.pg_wal()
+RETURNS TABLE(
+    wal_file_count bigint,
+    wal_bytes      bigint
+) LANGUAGE sql STABLE AS $$
+    SELECT
+    COUNT(*)::bigint  AS wal_file_count,
+    SUM(size)::bigint AS wal_bytes
+    FROM pg_ls_waldir()
+    WHERE name ~ '^[0-9A-F]{24}$';
+$$;
+
+-- Running vacuum operations (PG 10+). Returns no rows when no vacuum is active.
+CREATE OR REPLACE FUNCTION otel.pg_vacuum_progress()
+RETURNS TABLE(
+    "db.schema"                text,
+    "db.collection.name"       text,
+    "db.postgresql.vacuum.phase" text,
+    heap_blks_total            bigint,
+    heap_blks_scanned          bigint,
+    heap_blks_vacuumed         bigint,
+    vacuum_age_seconds         bigint
+) LANGUAGE sql STABLE AS $$
+    SELECT
+    n.nspname::text                                            AS "db.schema",
+    c.relname::text                                            AS "db.collection.name",
+    p.phase::text                                              AS "db.postgresql.vacuum.phase",
+    p.heap_blks_total,
+    p.heap_blks_scanned,
+    p.heap_blks_vacuumed,
+    EXTRACT(EPOCH FROM (now() - a.xact_start))::bigint
+    FROM pg_stat_progress_vacuum p
+    JOIN pg_stat_activity a ON a.pid    = p.pid
+    JOIN pg_class         c ON c.oid    = p.relid
+    JOIN pg_namespace     n ON n.oid    = c.relnamespace;
+$$;
+
+-- Top queries by call count from pg_stat_statements.
+-- Requires pg_stat_statements extension (loaded in step 2).
+CREATE OR REPLACE FUNCTION otel.pg_top_queries()
+RETURNS TABLE(
+    "db.namespace"          text,
+    "db.user.name"          text,
+    "server.address"        text,
+    "db.version"            text,
+    "db.query.text"         text,
+    calls                   bigint,
+    rows                    bigint,
+    total_exec_time         double precision,
+    total_plan_time         double precision,
+    shared_blks_hit         bigint,
+    shared_blks_read        bigint,
+    shared_blks_dirtied     bigint,
+    shared_blks_written     bigint,
+    temp_blks_read          bigint,
+    temp_blks_written       bigint
+) LANGUAGE sql STABLE AS $$
+    SELECT
+    d.datname::text                   AS "db.namespace",
+    COALESCE(r.rolname::text, '')     AS "db.user.name",
+    'postgresql'::text                AS "server.address",
+    current_setting('server_version') AS "db.version",
+    LEFT(s.query, 200)::text          AS "db.query.text",
+    s.calls,
+    s.rows,
+    s.total_exec_time,
+    s.total_plan_time,
+    s.shared_blks_hit,
+    s.shared_blks_read,
+    s.shared_blks_dirtied,
+    s.shared_blks_written,
+    s.temp_blks_read,
+    s.temp_blks_written
+    FROM pg_stat_statements s
+    LEFT JOIN pg_roles    r ON r.oid = s.userid
+    LEFT JOIN pg_database d ON d.oid = s.dbid
+    WHERE d.datname IS NOT NULL
+    AND s.query != '<insufficient privilege>'
+    AND s.query NOT LIKE '/* otel-collector-ignore */%'
+    ORDER BY s.calls DESC
+    LIMIT 20;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 5. Grants
+-- ---------------------------------------------------------------------------
+
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA otel TO otel_monitor;

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/configmap-pg-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/configmap-pg-monitoring.yaml
@@ -1,0 +1,320 @@
+---
+# Source: opentelemetry-database-monitoring/templates/configmap-pg-monitoring.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgresql-monitoring-setup
+data:
+  monitoring-setup.sql: |
+    -- PostgreSQL monitoring setup for OpenTelemetry
+    -- Run this as a superuser (or a role with CREATEROLE and CREATEDB).
+    -- Safe to re-run (all statements are idempotent).
+    
+    -- ---------------------------------------------------------------------------
+    -- 1. Monitoring user
+    -- ---------------------------------------------------------------------------
+    
+    DO $$
+    BEGIN
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'otel_monitor') THEN
+        CREATE USER otel_monitor WITH PASSWORD 'your-password';
+        END IF;
+    END;
+    $$;
+    
+    GRANT pg_monitor TO otel_monitor;
+    GRANT SELECT ON pg_stat_database TO otel_monitor;
+    
+    -- ---------------------------------------------------------------------------
+    -- 2. Extension
+    -- ---------------------------------------------------------------------------
+    
+    CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+    
+    -- ---------------------------------------------------------------------------
+    -- 3. Schema
+    -- ---------------------------------------------------------------------------
+    
+    CREATE SCHEMA IF NOT EXISTS otel;
+    GRANT USAGE ON SCHEMA otel TO otel_monitor;
+    
+    -- ---------------------------------------------------------------------------
+    -- 4. Monitoring functions
+    --
+    -- Attribute columns use OTel semconv names where defined:
+    --   db.namespace           → database name  (stable semconv)
+    --   db.collection.name     → table name     (stable semconv)
+    --   db.schema              → schema name    (experimental; no stable equivalent yet)
+    --   db.client.connection.state → connection state (development semconv)
+    -- PostgreSQL-specific attributes use the db.postgresql.* prefix.
+    -- ---------------------------------------------------------------------------
+    
+    -- Vacuum/analyze ages, autovacuum counts, and scan row counts.
+    -- The built-in postgresql receiver already covers live/dead tuples,
+    -- row operations, manual vacuum count, and sequential/index scan counts.
+    CREATE OR REPLACE FUNCTION otel.pg_table_stats()
+    RETURNS TABLE(
+        "db.schema"                     text,
+        "db.collection.name"            text,
+        seq_tup_read                    bigint,
+        idx_tup_fetch                   bigint,
+        n_mod_since_analyze             bigint,
+        seconds_since_last_vacuum       bigint,
+        seconds_since_last_autovacuum   bigint,
+        seconds_since_last_analyze      bigint,
+        seconds_since_last_autoanalyze  bigint,
+        autovacuum_count                bigint,
+        analyze_count                   bigint,
+        autoanalyze_count               bigint
+    ) LANGUAGE sql STABLE AS $$
+        SELECT
+        schemaname::text                                                       AS "db.schema",
+        relname::text                                                          AS "db.collection.name",
+        seq_tup_read,
+        idx_tup_fetch,
+        n_mod_since_analyze,
+        COALESCE(EXTRACT(EPOCH FROM (now() - last_vacuum))::bigint,      -1),
+        COALESCE(EXTRACT(EPOCH FROM (now() - last_autovacuum))::bigint,  -1),
+        COALESCE(EXTRACT(EPOCH FROM (now() - last_analyze))::bigint,     -1),
+        COALESCE(EXTRACT(EPOCH FROM (now() - last_autoanalyze))::bigint, -1),
+        autovacuum_count::bigint,
+        analyze_count::bigint,
+        autoanalyze_count::bigint
+        FROM pg_stat_user_tables
+        ORDER BY n_mod_since_analyze DESC NULLS LAST
+        LIMIT 50;
+    $$;
+    
+    -- Table bloat estimation (standard check_postgres algorithm).
+    CREATE OR REPLACE FUNCTION otel.pg_bloat()
+    RETURNS TABLE(
+        "db.schema"          text,
+        "db.collection.name" text,
+        tbloat               numeric,
+        wastedbytes          bigint
+    ) LANGUAGE sql STABLE AS $$
+        SELECT
+        schemaname::text  AS "db.schema",
+        tablename::text   AS "db.collection.name",
+        ROUND((CASE WHEN otta = 0 THEN 0.0 ELSE sml.relpages::float / otta END)::numeric, 1) AS tbloat,
+        CASE WHEN relpages < otta THEN 0 ELSE (bs * (sml.relpages - otta)::bigint) END        AS wastedbytes
+        FROM (
+        SELECT
+            schemaname, tablename, bs,
+            CEIL((cc.reltuples * ((datahdr + ma -
+            (CASE WHEN datahdr % ma = 0 THEN ma ELSE datahdr % ma END)) + nullhdr2 + 4)) / (bs - 20::float)) AS otta,
+            cc.relpages
+        FROM (
+            SELECT
+            ma, bs, schemaname, tablename,
+            (datawidth + (hdr + ma - (CASE WHEN hdr % ma = 0 THEN ma ELSE hdr % ma END)))::numeric AS datahdr,
+            (maxfracsum * (nullhdr + ma - (CASE WHEN nullhdr % ma = 0 THEN ma ELSE nullhdr % ma END)))        AS nullhdr2
+            FROM (
+            SELECT
+                schemaname, tablename, hdr, ma, bs,
+                SUM((1 - null_frac) * avg_width) AS datawidth,
+                MAX(null_frac)                   AS maxfracsum,
+                hdr + (
+                SELECT 1 + COUNT(*) / 8
+                FROM pg_stats s2
+                WHERE null_frac <> 0
+                    AND s2.schemaname = s.schemaname
+                    AND s2.tablename  = s.tablename
+                ) AS nullhdr
+            FROM pg_stats s, (
+                SELECT
+                current_setting('block_size')::numeric                                AS bs,
+                CASE WHEN substring(v, 12, 3) IN ('8.0','8.1','8.2') THEN 27 ELSE 23 END AS hdr,
+                CASE WHEN v ~ 'mingw32' THEN 8 ELSE 4 END                            AS ma
+                FROM (SELECT version() AS v) AS foo
+            ) AS constants
+            GROUP BY 1, 2, 3, 4, 5
+            ) AS foo
+        ) AS rs
+        JOIN pg_class cc     ON cc.relname      = tablename
+        JOIN pg_namespace nn ON cc.relnamespace = nn.oid
+                            AND nn.nspname      = schemaname
+                            AND nn.nspname     <> 'information_schema'
+        ) AS sml
+        WHERE schemaname NOT IN ('pg_catalog', 'information_schema')
+        ORDER BY wastedbytes DESC NULLS LAST
+        LIMIT 20;
+    $$;
+    
+    -- Per-state, per-database connection breakdown.
+    -- Total and max are covered by postgresql.backends and postgresql.connection.max.
+    -- Note: db.client.connection.state values in pg_stat_activity ('active', 'idle',
+    -- 'idle in transaction', etc.) are more granular than the semconv enum (idle/used).
+    CREATE OR REPLACE FUNCTION otel.pg_connections()
+    RETURNS TABLE(
+        "db.namespace"               text,
+        "db.client.connection.state" text,
+        connection_count             bigint,
+        max_state_age_seconds        bigint
+    ) LANGUAGE sql STABLE AS $$
+        SELECT
+        datname::text AS "db.namespace",
+        state::text   AS "db.client.connection.state",
+        COUNT(*)::bigint,
+        MAX(EXTRACT(EPOCH FROM (now() - state_change)))::bigint
+        FROM pg_stat_activity
+        WHERE pid <> pg_backend_pid()
+          AND datname IS NOT NULL
+          AND state IS NOT NULL
+        GROUP BY datname, state;
+    $$;
+    
+    -- Lock counts by type/mode/granted.
+    -- postgresql.database.locks (opt-in) covers lock counts by relation/mode;
+    -- this adds the granted status breakdown.
+    CREATE OR REPLACE FUNCTION otel.pg_lock_counts()
+    RETURNS TABLE(
+      "db.postgresql.lock.type"    text,
+      "db.postgresql.lock.mode"    text,
+      "db.postgresql.lock.granted" text,
+      lock_count                   bigint
+    ) LANGUAGE sql STABLE AS $$
+      SELECT
+        l.locktype::text AS "db.postgresql.lock.type",
+        l.mode::text     AS "db.postgresql.lock.mode",
+        l.granted::text  AS "db.postgresql.lock.granted",
+        COUNT(*)::bigint AS lock_count
+      FROM pg_locks l
+      GROUP BY l.locktype, l.mode, l.granted;
+    $$;
+    
+    -- Number of queries currently waiting on a lock.
+    CREATE OR REPLACE FUNCTION otel.pg_blocking_queries()
+    RETURNS TABLE(
+      blocking_count bigint
+    ) LANGUAGE sql STABLE AS $$
+      SELECT COUNT(*)::bigint
+      FROM pg_stat_activity
+      WHERE wait_event_type = 'Lock';
+    $$;
+    
+    -- Idle-in-transaction connections per database with max age.
+    CREATE OR REPLACE FUNCTION otel.pg_idle_in_transaction()
+    RETURNS TABLE(
+      "db.namespace"             text,
+      idle_in_transaction_count  bigint,
+      max_idle_tx_age_seconds    bigint
+    ) LANGUAGE sql STABLE AS $$
+      SELECT
+        datname::text                                             AS "db.namespace",
+        COUNT(*)::bigint,
+        MAX(EXTRACT(EPOCH FROM (now() - xact_start)))::bigint
+      FROM pg_stat_activity
+      WHERE state = 'idle in transaction'
+      GROUP BY datname;
+    $$;
+    
+    -- Replication slot lag.
+    -- Per-replica write/flush/replay lag is covered by postgresql.wal.lag
+    -- and postgresql.replication.data_delay.
+    CREATE OR REPLACE FUNCTION otel.pg_replication_slots()
+    RETURNS TABLE(
+        "db.postgresql.replication.slot.name"   text,
+        "db.postgresql.replication.slot.type"   text,
+        "db.postgresql.replication.slot.active" text,
+        replication_lag_bytes                   bigint
+    ) LANGUAGE sql STABLE AS $$
+        SELECT
+        slot_name::text  AS "db.postgresql.replication.slot.name",
+        slot_type::text  AS "db.postgresql.replication.slot.type",
+        active::text     AS "db.postgresql.replication.slot.active",
+        pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)::bigint
+        FROM pg_replication_slots;
+    $$;
+    
+    -- WAL segment file count and total directory size.
+    -- Distinct from postgresql.wal.age (archiver) and postgresql.wal.lag (replication).
+    CREATE OR REPLACE FUNCTION otel.pg_wal()
+    RETURNS TABLE(
+        wal_file_count bigint,
+        wal_bytes      bigint
+    ) LANGUAGE sql STABLE AS $$
+        SELECT
+        COUNT(*)::bigint  AS wal_file_count,
+        SUM(size)::bigint AS wal_bytes
+        FROM pg_ls_waldir()
+        WHERE name ~ '^[0-9A-F]{24}$';
+    $$;
+    
+    -- Running vacuum operations (PG 10+). Returns no rows when no vacuum is active.
+    CREATE OR REPLACE FUNCTION otel.pg_vacuum_progress()
+    RETURNS TABLE(
+        "db.schema"                text,
+        "db.collection.name"       text,
+        "db.postgresql.vacuum.phase" text,
+        heap_blks_total            bigint,
+        heap_blks_scanned          bigint,
+        heap_blks_vacuumed         bigint,
+        vacuum_age_seconds         bigint
+    ) LANGUAGE sql STABLE AS $$
+        SELECT
+        n.nspname::text                                            AS "db.schema",
+        c.relname::text                                            AS "db.collection.name",
+        p.phase::text                                              AS "db.postgresql.vacuum.phase",
+        p.heap_blks_total,
+        p.heap_blks_scanned,
+        p.heap_blks_vacuumed,
+        EXTRACT(EPOCH FROM (now() - a.xact_start))::bigint
+        FROM pg_stat_progress_vacuum p
+        JOIN pg_stat_activity a ON a.pid    = p.pid
+        JOIN pg_class         c ON c.oid    = p.relid
+        JOIN pg_namespace     n ON n.oid    = c.relnamespace;
+    $$;
+    
+    -- Top queries by call count from pg_stat_statements.
+    -- Requires pg_stat_statements extension (loaded in step 2).
+    CREATE OR REPLACE FUNCTION otel.pg_top_queries()
+    RETURNS TABLE(
+        "db.namespace"          text,
+        "db.user.name"          text,
+        "server.address"        text,
+        "db.version"            text,
+        "db.query.text"         text,
+        calls                   bigint,
+        rows                    bigint,
+        total_exec_time         double precision,
+        total_plan_time         double precision,
+        shared_blks_hit         bigint,
+        shared_blks_read        bigint,
+        shared_blks_dirtied     bigint,
+        shared_blks_written     bigint,
+        temp_blks_read          bigint,
+        temp_blks_written       bigint
+    ) LANGUAGE sql STABLE AS $$
+        SELECT
+        d.datname::text                   AS "db.namespace",
+        COALESCE(r.rolname::text, '')     AS "db.user.name",
+        'postgresql'::text                AS "server.address",
+        current_setting('server_version') AS "db.version",
+        LEFT(s.query, 200)::text          AS "db.query.text",
+        s.calls,
+        s.rows,
+        s.total_exec_time,
+        s.total_plan_time,
+        s.shared_blks_hit,
+        s.shared_blks_read,
+        s.shared_blks_dirtied,
+        s.shared_blks_written,
+        s.temp_blks_read,
+        s.temp_blks_written
+        FROM pg_stat_statements s
+        LEFT JOIN pg_roles    r ON r.oid = s.userid
+        LEFT JOIN pg_database d ON d.oid = s.dbid
+        WHERE d.datname IS NOT NULL
+        AND s.query != '<insufficient privilege>'
+        AND s.query NOT LIKE '/* otel-collector-ignore */%'
+        ORDER BY s.calls DESC
+        LIMIT 20;
+    $$;
+    
+    -- ---------------------------------------------------------------------------
+    -- 5. Grants
+    -- ---------------------------------------------------------------------------
+    
+    GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA otel TO otel_monitor;
+    

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/job-pg-monitoring-setup.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/job-pg-monitoring-setup.yaml
@@ -1,0 +1,76 @@
+---
+# Source: opentelemetry-database-monitoring/templates/job-pg-monitoring-setup.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: postgresql-postgresql-monitoring-setup
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: setup
+          image: postgres:17
+          command:
+            - /bin/sh
+            - -c
+            - |
+              until pg_isready -h postgresql -p 5432 -U root; do sleep 2; done
+              PGPASSWORD=otel psql -h postgresql -p 5432 -U root -d otel -f /scripts/monitoring-setup.sql
+              PGPASSWORD=otel psql -h postgresql -p 5432 -U root -d otel -c "ALTER USER otel_monitor WITH PASSWORD '$OTEL_MONITOR_PASSWORD'"
+          env:
+            - name: OTEL_MONITOR_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-pg-monitor-credentials
+                  key: password
+          volumeMounts:
+            - name: monitoring-setup
+              mountPath: /scripts
+      volumes:
+        - name: monitoring-setup
+          configMap:
+            name: postgresql-monitoring-setup
+---
+# Source: opentelemetry-database-monitoring/templates/job-pg-monitoring-setup.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: postgresql2-postgresql-monitoring-setup
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: setup
+          image: postgres:17
+          command:
+            - /bin/sh
+            - -c
+            - |
+              until pg_isready -h postgresql2 -p 5432 -U root; do sleep 2; done
+              PGPASSWORD=otel psql -h postgresql2 -p 5432 -U root -d otel -f /scripts/monitoring-setup.sql
+              PGPASSWORD=otel psql -h postgresql2 -p 5432 -U root -d otel -c "ALTER USER otel_monitor WITH PASSWORD '$OTEL_MONITOR_PASSWORD'"
+          env:
+            - name: OTEL_MONITOR_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql2-pg-monitor-credentials
+                  key: password
+          volumeMounts:
+            - name: monitoring-setup
+              mountPath: /scripts
+      volumes:
+        - name: monitoring-setup
+          configMap:
+            name: postgresql-monitoring-setup

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/postgres-dbm-sidecar.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/postgres-dbm-sidecar.yaml
@@ -1,0 +1,923 @@
+---
+# Source: opentelemetry-database-monitoring/templates/postgres-dbm-sidecar.yaml
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: postgres-dbm-sidecar
+  annotations:
+    meta.helm.sh/release-name: "example"
+    meta.helm.sh/release-namespace: "default"
+spec:
+  mode: sidecar
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+  env:
+    - name: K8S_NODE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: OTEL_MONITOR_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: postgresql-pg-monitor-credentials
+          key: password
+  config:
+    receivers:
+      postgresql:
+        endpoint: ${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME}:5432
+        metrics:
+          postgresql.bgwriter.buffers.allocated:
+            enabled: true
+          postgresql.bgwriter.buffers.writes:
+            enabled: true
+          postgresql.bgwriter.checkpoint.count:
+            enabled: true
+          postgresql.bgwriter.duration:
+            enabled: true
+          postgresql.bgwriter.maxwritten:
+            enabled: true
+          postgresql.blks_hit:
+            enabled: true
+          postgresql.blks_read:
+            enabled: true
+          postgresql.connection.max:
+            enabled: true
+          postgresql.database.locks:
+            enabled: true
+          postgresql.deadlocks:
+            enabled: true
+          postgresql.replication.data_delay:
+            enabled: true
+          postgresql.sequential_scans:
+            enabled: true
+          postgresql.temp_files:
+            enabled: true
+          postgresql.tup_deleted:
+            enabled: true
+          postgresql.tup_fetched:
+            enabled: true
+          postgresql.tup_inserted:
+            enabled: true
+          postgresql.tup_returned:
+            enabled: true
+          postgresql.tup_updated:
+            enabled: true
+          postgresql.wal.age:
+            enabled: true
+          postgresql.wal.lag:
+            enabled: true
+        password: ${env:OTEL_MONITOR_PASSWORD}
+        tls:
+          insecure: true
+        username: otel_monitor
+      sqlquery/pg_bloat:
+        collection_interval: 3600s
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.bloat.ratio
+                unit: "1"
+                value_column: tbloat
+                value_type: double
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.bloat.bytes
+                unit: By
+                value_column: wastedbytes
+                value_type: int
+            sql: SELECT * FROM otel.pg_bloat()
+      sqlquery/pg_connections:
+        collection_interval: 30s
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - attribute_columns:
+                  - db.namespace
+                  - db.client.connection.state
+                data_type: gauge
+                metric_name: postgresql.backends
+                unit: "{connection}"
+                value_column: connection_count
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.client.connection.state
+                data_type: gauge
+                metric_name: postgresql.backends.age
+                unit: s
+                value_column: max_state_age_seconds
+                value_type: int
+            sql: SELECT * FROM otel.pg_connections()
+      sqlquery/pg_locks:
+        collection_interval: 30s
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - attribute_columns:
+                  - db.postgresql.lock.type
+                  - db.postgresql.lock.mode
+                  - db.postgresql.lock.granted
+                data_type: gauge
+                metric_name: postgresql.lock.count
+                unit: "{lock}"
+                value_column: lock_count
+                value_type: int
+            sql: SELECT * FROM otel.pg_lock_counts()
+          - metrics:
+              - data_type: gauge
+                metric_name: postgresql.lock.blocking_queries
+                unit: "{query}"
+                value_column: blocking_count
+                value_type: int
+            sql: SELECT * FROM otel.pg_blocking_queries()
+          - metrics:
+              - attribute_columns:
+                  - db.namespace
+                data_type: gauge
+                metric_name: postgresql.connection.idle_in_transaction
+                unit: "{connection}"
+                value_column: idle_in_transaction_count
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                data_type: gauge
+                metric_name: postgresql.connection.idle_in_transaction.age
+                unit: s
+                value_column: max_idle_tx_age_seconds
+                value_type: int
+            sql: SELECT * FROM otel.pg_idle_in_transaction()
+      sqlquery/pg_replication:
+        collection_interval: 30s
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - attribute_columns:
+                  - db.postgresql.replication.slot.name
+                  - db.postgresql.replication.slot.type
+                  - db.postgresql.replication.slot.active
+                data_type: gauge
+                metric_name: postgresql.replication.slot.lag
+                unit: By
+                value_column: replication_lag_bytes
+                value_type: int
+            sql: SELECT * FROM otel.pg_replication_slots()
+      sqlquery/pg_table_stats:
+        collection_interval: 300s
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.vacuum.age
+                unit: s
+                value_column: seconds_since_last_vacuum
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.autovacuum.age
+                unit: s
+                value_column: seconds_since_last_autovacuum
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.analyze.age
+                unit: s
+                value_column: seconds_since_last_analyze
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.autoanalyze.age
+                unit: s
+                value_column: seconds_since_last_autoanalyze
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.autovacuum.count
+                unit: "{operation}"
+                value_column: autovacuum_count
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.analyze.count
+                unit: "{operation}"
+                value_column: analyze_count
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.autoanalyze.count
+                unit: "{operation}"
+                value_column: autoanalyze_count
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.rows.modified.since.analyze
+                unit: "{row}"
+                value_column: n_mod_since_analyze
+                value_type: int
+            sql: SELECT * FROM otel.pg_table_stats()
+      sqlquery/pg_vacuum_progress:
+        collection_interval: 60s
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                  - db.postgresql.vacuum.phase
+                data_type: gauge
+                metric_name: postgresql.vacuum.heap_blks_total
+                unit: "{block}"
+                value_column: heap_blks_total
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                  - db.postgresql.vacuum.phase
+                data_type: gauge
+                metric_name: postgresql.vacuum.heap_blks_scanned
+                unit: "{block}"
+                value_column: heap_blks_scanned
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                  - db.postgresql.vacuum.phase
+                data_type: gauge
+                metric_name: postgresql.vacuum.heap_blks_vacuumed
+                unit: "{block}"
+                value_column: heap_blks_vacuumed
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.vacuum.age
+                unit: s
+                value_column: vacuum_age_seconds
+                value_type: int
+            sql: SELECT * FROM otel.pg_vacuum_progress()
+      sqlquery/pg_wal:
+        collection_interval: 60s
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - data_type: gauge
+                metric_name: postgresql.wal.file_count
+                unit: "{file}"
+                value_column: wal_file_count
+                value_type: int
+              - data_type: gauge
+                metric_name: postgresql.wal.bytes
+                unit: By
+                value_column: wal_bytes
+                value_type: int
+            sql: SELECT * FROM otel.pg_wal()
+      sqlquery/postgresql_top_queries:
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.calls
+                unit: "{query}"
+                value_column: calls
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.rows
+                unit: "{row}"
+                value_column: rows
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.exec_time
+                unit: ms
+                value_column: total_exec_time
+                value_type: double
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.plan_time
+                unit: ms
+                value_column: total_plan_time
+                value_type: double
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.blocks.shared.hit
+                unit: "{block}"
+                value_column: shared_blks_hit
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.blocks.shared.read
+                unit: "{block}"
+                value_column: shared_blks_read
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.blocks.shared.dirtied
+                unit: "{block}"
+                value_column: shared_blks_dirtied
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.blocks.shared.written
+                unit: "{block}"
+                value_column: shared_blks_written
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.blocks.temp.read
+                unit: "{block}"
+                value_column: temp_blks_read
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.blocks.temp.written
+                unit: "{block}"
+                value_column: temp_blks_written
+                value_type: int
+            sql: SELECT * FROM otel.pg_top_queries()
+    processors:
+      batch:
+        send_batch_max_size: 5000
+        send_batch_size: 5000
+    exporters:
+      otlp:
+        compression: gzip
+        endpoint: ${env:K8S_NODE_IP}:4317
+        tls:
+          insecure: true
+    service:
+      pipelines:
+        metrics:
+          exporters:
+            - otlp
+          processors:
+            - batch
+          receivers:
+            - postgresql
+            - sqlquery/postgresql_top_queries
+            - sqlquery/pg_table_stats
+            - sqlquery/pg_bloat
+            - sqlquery/pg_connections
+            - sqlquery/pg_locks
+            - sqlquery/pg_replication
+            - sqlquery/pg_wal
+            - sqlquery/pg_vacuum_progress
+---
+# Source: opentelemetry-database-monitoring/templates/postgres-dbm-sidecar.yaml
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: postgres2-dbm-sidecar
+  annotations:
+    meta.helm.sh/release-name: "example"
+    meta.helm.sh/release-namespace: "default"
+spec:
+  mode: sidecar
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+  env:
+    - name: K8S_NODE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: OTEL_MONITOR_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: postgresql2-pg-monitor-credentials
+          key: password
+  config:
+    receivers:
+      postgresql:
+        endpoint: ${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME}:5432
+        metrics:
+          postgresql.bgwriter.buffers.allocated:
+            enabled: true
+          postgresql.bgwriter.buffers.writes:
+            enabled: true
+          postgresql.bgwriter.checkpoint.count:
+            enabled: true
+          postgresql.bgwriter.duration:
+            enabled: true
+          postgresql.bgwriter.maxwritten:
+            enabled: true
+          postgresql.blks_hit:
+            enabled: true
+          postgresql.blks_read:
+            enabled: true
+          postgresql.connection.max:
+            enabled: true
+          postgresql.database.locks:
+            enabled: true
+          postgresql.deadlocks:
+            enabled: true
+          postgresql.replication.data_delay:
+            enabled: true
+          postgresql.sequential_scans:
+            enabled: true
+          postgresql.temp_files:
+            enabled: true
+          postgresql.tup_deleted:
+            enabled: true
+          postgresql.tup_fetched:
+            enabled: true
+          postgresql.tup_inserted:
+            enabled: true
+          postgresql.tup_returned:
+            enabled: true
+          postgresql.tup_updated:
+            enabled: true
+          postgresql.wal.age:
+            enabled: true
+          postgresql.wal.lag:
+            enabled: true
+        password: ${env:OTEL_MONITOR_PASSWORD}
+        tls:
+          insecure: true
+        username: otel_monitor
+      sqlquery/pg_bloat:
+        collection_interval: 3600s
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.bloat.ratio
+                unit: "1"
+                value_column: tbloat
+                value_type: double
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.bloat.bytes
+                unit: By
+                value_column: wastedbytes
+                value_type: int
+            sql: SELECT * FROM otel.pg_bloat()
+      sqlquery/pg_connections:
+        collection_interval: 30s
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - attribute_columns:
+                  - db.namespace
+                  - db.client.connection.state
+                data_type: gauge
+                metric_name: postgresql.backends
+                unit: "{connection}"
+                value_column: connection_count
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.client.connection.state
+                data_type: gauge
+                metric_name: postgresql.backends.age
+                unit: s
+                value_column: max_state_age_seconds
+                value_type: int
+            sql: SELECT * FROM otel.pg_connections()
+      sqlquery/pg_locks:
+        collection_interval: 30s
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - attribute_columns:
+                  - db.postgresql.lock.type
+                  - db.postgresql.lock.mode
+                  - db.postgresql.lock.granted
+                data_type: gauge
+                metric_name: postgresql.lock.count
+                unit: "{lock}"
+                value_column: lock_count
+                value_type: int
+            sql: SELECT * FROM otel.pg_lock_counts()
+          - metrics:
+              - data_type: gauge
+                metric_name: postgresql.lock.blocking_queries
+                unit: "{query}"
+                value_column: blocking_count
+                value_type: int
+            sql: SELECT * FROM otel.pg_blocking_queries()
+          - metrics:
+              - attribute_columns:
+                  - db.namespace
+                data_type: gauge
+                metric_name: postgresql.connection.idle_in_transaction
+                unit: "{connection}"
+                value_column: idle_in_transaction_count
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                data_type: gauge
+                metric_name: postgresql.connection.idle_in_transaction.age
+                unit: s
+                value_column: max_idle_tx_age_seconds
+                value_type: int
+            sql: SELECT * FROM otel.pg_idle_in_transaction()
+      sqlquery/pg_replication:
+        collection_interval: 30s
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - attribute_columns:
+                  - db.postgresql.replication.slot.name
+                  - db.postgresql.replication.slot.type
+                  - db.postgresql.replication.slot.active
+                data_type: gauge
+                metric_name: postgresql.replication.slot.lag
+                unit: By
+                value_column: replication_lag_bytes
+                value_type: int
+            sql: SELECT * FROM otel.pg_replication_slots()
+      sqlquery/pg_table_stats:
+        collection_interval: 300s
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.vacuum.age
+                unit: s
+                value_column: seconds_since_last_vacuum
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.autovacuum.age
+                unit: s
+                value_column: seconds_since_last_autovacuum
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.analyze.age
+                unit: s
+                value_column: seconds_since_last_analyze
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.autoanalyze.age
+                unit: s
+                value_column: seconds_since_last_autoanalyze
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.autovacuum.count
+                unit: "{operation}"
+                value_column: autovacuum_count
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.analyze.count
+                unit: "{operation}"
+                value_column: analyze_count
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.autoanalyze.count
+                unit: "{operation}"
+                value_column: autoanalyze_count
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.rows.modified.since.analyze
+                unit: "{row}"
+                value_column: n_mod_since_analyze
+                value_type: int
+            sql: SELECT * FROM otel.pg_table_stats()
+      sqlquery/pg_vacuum_progress:
+        collection_interval: 60s
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                  - db.postgresql.vacuum.phase
+                data_type: gauge
+                metric_name: postgresql.vacuum.heap_blks_total
+                unit: "{block}"
+                value_column: heap_blks_total
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                  - db.postgresql.vacuum.phase
+                data_type: gauge
+                metric_name: postgresql.vacuum.heap_blks_scanned
+                unit: "{block}"
+                value_column: heap_blks_scanned
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                  - db.postgresql.vacuum.phase
+                data_type: gauge
+                metric_name: postgresql.vacuum.heap_blks_vacuumed
+                unit: "{block}"
+                value_column: heap_blks_vacuumed
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.vacuum.age
+                unit: s
+                value_column: vacuum_age_seconds
+                value_type: int
+            sql: SELECT * FROM otel.pg_vacuum_progress()
+      sqlquery/pg_wal:
+        collection_interval: 60s
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - data_type: gauge
+                metric_name: postgresql.wal.file_count
+                unit: "{file}"
+                value_column: wal_file_count
+                value_type: int
+              - data_type: gauge
+                metric_name: postgresql.wal.bytes
+                unit: By
+                value_column: wal_bytes
+                value_type: int
+            sql: SELECT * FROM otel.pg_wal()
+      sqlquery/postgresql_top_queries:
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.calls
+                unit: "{query}"
+                value_column: calls
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.rows
+                unit: "{row}"
+                value_column: rows
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.exec_time
+                unit: ms
+                value_column: total_exec_time
+                value_type: double
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.plan_time
+                unit: ms
+                value_column: total_plan_time
+                value_type: double
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.blocks.shared.hit
+                unit: "{block}"
+                value_column: shared_blks_hit
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.blocks.shared.read
+                unit: "{block}"
+                value_column: shared_blks_read
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.blocks.shared.dirtied
+                unit: "{block}"
+                value_column: shared_blks_dirtied
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.blocks.shared.written
+                unit: "{block}"
+                value_column: shared_blks_written
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.blocks.temp.read
+                unit: "{block}"
+                value_column: temp_blks_read
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.blocks.temp.written
+                unit: "{block}"
+                value_column: temp_blks_written
+                value_type: int
+            sql: SELECT * FROM otel.pg_top_queries()
+    processors:
+      batch:
+        send_batch_max_size: 5000
+        send_batch_size: 5000
+    exporters:
+      otlp:
+        compression: gzip
+        endpoint: ${env:K8S_NODE_IP}:4317
+        tls:
+          insecure: true
+    service:
+      pipelines:
+        metrics:
+          exporters:
+            - otlp
+          processors:
+            - batch
+          receivers:
+            - postgresql
+            - sqlquery/postgresql_top_queries
+            - sqlquery/pg_table_stats
+            - sqlquery/pg_bloat
+            - sqlquery/pg_connections
+            - sqlquery/pg_locks
+            - sqlquery/pg_replication
+            - sqlquery/pg_wal
+            - sqlquery/pg_vacuum_progress
+    

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/secret-pg-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/secret-pg-monitoring.yaml
@@ -1,0 +1,18 @@
+---
+# Source: opentelemetry-database-monitoring/templates/secret-pg-monitoring.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-pg-monitor-credentials
+type: Opaque
+data:
+  password: "U1dOY1ZIYnFpUnZhSGJERXYwZmxoV2Ey"
+---
+# Source: opentelemetry-database-monitoring/templates/secret-pg-monitoring.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql2-pg-monitor-credentials
+type: Opaque
+data:
+  password: "aTNwTzRQNDFSZUZGVjNaQmhnVkFPaFdB"

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/values.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/values.yaml
@@ -1,0 +1,15 @@
+postgres:
+  enabled: true
+  databases:
+    - name: postgresql
+      sidecar-name: postgres-dbm-sidecar
+      user: root
+      pwd: otel
+      port: 5432
+      host: postgresql
+    - name: postgresql2
+      sidecar-name: postgres2-dbm-sidecar
+      user: root
+      pwd: otel
+      port: 5432
+      host: postgresql2

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/configmap-pg-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/configmap-pg-monitoring.yaml
@@ -1,0 +1,320 @@
+---
+# Source: opentelemetry-database-monitoring/templates/configmap-pg-monitoring.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgresql-monitoring-setup
+data:
+  monitoring-setup.sql: |
+    -- PostgreSQL monitoring setup for OpenTelemetry
+    -- Run this as a superuser (or a role with CREATEROLE and CREATEDB).
+    -- Safe to re-run (all statements are idempotent).
+    
+    -- ---------------------------------------------------------------------------
+    -- 1. Monitoring user
+    -- ---------------------------------------------------------------------------
+    
+    DO $$
+    BEGIN
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'otel_monitor') THEN
+        CREATE USER otel_monitor WITH PASSWORD 'your-password';
+        END IF;
+    END;
+    $$;
+    
+    GRANT pg_monitor TO otel_monitor;
+    GRANT SELECT ON pg_stat_database TO otel_monitor;
+    
+    -- ---------------------------------------------------------------------------
+    -- 2. Extension
+    -- ---------------------------------------------------------------------------
+    
+    CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+    
+    -- ---------------------------------------------------------------------------
+    -- 3. Schema
+    -- ---------------------------------------------------------------------------
+    
+    CREATE SCHEMA IF NOT EXISTS otel;
+    GRANT USAGE ON SCHEMA otel TO otel_monitor;
+    
+    -- ---------------------------------------------------------------------------
+    -- 4. Monitoring functions
+    --
+    -- Attribute columns use OTel semconv names where defined:
+    --   db.namespace           → database name  (stable semconv)
+    --   db.collection.name     → table name     (stable semconv)
+    --   db.schema              → schema name    (experimental; no stable equivalent yet)
+    --   db.client.connection.state → connection state (development semconv)
+    -- PostgreSQL-specific attributes use the db.postgresql.* prefix.
+    -- ---------------------------------------------------------------------------
+    
+    -- Vacuum/analyze ages, autovacuum counts, and scan row counts.
+    -- The built-in postgresql receiver already covers live/dead tuples,
+    -- row operations, manual vacuum count, and sequential/index scan counts.
+    CREATE OR REPLACE FUNCTION otel.pg_table_stats()
+    RETURNS TABLE(
+        "db.schema"                     text,
+        "db.collection.name"            text,
+        seq_tup_read                    bigint,
+        idx_tup_fetch                   bigint,
+        n_mod_since_analyze             bigint,
+        seconds_since_last_vacuum       bigint,
+        seconds_since_last_autovacuum   bigint,
+        seconds_since_last_analyze      bigint,
+        seconds_since_last_autoanalyze  bigint,
+        autovacuum_count                bigint,
+        analyze_count                   bigint,
+        autoanalyze_count               bigint
+    ) LANGUAGE sql STABLE AS $$
+        SELECT
+        schemaname::text                                                       AS "db.schema",
+        relname::text                                                          AS "db.collection.name",
+        seq_tup_read,
+        idx_tup_fetch,
+        n_mod_since_analyze,
+        COALESCE(EXTRACT(EPOCH FROM (now() - last_vacuum))::bigint,      -1),
+        COALESCE(EXTRACT(EPOCH FROM (now() - last_autovacuum))::bigint,  -1),
+        COALESCE(EXTRACT(EPOCH FROM (now() - last_analyze))::bigint,     -1),
+        COALESCE(EXTRACT(EPOCH FROM (now() - last_autoanalyze))::bigint, -1),
+        autovacuum_count::bigint,
+        analyze_count::bigint,
+        autoanalyze_count::bigint
+        FROM pg_stat_user_tables
+        ORDER BY n_mod_since_analyze DESC NULLS LAST
+        LIMIT 50;
+    $$;
+    
+    -- Table bloat estimation (standard check_postgres algorithm).
+    CREATE OR REPLACE FUNCTION otel.pg_bloat()
+    RETURNS TABLE(
+        "db.schema"          text,
+        "db.collection.name" text,
+        tbloat               numeric,
+        wastedbytes          bigint
+    ) LANGUAGE sql STABLE AS $$
+        SELECT
+        schemaname::text  AS "db.schema",
+        tablename::text   AS "db.collection.name",
+        ROUND((CASE WHEN otta = 0 THEN 0.0 ELSE sml.relpages::float / otta END)::numeric, 1) AS tbloat,
+        CASE WHEN relpages < otta THEN 0 ELSE (bs * (sml.relpages - otta)::bigint) END        AS wastedbytes
+        FROM (
+        SELECT
+            schemaname, tablename, bs,
+            CEIL((cc.reltuples * ((datahdr + ma -
+            (CASE WHEN datahdr % ma = 0 THEN ma ELSE datahdr % ma END)) + nullhdr2 + 4)) / (bs - 20::float)) AS otta,
+            cc.relpages
+        FROM (
+            SELECT
+            ma, bs, schemaname, tablename,
+            (datawidth + (hdr + ma - (CASE WHEN hdr % ma = 0 THEN ma ELSE hdr % ma END)))::numeric AS datahdr,
+            (maxfracsum * (nullhdr + ma - (CASE WHEN nullhdr % ma = 0 THEN ma ELSE nullhdr % ma END)))        AS nullhdr2
+            FROM (
+            SELECT
+                schemaname, tablename, hdr, ma, bs,
+                SUM((1 - null_frac) * avg_width) AS datawidth,
+                MAX(null_frac)                   AS maxfracsum,
+                hdr + (
+                SELECT 1 + COUNT(*) / 8
+                FROM pg_stats s2
+                WHERE null_frac <> 0
+                    AND s2.schemaname = s.schemaname
+                    AND s2.tablename  = s.tablename
+                ) AS nullhdr
+            FROM pg_stats s, (
+                SELECT
+                current_setting('block_size')::numeric                                AS bs,
+                CASE WHEN substring(v, 12, 3) IN ('8.0','8.1','8.2') THEN 27 ELSE 23 END AS hdr,
+                CASE WHEN v ~ 'mingw32' THEN 8 ELSE 4 END                            AS ma
+                FROM (SELECT version() AS v) AS foo
+            ) AS constants
+            GROUP BY 1, 2, 3, 4, 5
+            ) AS foo
+        ) AS rs
+        JOIN pg_class cc     ON cc.relname      = tablename
+        JOIN pg_namespace nn ON cc.relnamespace = nn.oid
+                            AND nn.nspname      = schemaname
+                            AND nn.nspname     <> 'information_schema'
+        ) AS sml
+        WHERE schemaname NOT IN ('pg_catalog', 'information_schema')
+        ORDER BY wastedbytes DESC NULLS LAST
+        LIMIT 20;
+    $$;
+    
+    -- Per-state, per-database connection breakdown.
+    -- Total and max are covered by postgresql.backends and postgresql.connection.max.
+    -- Note: db.client.connection.state values in pg_stat_activity ('active', 'idle',
+    -- 'idle in transaction', etc.) are more granular than the semconv enum (idle/used).
+    CREATE OR REPLACE FUNCTION otel.pg_connections()
+    RETURNS TABLE(
+        "db.namespace"               text,
+        "db.client.connection.state" text,
+        connection_count             bigint,
+        max_state_age_seconds        bigint
+    ) LANGUAGE sql STABLE AS $$
+        SELECT
+        datname::text AS "db.namespace",
+        state::text   AS "db.client.connection.state",
+        COUNT(*)::bigint,
+        MAX(EXTRACT(EPOCH FROM (now() - state_change)))::bigint
+        FROM pg_stat_activity
+        WHERE pid <> pg_backend_pid()
+          AND datname IS NOT NULL
+          AND state IS NOT NULL
+        GROUP BY datname, state;
+    $$;
+    
+    -- Lock counts by type/mode/granted.
+    -- postgresql.database.locks (opt-in) covers lock counts by relation/mode;
+    -- this adds the granted status breakdown.
+    CREATE OR REPLACE FUNCTION otel.pg_lock_counts()
+    RETURNS TABLE(
+      "db.postgresql.lock.type"    text,
+      "db.postgresql.lock.mode"    text,
+      "db.postgresql.lock.granted" text,
+      lock_count                   bigint
+    ) LANGUAGE sql STABLE AS $$
+      SELECT
+        l.locktype::text AS "db.postgresql.lock.type",
+        l.mode::text     AS "db.postgresql.lock.mode",
+        l.granted::text  AS "db.postgresql.lock.granted",
+        COUNT(*)::bigint AS lock_count
+      FROM pg_locks l
+      GROUP BY l.locktype, l.mode, l.granted;
+    $$;
+    
+    -- Number of queries currently waiting on a lock.
+    CREATE OR REPLACE FUNCTION otel.pg_blocking_queries()
+    RETURNS TABLE(
+      blocking_count bigint
+    ) LANGUAGE sql STABLE AS $$
+      SELECT COUNT(*)::bigint
+      FROM pg_stat_activity
+      WHERE wait_event_type = 'Lock';
+    $$;
+    
+    -- Idle-in-transaction connections per database with max age.
+    CREATE OR REPLACE FUNCTION otel.pg_idle_in_transaction()
+    RETURNS TABLE(
+      "db.namespace"             text,
+      idle_in_transaction_count  bigint,
+      max_idle_tx_age_seconds    bigint
+    ) LANGUAGE sql STABLE AS $$
+      SELECT
+        datname::text                                             AS "db.namespace",
+        COUNT(*)::bigint,
+        MAX(EXTRACT(EPOCH FROM (now() - xact_start)))::bigint
+      FROM pg_stat_activity
+      WHERE state = 'idle in transaction'
+      GROUP BY datname;
+    $$;
+    
+    -- Replication slot lag.
+    -- Per-replica write/flush/replay lag is covered by postgresql.wal.lag
+    -- and postgresql.replication.data_delay.
+    CREATE OR REPLACE FUNCTION otel.pg_replication_slots()
+    RETURNS TABLE(
+        "db.postgresql.replication.slot.name"   text,
+        "db.postgresql.replication.slot.type"   text,
+        "db.postgresql.replication.slot.active" text,
+        replication_lag_bytes                   bigint
+    ) LANGUAGE sql STABLE AS $$
+        SELECT
+        slot_name::text  AS "db.postgresql.replication.slot.name",
+        slot_type::text  AS "db.postgresql.replication.slot.type",
+        active::text     AS "db.postgresql.replication.slot.active",
+        pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)::bigint
+        FROM pg_replication_slots;
+    $$;
+    
+    -- WAL segment file count and total directory size.
+    -- Distinct from postgresql.wal.age (archiver) and postgresql.wal.lag (replication).
+    CREATE OR REPLACE FUNCTION otel.pg_wal()
+    RETURNS TABLE(
+        wal_file_count bigint,
+        wal_bytes      bigint
+    ) LANGUAGE sql STABLE AS $$
+        SELECT
+        COUNT(*)::bigint  AS wal_file_count,
+        SUM(size)::bigint AS wal_bytes
+        FROM pg_ls_waldir()
+        WHERE name ~ '^[0-9A-F]{24}$';
+    $$;
+    
+    -- Running vacuum operations (PG 10+). Returns no rows when no vacuum is active.
+    CREATE OR REPLACE FUNCTION otel.pg_vacuum_progress()
+    RETURNS TABLE(
+        "db.schema"                text,
+        "db.collection.name"       text,
+        "db.postgresql.vacuum.phase" text,
+        heap_blks_total            bigint,
+        heap_blks_scanned          bigint,
+        heap_blks_vacuumed         bigint,
+        vacuum_age_seconds         bigint
+    ) LANGUAGE sql STABLE AS $$
+        SELECT
+        n.nspname::text                                            AS "db.schema",
+        c.relname::text                                            AS "db.collection.name",
+        p.phase::text                                              AS "db.postgresql.vacuum.phase",
+        p.heap_blks_total,
+        p.heap_blks_scanned,
+        p.heap_blks_vacuumed,
+        EXTRACT(EPOCH FROM (now() - a.xact_start))::bigint
+        FROM pg_stat_progress_vacuum p
+        JOIN pg_stat_activity a ON a.pid    = p.pid
+        JOIN pg_class         c ON c.oid    = p.relid
+        JOIN pg_namespace     n ON n.oid    = c.relnamespace;
+    $$;
+    
+    -- Top queries by call count from pg_stat_statements.
+    -- Requires pg_stat_statements extension (loaded in step 2).
+    CREATE OR REPLACE FUNCTION otel.pg_top_queries()
+    RETURNS TABLE(
+        "db.namespace"          text,
+        "db.user.name"          text,
+        "server.address"        text,
+        "db.version"            text,
+        "db.query.text"         text,
+        calls                   bigint,
+        rows                    bigint,
+        total_exec_time         double precision,
+        total_plan_time         double precision,
+        shared_blks_hit         bigint,
+        shared_blks_read        bigint,
+        shared_blks_dirtied     bigint,
+        shared_blks_written     bigint,
+        temp_blks_read          bigint,
+        temp_blks_written       bigint
+    ) LANGUAGE sql STABLE AS $$
+        SELECT
+        d.datname::text                   AS "db.namespace",
+        COALESCE(r.rolname::text, '')     AS "db.user.name",
+        'postgresql'::text                AS "server.address",
+        current_setting('server_version') AS "db.version",
+        LEFT(s.query, 200)::text          AS "db.query.text",
+        s.calls,
+        s.rows,
+        s.total_exec_time,
+        s.total_plan_time,
+        s.shared_blks_hit,
+        s.shared_blks_read,
+        s.shared_blks_dirtied,
+        s.shared_blks_written,
+        s.temp_blks_read,
+        s.temp_blks_written
+        FROM pg_stat_statements s
+        LEFT JOIN pg_roles    r ON r.oid = s.userid
+        LEFT JOIN pg_database d ON d.oid = s.dbid
+        WHERE d.datname IS NOT NULL
+        AND s.query != '<insufficient privilege>'
+        AND s.query NOT LIKE '/* otel-collector-ignore */%'
+        ORDER BY s.calls DESC
+        LIMIT 20;
+    $$;
+    
+    -- ---------------------------------------------------------------------------
+    -- 5. Grants
+    -- ---------------------------------------------------------------------------
+    
+    GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA otel TO otel_monitor;
+    

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/job-pg-monitoring-setup.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/job-pg-monitoring-setup.yaml
@@ -1,0 +1,38 @@
+---
+# Source: opentelemetry-database-monitoring/templates/job-pg-monitoring-setup.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: postgresql-postgresql-monitoring-setup
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: setup
+          image: postgres:17
+          command:
+            - /bin/sh
+            - -c
+            - |
+              until pg_isready -h postgresql -p 5432 -U root; do sleep 2; done
+              PGPASSWORD=otel psql -h postgresql -p 5432 -U root -d otel -f /scripts/monitoring-setup.sql
+              PGPASSWORD=otel psql -h postgresql -p 5432 -U root -d otel -c "ALTER USER otel_monitor WITH PASSWORD '$OTEL_MONITOR_PASSWORD'"
+          env:
+            - name: OTEL_MONITOR_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-pg-monitor-credentials
+                  key: password
+          volumeMounts:
+            - name: monitoring-setup
+              mountPath: /scripts
+      volumes:
+        - name: monitoring-setup
+          configMap:
+            name: postgresql-monitoring-setup

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/postgres-dbm-sidecar.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/postgres-dbm-sidecar.yaml
@@ -1,0 +1,462 @@
+---
+# Source: opentelemetry-database-monitoring/templates/postgres-dbm-sidecar.yaml
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: postgres-dbm-sidecar
+  annotations:
+    meta.helm.sh/release-name: "example"
+    meta.helm.sh/release-namespace: "default"
+spec:
+  mode: sidecar
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+  env:
+    - name: K8S_NODE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: OTEL_MONITOR_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: postgresql-pg-monitor-credentials
+          key: password
+  config:
+    receivers:
+      postgresql:
+        endpoint: ${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME}:5432
+        metrics:
+          postgresql.bgwriter.buffers.allocated:
+            enabled: true
+          postgresql.bgwriter.buffers.writes:
+            enabled: true
+          postgresql.bgwriter.checkpoint.count:
+            enabled: true
+          postgresql.bgwriter.duration:
+            enabled: true
+          postgresql.bgwriter.maxwritten:
+            enabled: true
+          postgresql.blks_hit:
+            enabled: true
+          postgresql.blks_read:
+            enabled: true
+          postgresql.connection.max:
+            enabled: true
+          postgresql.database.locks:
+            enabled: true
+          postgresql.deadlocks:
+            enabled: true
+          postgresql.replication.data_delay:
+            enabled: true
+          postgresql.sequential_scans:
+            enabled: true
+          postgresql.temp_files:
+            enabled: true
+          postgresql.tup_deleted:
+            enabled: true
+          postgresql.tup_fetched:
+            enabled: true
+          postgresql.tup_inserted:
+            enabled: true
+          postgresql.tup_returned:
+            enabled: true
+          postgresql.tup_updated:
+            enabled: true
+          postgresql.wal.age:
+            enabled: true
+          postgresql.wal.lag:
+            enabled: true
+        password: ${env:OTEL_MONITOR_PASSWORD}
+        tls:
+          insecure: true
+        username: otel_monitor
+      sqlquery/pg_bloat:
+        collection_interval: 3600s
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.bloat.ratio
+                unit: "1"
+                value_column: tbloat
+                value_type: double
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.bloat.bytes
+                unit: By
+                value_column: wastedbytes
+                value_type: int
+            sql: SELECT * FROM otel.pg_bloat()
+      sqlquery/pg_connections:
+        collection_interval: 30s
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - attribute_columns:
+                  - db.namespace
+                  - db.client.connection.state
+                data_type: gauge
+                metric_name: postgresql.backends
+                unit: "{connection}"
+                value_column: connection_count
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.client.connection.state
+                data_type: gauge
+                metric_name: postgresql.backends.age
+                unit: s
+                value_column: max_state_age_seconds
+                value_type: int
+            sql: SELECT * FROM otel.pg_connections()
+      sqlquery/pg_locks:
+        collection_interval: 30s
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - attribute_columns:
+                  - db.postgresql.lock.type
+                  - db.postgresql.lock.mode
+                  - db.postgresql.lock.granted
+                data_type: gauge
+                metric_name: postgresql.lock.count
+                unit: "{lock}"
+                value_column: lock_count
+                value_type: int
+            sql: SELECT * FROM otel.pg_lock_counts()
+          - metrics:
+              - data_type: gauge
+                metric_name: postgresql.lock.blocking_queries
+                unit: "{query}"
+                value_column: blocking_count
+                value_type: int
+            sql: SELECT * FROM otel.pg_blocking_queries()
+          - metrics:
+              - attribute_columns:
+                  - db.namespace
+                data_type: gauge
+                metric_name: postgresql.connection.idle_in_transaction
+                unit: "{connection}"
+                value_column: idle_in_transaction_count
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                data_type: gauge
+                metric_name: postgresql.connection.idle_in_transaction.age
+                unit: s
+                value_column: max_idle_tx_age_seconds
+                value_type: int
+            sql: SELECT * FROM otel.pg_idle_in_transaction()
+      sqlquery/pg_replication:
+        collection_interval: 30s
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - attribute_columns:
+                  - db.postgresql.replication.slot.name
+                  - db.postgresql.replication.slot.type
+                  - db.postgresql.replication.slot.active
+                data_type: gauge
+                metric_name: postgresql.replication.slot.lag
+                unit: By
+                value_column: replication_lag_bytes
+                value_type: int
+            sql: SELECT * FROM otel.pg_replication_slots()
+      sqlquery/pg_table_stats:
+        collection_interval: 300s
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.vacuum.age
+                unit: s
+                value_column: seconds_since_last_vacuum
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.autovacuum.age
+                unit: s
+                value_column: seconds_since_last_autovacuum
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.analyze.age
+                unit: s
+                value_column: seconds_since_last_analyze
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.autoanalyze.age
+                unit: s
+                value_column: seconds_since_last_autoanalyze
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.autovacuum.count
+                unit: "{operation}"
+                value_column: autovacuum_count
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.analyze.count
+                unit: "{operation}"
+                value_column: analyze_count
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.autoanalyze.count
+                unit: "{operation}"
+                value_column: autoanalyze_count
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.table.rows.modified.since.analyze
+                unit: "{row}"
+                value_column: n_mod_since_analyze
+                value_type: int
+            sql: SELECT * FROM otel.pg_table_stats()
+      sqlquery/pg_vacuum_progress:
+        collection_interval: 60s
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                  - db.postgresql.vacuum.phase
+                data_type: gauge
+                metric_name: postgresql.vacuum.heap_blks_total
+                unit: "{block}"
+                value_column: heap_blks_total
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                  - db.postgresql.vacuum.phase
+                data_type: gauge
+                metric_name: postgresql.vacuum.heap_blks_scanned
+                unit: "{block}"
+                value_column: heap_blks_scanned
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                  - db.postgresql.vacuum.phase
+                data_type: gauge
+                metric_name: postgresql.vacuum.heap_blks_vacuumed
+                unit: "{block}"
+                value_column: heap_blks_vacuumed
+                value_type: int
+              - attribute_columns:
+                  - db.schema
+                  - db.collection.name
+                data_type: gauge
+                metric_name: postgresql.vacuum.age
+                unit: s
+                value_column: vacuum_age_seconds
+                value_type: int
+            sql: SELECT * FROM otel.pg_vacuum_progress()
+      sqlquery/pg_wal:
+        collection_interval: 60s
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - data_type: gauge
+                metric_name: postgresql.wal.file_count
+                unit: "{file}"
+                value_column: wal_file_count
+                value_type: int
+              - data_type: gauge
+                metric_name: postgresql.wal.bytes
+                unit: By
+                value_column: wal_bytes
+                value_type: int
+            sql: SELECT * FROM otel.pg_wal()
+      sqlquery/postgresql_top_queries:
+        datasource:
+          host=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME} port=5432 dbname=otel user=otel_monitor password=${env:OTEL_MONITOR_PASSWORD}
+          sslmode=disable
+        driver: postgres
+        queries:
+          - metrics:
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.calls
+                unit: "{query}"
+                value_column: calls
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.rows
+                unit: "{row}"
+                value_column: rows
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.exec_time
+                unit: ms
+                value_column: total_exec_time
+                value_type: double
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.plan_time
+                unit: ms
+                value_column: total_plan_time
+                value_type: double
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.blocks.shared.hit
+                unit: "{block}"
+                value_column: shared_blks_hit
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.blocks.shared.read
+                unit: "{block}"
+                value_column: shared_blks_read
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.blocks.shared.dirtied
+                unit: "{block}"
+                value_column: shared_blks_dirtied
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.blocks.shared.written
+                unit: "{block}"
+                value_column: shared_blks_written
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.blocks.temp.read
+                unit: "{block}"
+                value_column: temp_blks_read
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.user.name
+                  - server.address
+                  - db.version
+                  - db.query.text
+                data_type: gauge
+                metric_name: postgresql.query.blocks.temp.written
+                unit: "{block}"
+                value_column: temp_blks_written
+                value_type: int
+            sql: SELECT * FROM otel.pg_top_queries()
+    processors:
+      batch:
+        send_batch_max_size: 5000
+        send_batch_size: 5000
+    exporters:
+      otlp:
+        compression: gzip
+        endpoint: ${env:K8S_NODE_IP}:4317
+        tls:
+          insecure: true
+    service:
+      pipelines:
+        metrics:
+          exporters:
+            - otlp
+          processors:
+            - batch
+          receivers:
+            - postgresql
+            - sqlquery/postgresql_top_queries
+            - sqlquery/pg_table_stats
+            - sqlquery/pg_bloat
+            - sqlquery/pg_connections
+            - sqlquery/pg_locks
+            - sqlquery/pg_replication
+            - sqlquery/pg_wal
+            - sqlquery/pg_vacuum_progress
+    

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/secret-pg-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/secret-pg-monitoring.yaml
@@ -1,0 +1,9 @@
+---
+# Source: opentelemetry-database-monitoring/templates/secret-pg-monitoring.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-pg-monitor-credentials
+type: Opaque
+data:
+  password: "NTBvZ0JrVFJlT3VWcFJnNXk3a1Y2Z3hQ"

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/values.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/values.yaml
@@ -1,0 +1,9 @@
+postgres:
+  enabled: true
+  databases:
+    - name: postgresql
+      sidecar-name: postgres-dbm-sidecar
+      user: root
+      pwd: otel
+      port: 5432
+      host: postgresql

--- a/charts/opentelemetry-database-monitoring/templates/NOTES.txt
+++ b/charts/opentelemetry-database-monitoring/templates/NOTES.txt
@@ -1,0 +1,19 @@
+{{- if .Values.postgres.enabled }}
+PostgreSQL monitoring deployed for {{ len .Values.postgres.databases }} database(s).
+
+{{- range .Values.postgres.databases }}
+  Database : {{ .name }} ({{ .host }}:{{ .port }})
+  Secret   : {{ .name }}-pg-monitor-credentials
+  Sidecar  : {{ index . "sidecar-name" }}
+{{ end }}
+Check that the setup Jobs completed successfully:
+  kubectl get jobs -n {{ .Release.Namespace }} -l app.kubernetes.io/managed-by=Helm
+
+If a Job failed, inspect its logs:
+  kubectl logs job/<db-name>-postgresql-monitoring-setup -n {{ .Release.Namespace }}
+
+Verify the OTel sidecars are running inside the target Pods:
+  kubectl get opentelemetrycollectors -n {{ .Release.Namespace }}
+{{- else }}
+PostgreSQL monitoring is disabled. Set postgres.enabled=true to deploy.
+{{- end }}

--- a/charts/opentelemetry-database-monitoring/templates/configmap-pg-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/configmap-pg-monitoring.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgresql-monitoring-setup
+data:
+  monitoring-setup.sql: |
+{{ .Files.Get "assets/pg-monitoring-setup.sql" | indent 4 }}

--- a/charts/opentelemetry-database-monitoring/templates/job-pg-monitoring-setup.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/job-pg-monitoring-setup.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.postgres.enabled }}
+{{- $root := . }}
+{{- range $db := .Values.postgres.databases }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{$db.name}}-postgresql-monitoring-setup
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: setup
+          image: postgres:17
+          command:
+            - /bin/sh
+            - -c
+            - |
+              until pg_isready -h {{$db.host}} -p {{$db.port}} -U {{$db.user}}; do sleep 2; done
+              PGPASSWORD={{$db.pwd}} psql -h {{$db.host}} -p {{$db.port}} -U {{$db.user}} -d otel -f /scripts/monitoring-setup.sql
+              PGPASSWORD={{$db.pwd}} psql -h {{$db.host}} -p {{$db.port}} -U {{$db.user}} -d otel -c "ALTER USER otel_monitor WITH PASSWORD '$OTEL_MONITOR_PASSWORD'"
+          env:
+            - name: OTEL_MONITOR_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ printf "%s-pg-monitor-credentials" $db.name }}
+                  key: password
+          volumeMounts:
+            - name: monitoring-setup
+              mountPath: /scripts
+      volumes:
+        - name: monitoring-setup
+          configMap:
+            name: postgresql-monitoring-setup
+{{- end }}
+{{- end }}

--- a/charts/opentelemetry-database-monitoring/templates/postgres-dbm-sidecar.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/postgres-dbm-sidecar.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.postgres.enabled}}
+{{- $root := . }}
+{{- range $db := .Values.postgres.databases }}
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: {{index $db "sidecar-name"}}
+  annotations:
+    meta.helm.sh/release-name: {{ $root.Release.Name | quote }}
+    meta.helm.sh/release-namespace: {{ $root.Release.Namespace | quote }}
+spec:
+  mode: sidecar
+  image: {{ $root.Values.postgres.image | default "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib" }}
+  env:
+    - name: K8S_NODE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: OTEL_MONITOR_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ printf "%s-pg-monitor-credentials" $db.name }}
+          key: password
+  config:
+{{ $root.Files.Get "assets/pg-monitoring-config.yaml" | indent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/opentelemetry-database-monitoring/templates/secret-pg-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/secret-pg-monitoring.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.postgres.enabled }}
+{{- $root := . }}
+{{- range $db := .Values.postgres.databases }}
+{{- $secretName := printf "%s-pg-monitor-credentials" $db.name }}
+{{- $existingSecret := lookup "v1" "Secret" $root.Release.Namespace $secretName }}
+{{- $password := randAlphaNum 24 }}
+{{- if $existingSecret }}
+{{- $password = index $existingSecret.data "password" | b64dec }}
+{{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+type: Opaque
+data:
+  password: {{ $password | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/charts/opentelemetry-database-monitoring/values.schema.json
+++ b/charts/opentelemetry-database-monitoring/values.schema.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "postgres": {
+            "type": "object",
+            "properties": {
+                "databases": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "host": {
+                                "type": "string"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "port": {
+                                "type": "integer"
+                            },
+                            "pwd": {
+                                "type": "string"
+                            },
+                            "sidecar-name": {
+                                "type": "string"
+                            },
+                            "user": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "image": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/charts/opentelemetry-database-monitoring/values.yaml
+++ b/charts/opentelemetry-database-monitoring/values.yaml
@@ -1,0 +1,10 @@
+postgres:
+  enabled: false
+  image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib"
+  databases:
+    - name: postgresql
+      sidecar-name: postgres-dbm-sidecar
+      user: ""
+      pwd: ""
+      port: 5432
+      host: ""

--- a/charts/opentelemetry-demo/CHANGELOG.md
+++ b/charts/opentelemetry-demo/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [opentelemetry-demo-0.9.3] - 2026-06-08
+
+### Added
+- Add PostgreSQL top queries metrics via sqlquery receiver (#88) by @abruneau in [#88](https://github.com/tsuga-dev/helm-charts/pull/88)
+
 ## [opentelemetry-demo-0.9.2] - 2026-06-05
 
 ### Fixed
@@ -143,6 +148,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump versions by @abruneau
 - Revert "Otel-demo-improvement" by @abruneau
 - Enhance OpenTelemetry demo chart and CI/CD configuration by @abruneau
+[opentelemetry-demo-0.9.3]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.2...opentelemetry-demo-0.9.3
+
 [opentelemetry-demo-0.9.2]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.1...opentelemetry-demo-0.9.2
 
 [opentelemetry-demo-0.9.1]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.0...opentelemetry-demo-0.9.1

--- a/charts/opentelemetry-kube-stack/CHANGELOG.md
+++ b/charts/opentelemetry-kube-stack/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [opentelemetry-kube-stack-0.7.1] - 2026-06-08
+
+### Added
+- Add cluster name and instance ID to collector telemetry (#89) by @abruneau in [#89](https://github.com/tsuga-dev/helm-charts/pull/89)
+
 ## [opentelemetry-kube-stack-0.7.0] - 2026-06-05
 
 ### Added
@@ -219,6 +224,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - First commit by @abruneau
 - Add Makefile for example generation and validation; update Helm chart configurations by @abruneau
+[opentelemetry-kube-stack-0.7.1]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.7.0...opentelemetry-kube-stack-0.7.1
+
 [opentelemetry-kube-stack-0.7.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.6.3...opentelemetry-kube-stack-0.7.0
 
 [opentelemetry-kube-stack-0.6.3]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.6.2...opentelemetry-kube-stack-0.6.3


### PR DESCRIPTION
## Summary

- Introduces a new standalone Helm chart `opentelemetry-database-monitoring` for deploying OpenTelemetry-based PostgreSQL database monitoring
- Provides a ConfigMap with sqlquery receiver configuration covering top queries, table/index stats, and bgwriter metrics
- Includes an init Job that installs required stored functions (`pg-monitoring-setup.sql`) on target PostgreSQL databases
- Supports both single-DB and multi-DB deployment patterns via a sidecar OTel collector
- Ships rendered examples for both configurations
- Adds a full `README.md` (via `README.md.gotmpl`) documenting architecture, prerequisites, metrics reference, security notes, and troubleshooting
- Adds `NOTES.txt` with post-install status check commands

## Changes

| Component | Description |
|-----------|-------------|
| `Chart.yaml` | New chart definition, version 0.1.0 |
| `templates/configmap-pg-monitoring.yaml` | OTel sqlquery receiver config |
| `templates/secret-pg-monitoring.yaml` | PostgreSQL credentials secret |
| `templates/job-pg-monitoring-setup.yaml` | Init job for stored function setup |
| `templates/postgres-dbm-sidecar.yaml` | OTel collector sidecar deployment |
| `templates/NOTES.txt` | Post-install output with per-database status and kubectl commands |
| `assets/pg-monitoring-config.yaml` | Base receiver config asset |
| `assets/pg-monitoring-setup.sql` | Stored functions for query monitoring |
| `examples/pg-single-db/` | Single database example + rendered manifests |
| `examples/pg-multiple-db/` | Multiple databases example + rendered manifests |
| `README.md.gotmpl` | helm-docs template with full chart documentation |
| `README.md` | Generated README covering architecture, metrics, security, and troubleshooting |

## Test plan

- [ ] `helm lint charts/opentelemetry-database-monitoring` passes
- [ ] Rendered examples match expected manifests
- [ ] Init job successfully installs stored functions on a test PostgreSQL instance
- [ ] OTel collector sidecar collects metrics and forwards to configured endpoint
- [ ] `helm install` output shows correct NOTES with database list and kubectl commands