### PR TITLE
feat(opentelemetry-demo): add Faro frontend image and env overrides

### DIFF
--- a/charts/opentelemetry-demo/CHANGELOG.md
+++ b/charts/opentelemetry-demo/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [opentelemetry-demo-0.9.7] - 2026-06-17
+
+### Added
+- Use the custom frontend image by default and expose frontend environment overrides for Faro configuration
+
 ## [opentelemetry-demo-0.9.5] - 2026-06-15
 
 ### Added

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.6
+version: 0.9.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-demo/README.md
+++ b/charts/opentelemetry-demo/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-demo
 
-![Version: 0.9.6](https://img.shields.io/badge/Version-0.9.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.0](https://img.shields.io/badge/AppVersion-0.40.0-informational?style=flat-square)
+![Version: 0.9.7](https://img.shields.io/badge/Version-0.9.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.0](https://img.shields.io/badge/AppVersion-0.40.0-informational?style=flat-square)
 
 A Helm chart for Tsuga Observability Demo
 
@@ -54,6 +54,9 @@ A Helm chart for Tsuga Observability Demo
 | opentelemetry-demo.components.frontend-proxy.podAnnotations."io.opentelemetry.discovery.logs/config" | string | `"include_file_path: true\noperators:\n  - type: container\n    id: container-parser\n"` |  |
 | opentelemetry-demo.components.frontend-proxy.podAnnotations."io.opentelemetry.discovery.logs/enabled" | string | `"true"` |  |
 | opentelemetry-demo.components.frontend-proxy.podAnnotations."resource.opentelemetry.io/team" | string | `"platform"` |  |
+| opentelemetry-demo.components.frontend.envOverrides | array | `[]` |  |
+| opentelemetry-demo.components.frontend.imageOverride.repository | string | `"014498635196.dkr.ecr.eu-central-1.amazonaws.com/tsuga-dev/otel-demo"` |  |
+| opentelemetry-demo.components.frontend.imageOverride.tag | string | `"2.2.0.2-frontend"` |  |
 | opentelemetry-demo.components.frontend.podAnnotations."io.opentelemetry.discovery.logs/config" | string | `"include_file_path: true\noperators:\n  - type: container\n    id: container-parser\n\n  # Recombine Next.js multi-line errors (stack traces)\n  - type: recombine\n    id: nextjs-multiline\n    combine_field: body\n    is_first_entry: body matches \"^Error:\"\n    source_identifier: attributes[\"log.file.path\"]\n    force_flush_period: 2s\n    max_log_size: 2MiB\n    preserve_leading_whitespaces: true\n"` |  |
 | opentelemetry-demo.components.frontend.podAnnotations."io.opentelemetry.discovery.logs/enabled" | string | `"true"` |  |
 | opentelemetry-demo.components.frontend.podAnnotations."resource.opentelemetry.io/service.name" | string | `"frontend"` |  |

--- a/charts/opentelemetry-demo/values.schema.json
+++ b/charts/opentelemetry-demo/values.schema.json
@@ -211,6 +211,47 @@
                         "frontend": {
                             "type": "object",
                             "properties": {
+                                "envOverrides": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "type": "string"
+                                            },
+                                            "valueFrom": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "fieldRef": {
+                                                        "type": "object",
+                                                        "properties": {
+                                                            "apiVersion": {
+                                                                "type": "string"
+                                                            },
+                                                            "fieldPath": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "imageOverride": {
+                                    "type": "object",
+                                    "properties": {
+                                        "repository": {
+                                            "type": "string"
+                                        },
+                                        "tag": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
                                 "podAnnotations": {
                                     "type": "object",
                                     "properties": {

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -89,6 +89,10 @@ opentelemetry-demo:
             - type: container
               id: container-parser
     frontend:
+      envOverrides: []
+      imageOverride:
+        repository: "014498635196.dkr.ecr.eu-central-1.amazonaws.com/tsuga-dev/otel-demo"
+        tag: "2.2.0.2-frontend"
       podAnnotations:
         resource.opentelemetry.io/team: app
         resource.opentelemetry.io/service.name: frontend


### PR DESCRIPTION
Update the `opentelemetry-demo` chart to use the custom Faro-enabled frontend image and expose frontend env overrides for Faro configuration.

This bumps the chart to `0.9.7`, sets the frontend image override to `2.2.0.2-frontend`