### PR TITLE
docs: Update README with current charts and per-chart READMEs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,19 +85,19 @@ repos:
         pass_filenames: false
       - id: changelog-kube-stack
         name: Update CHANGELOG.md for opentelemetry-kube-stack
-        entry: bash -c 'git cliff -c charts/opentelemetry-kube-stack/cliff.toml && perl -0pi -e "s/\n{3,}/\n\n/g" charts/opentelemetry-kube-stack/CHANGELOG.md'
+        entry: bash -c 'GITHUB_TOKEN="${GITHUB_TOKEN:-$(gh auth token 2>/dev/null)}" git cliff -c charts/opentelemetry-kube-stack/cliff.toml && perl -0pi -e "s/\n{3,}/\n\n/g" charts/opentelemetry-kube-stack/CHANGELOG.md'
         language: system
         files: ^charts/opentelemetry-kube-stack/
         pass_filenames: false
       - id: changelog-demo
         name: Update CHANGELOG.md for opentelemetry-demo
-        entry: bash -c 'git cliff -c charts/opentelemetry-demo/cliff.toml && perl -0pi -e "s/\n{3,}/\n\n/g" charts/opentelemetry-demo/CHANGELOG.md'
+        entry: bash -c 'GITHUB_TOKEN="${GITHUB_TOKEN:-$(gh auth token 2>/dev/null)}" git cliff -c charts/opentelemetry-demo/cliff.toml && perl -0pi -e "s/\n{3,}/\n\n/g" charts/opentelemetry-demo/CHANGELOG.md'
         language: system
         files: ^charts/opentelemetry-demo/
         pass_filenames: false
       - id: changelog-gremlin
         name: Update CHANGELOG.md for tsuga-spicy-gremlin
-        entry: bash -c 'git cliff -c charts/tsuga-spicy-gremlin/cliff.toml && perl -0pi -e "s/\n{3,}/\n\n/g" charts/tsuga-spicy-gremlin/CHANGELOG.md'
+        entry: bash -c 'GITHUB_TOKEN="${GITHUB_TOKEN:-$(gh auth token 2>/dev/null)}" git cliff -c charts/tsuga-spicy-gremlin/cliff.toml && perl -0pi -e "s/\n{3,}/\n\n/g" charts/tsuga-spicy-gremlin/CHANGELOG.md'
         language: system
         files: ^charts/tsuga-spicy-gremlin/
         pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -99,9 +99,12 @@ You can check the [examples](./charts/opentelemetry-kube-stack/examples) folder 
 
 ## Available Charts
 
-- **opentelemetry-kube-stack**: A comprehensive Helm chart for OpenTelemetry Kubernetes operator with namespace and secret management
-- **opentelemetry-demo**: Demo stack wiring OpenTelemetry demo app with Tsuga-focused defaults
-- **tsuga-spicy-gremlin**: Reusable chaos-style rotator for OpenTelemetry demo feature flags
+Each chart has its own README with full configuration and values reference:
+
+- **[opentelemetry-kube-stack](./charts/opentelemetry-kube-stack/README.md)**: OpenTelemetry Kubernetes operator with Tsuga integration — dual deployment pattern (agent DaemonSet + cluster receiver), secure credential management, and production-ready telemetry collection.
+- **[opentelemetry-demo](./charts/opentelemetry-demo/README.md)**: Tsuga Observability Demo stack wiring the OpenTelemetry demo app with Tsuga-focused defaults.
+- **[opentelemetry-database-monitoring](./charts/opentelemetry-database-monitoring/README.md)**: Deep monitoring for PostgreSQL via an OpenTelemetry sidecar collector — installs stored functions, a dedicated monitoring user, and emits metrics over OTLP.
+- **[tsuga-spicy-gremlin](./charts/tsuga-spicy-gremlin/README.md)**: A minimal chart to run spicy-gremlin against OpenTelemetry Demo feature flags.
 
 ## Changelog
 

--- a/charts/opentelemetry-database-monitoring/Chart.lock
+++ b/charts/opentelemetry-database-monitoring/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: argo-events
   repository: https://argoproj.github.io/argo-helm
-  version: 2.4.21
-digest: sha256:2b7c9dd2e12863f9dd32698d9cb9b9894e39329851f934aa45d683bf4196698a
-generated: "2026-06-12T10:41:22.337469+02:00"
+  version: 2.4.22
+digest: sha256:0c55589af38cc598959163933e4d6ef736c7b79638a81014b4438d5c581b1c25
+generated: "2026-06-22T09:00:48.700613+02:00"

--- a/charts/opentelemetry-database-monitoring/Chart.yaml
+++ b/charts/opentelemetry-database-monitoring/Chart.yaml
@@ -26,6 +26,6 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: argo-events
-    version: "2.x.x"
+    version: "2.4.22"
     repository: "https://argoproj.github.io/argo-helm"
     condition: argoEvents.enabled

--- a/charts/opentelemetry-database-monitoring/README.md
+++ b/charts/opentelemetry-database-monitoring/README.md
@@ -10,7 +10,7 @@ When `argoEvents.enabled=true`, the chart also installs [Argo Events](https://ar
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://argoproj.github.io/argo-helm | argo-events | 2.x.x |
+| https://argoproj.github.io/argo-helm | argo-events | 2.4.22 |
 
 ## How it works
 

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-events/argo-events-controller/config.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-events/argo-events-controller/config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-argo-events-controller-manager
   namespace: "default"
   labels:
-    helm.sh/chart: argo-events-2.4.21
+    helm.sh/chart: argo-events-2.4.22
     app.kubernetes.io/name: argo-events-controller-manager
     app.kubernetes.io/instance: example
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-events/argo-events-controller/deployment.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-events/argo-events-controller/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-argo-events-controller-manager
   namespace: "default"
   labels:
-    helm.sh/chart: argo-events-2.4.21
+    helm.sh/chart: argo-events-2.4.22
     app.kubernetes.io/name: argo-events-controller-manager
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -20,12 +20,14 @@ spec:
       app.kubernetes.io/instance: example
   revisionHistoryLimit: 5
   replicas: 1
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:
-        checksum/config: 01ce187b3292165e6c77edb03e1c8718bda1798e28d39fc11cbd940ecbbec4bb
+        checksum/config: e582d4d24cbef623004e1fa804eb237a2c123cfb72fb4fa0424a6d46d28bff50
       labels:
-        helm.sh/chart: argo-events-2.4.21
+        helm.sh/chart: argo-events-2.4.22
         app.kubernetes.io/name: argo-events-controller-manager
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: controller-manager
@@ -39,6 +41,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - controller
+        - --leader-election=false
         env:
         - name: ARGO_EVENTS_IMAGE
           value: quay.io/argoproj/argo-events:v1.9.10

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-events/argo-events-controller/rbac.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-events/argo-events-controller/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-argo-events-controller-manager
   labels:
-    helm.sh/chart: argo-events-2.4.21
+    helm.sh/chart: argo-events-2.4.22
     app.kubernetes.io/name: argo-events-controller-manager
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -99,7 +99,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-argo-events-controller-manager
   labels:
-    helm.sh/chart: argo-events-2.4.21
+    helm.sh/chart: argo-events-2.4.22
     app.kubernetes.io/name: argo-events-controller-manager
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-events/argo-events-controller/serviceaccount.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-events/argo-events-controller/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-argo-events-controller-manager
   namespace: "default"
   labels:
-    helm.sh/chart: argo-events-2.4.21
+    helm.sh/chart: argo-events-2.4.22
     app.kubernetes.io/name: argo-events-controller-manager
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-events/argo-events-webhook/serviceaccount.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-events/argo-events-webhook/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-argo-events-events-webhook
   namespace: "default"
   labels:
-    helm.sh/chart: argo-events-2.4.21
+    helm.sh/chart: argo-events-2.4.22
     app.kubernetes.io/name: argo-events-events-webhook
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: events-webhook

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-events/argo-events-controller/config.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-events/argo-events-controller/config.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-argo-events-controller-manager
   namespace: "default"
   labels:
-    helm.sh/chart: argo-events-2.4.21
+    helm.sh/chart: argo-events-2.4.22
     app.kubernetes.io/name: argo-events-controller-manager
     app.kubernetes.io/instance: example
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-events/argo-events-controller/deployment.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-events/argo-events-controller/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: example-argo-events-controller-manager
   namespace: "default"
   labels:
-    helm.sh/chart: argo-events-2.4.21
+    helm.sh/chart: argo-events-2.4.22
     app.kubernetes.io/name: argo-events-controller-manager
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -20,12 +20,14 @@ spec:
       app.kubernetes.io/instance: example
   revisionHistoryLimit: 5
   replicas: 1
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:
-        checksum/config: 01ce187b3292165e6c77edb03e1c8718bda1798e28d39fc11cbd940ecbbec4bb
+        checksum/config: e582d4d24cbef623004e1fa804eb237a2c123cfb72fb4fa0424a6d46d28bff50
       labels:
-        helm.sh/chart: argo-events-2.4.21
+        helm.sh/chart: argo-events-2.4.22
         app.kubernetes.io/name: argo-events-controller-manager
         app.kubernetes.io/instance: example
         app.kubernetes.io/component: controller-manager
@@ -39,6 +41,7 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - controller
+        - --leader-election=false
         env:
         - name: ARGO_EVENTS_IMAGE
           value: quay.io/argoproj/argo-events:v1.9.10

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-events/argo-events-controller/rbac.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-events/argo-events-controller/rbac.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: example-argo-events-controller-manager
   labels:
-    helm.sh/chart: argo-events-2.4.21
+    helm.sh/chart: argo-events-2.4.22
     app.kubernetes.io/name: argo-events-controller-manager
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager
@@ -99,7 +99,7 @@ kind: ClusterRoleBinding
 metadata:
   name: example-argo-events-controller-manager
   labels:
-    helm.sh/chart: argo-events-2.4.21
+    helm.sh/chart: argo-events-2.4.22
     app.kubernetes.io/name: argo-events-controller-manager
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-events/argo-events-controller/serviceaccount.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-events/argo-events-controller/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-argo-events-controller-manager
   namespace: "default"
   labels:
-    helm.sh/chart: argo-events-2.4.21
+    helm.sh/chart: argo-events-2.4.22
     app.kubernetes.io/name: argo-events-controller-manager
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: controller-manager

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-events/argo-events-webhook/serviceaccount.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-events/argo-events-webhook/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-argo-events-events-webhook
   namespace: "default"
   labels:
-    helm.sh/chart: argo-events-2.4.21
+    helm.sh/chart: argo-events-2.4.22
     app.kubernetes.io/name: argo-events-events-webhook
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: events-webhook

--- a/charts/opentelemetry-demo/CHANGELOG.md
+++ b/charts/opentelemetry-demo/CHANGELOG.md
@@ -8,210 +8,219 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [opentelemetry-demo-0.9.7] - 2026-06-18
 
 ### Added
-- Add Faro frontend image and env overrides
+- Add Faro frontend image and env overrides by @dussault-antoine
+
+### New Contributors
+* @dussault-antoine made their first contribution in [#102](https://github.com/tsuga-dev/helm-charts/pull/102)
 
 ## [opentelemetry-demo-0.9.6] - 2026-06-15
 
 ### Changed
-- Generate values.schema.json for demo and spicy-gremlin (#99)
-- Change storage class to `standard` (#100)
-- Bump otel demo 0.9.6 (#101)
+- Generate values.schema.json for demo and spicy-gremlin (#99) by @abruneau in [#99](https://github.com/tsuga-dev/helm-charts/pull/99)
+- Change storage class to `standard` (#100) by @abruneau in [#100](https://github.com/tsuga-dev/helm-charts/pull/100)
+- Bump otel demo 0.9.6 (#101) by @abruneau in [#101](https://github.com/tsuga-dev/helm-charts/pull/101)
 
 ## [opentelemetry-demo-0.9.5] - 2026-06-15
 
 ### Added
-- Align demo and kube-stack with OTel naming conventions (#95)
+- Align demo and kube-stack with OTel naming conventions (#95) by @abruneau in [#95](https://github.com/tsuga-dev/helm-charts/pull/95)
 
 ## [opentelemetry-demo-0.9.4] - 2026-06-11
 
 ### Added
-- PostgreSQL deep monitoring via stored functions and receiver_creator (#90)
+- PostgreSQL deep monitoring via stored functions and receiver_creator (#90) by @abruneau in [#90](https://github.com/tsuga-dev/helm-charts/pull/90)
 
 ## [opentelemetry-demo-0.9.3] - 2026-06-08
 
 ### Added
-- Add PostgreSQL top queries metrics via sqlquery receiver (#88)
+- Add PostgreSQL top queries metrics via sqlquery receiver (#88) by @abruneau in [#88](https://github.com/tsuga-dev/helm-charts/pull/88)
 
 ## [opentelemetry-demo-0.9.2] - 2026-06-05
 
 ### Fixed
-- Fix sql statement (#87)
+- Fix sql statement (#87) by @abruneau in [#87](https://github.com/tsuga-dev/helm-charts/pull/87)
 
 ## [opentelemetry-demo-0.9.1] - 2026-06-05
 
 ### Fixed
-- Fix postgresql subPath volume mount conflict (#86)
+- Fix postgresql subPath volume mount conflict (#86) by @abruneau in [#86](https://github.com/tsuga-dev/helm-charts/pull/86)
 
 ## [opentelemetry-demo-0.9.0] - 2026-06-05
 
 ### Added
-- Add pod watch, memory metrics, bump to 0.7.0 (#84)
+- Add pod watch, memory metrics, bump to 0.7.0 (#84) by @abruneau in [#84](https://github.com/tsuga-dev/helm-charts/pull/84)
 
 ### Changed
-- Standardize YAML formatting checks (#82)
-- Update/opentelemetry demo deps 0.7.0 and pg stats (#85)
+- Standardize YAML formatting checks (#82) by @abruneau in [#82](https://github.com/tsuga-dev/helm-charts/pull/82)
+- Update/opentelemetry demo deps 0.7.0 and pg stats (#85) by @abruneau in [#85](https://github.com/tsuga-dev/helm-charts/pull/85)
 
 ## [opentelemetry-demo-0.8.0] - 2026-04-28
 
 ### Added
-- Add per-chart changelogs and release notes from git-cliff
-- Add k8s metrics and objects for otel demo
+- Add per-chart changelogs and release notes from git-cliff by @abruneau
+- Add k8s metrics and objects for otel demo by @kkontoudi
 
 ### Changed
-- Update changelog templates and enhance validation
+- Update changelog templates and enhance validation by @abruneau
+
+### New Contributors
+* @kkontoudi made their first contribution in [#79](https://github.com/tsuga-dev/helm-charts/pull/79)
 
 ## [opentelemetry-demo-0.7.0] - 2026-02-17
 
 ### Added
-- Add resourcedetection processor for cloud metadata
+- Add resourcedetection processor for cloud metadata by @abruneau
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to 0.4.0 and bump chart version to 0.7.0
+- Update opentelemetry-kube-stack dependency to 0.4.0 and bump chart version to 0.7.0 by @abruneau
 
 ## [opentelemetry-demo-0.6.8] - 2026-02-16
 
 ### Added
-- Add dynamic receiver discovery and multiline logs
+- Add dynamic receiver discovery and multiline logs by @abruneau
 
 ### Changed
-- Bump tsuga-spicy-gremlin to 0.1.2
-- Bump chart version to 0.6.7
-- Add metrics discovery for image-provider and valkey-cart services
-- Bump version
+- Bump tsuga-spicy-gremlin to 0.1.2 by @abruneau
+- Bump chart version to 0.6.7 by @abruneau
+- Add metrics discovery for image-provider and valkey-cart services by @abruneau
+- Bump version by @abruneau
 
 ## [opentelemetry-demo-0.6.6] - 2026-02-16
 
 ### Changed
-- Bump tsuga-spicy-gremlin verstion
-- Remove hardcoded OTEL env vars and add examples
-- Downgrade chart version to 0.6.6 and dependency version to 0.1.1
+- Bump tsuga-spicy-gremlin verstion by @abruneau
+- Remove hardcoded OTEL env vars and add examples by @abruneau
+- Downgrade chart version to 0.6.6 and dependency version to 0.1.1 by @abruneau
 
 ## [opentelemetry-demo-0.6.7] - 2026-02-16
 
 ### Changed
-- Leveraging new gremlin with o11y in it
-- Using new spicy-gremlin version with o11y implemented
-- Removing hard-coded env
-- Cleaning custom env logic
-- Making spicy gremlin run more often
+- Leveraging new gremlin with o11y in it by @gus-tsuga
+- Using new spicy-gremlin version with o11y implemented by @gus-tsuga
+- Removing hard-coded env by @gus-tsuga
+- Cleaning custom env logic by @gus-tsuga
+- Making spicy gremlin run more often by @gus-tsuga
 
 ## [opentelemetry-demo-0.6.4] - 2026-02-13
 
 ### Changed
-- Adding tsuga-spicy-gremlin
-- Revert "Collecting more data out of kafka, redis, postgres, envoy"
+- Adding tsuga-spicy-gremlin by @gus-tsuga
+- Revert "Collecting more data out of kafka, redis, postgres, envoy" by @gus-tsuga
 
 ## [opentelemetry-demo-0.6.2] - 2026-02-12
 
 ### Changed
-- Collecting more data out of kafka, redis, postgres, envoy
+- Collecting more data out of kafka, redis, postgres, envoy by @gus-tsuga
+
+### New Contributors
+* @gus-tsuga made their first contribution in [#46](https://github.com/tsuga-dev/helm-charts/pull/46)
 
 ## [opentelemetry-demo-0.6.1] - 2026-01-14
 
 ### Changed
-- Update opentelemetry-demo to version 0.6.1, enhance PostgreSQL logging configuration by adding log_min_duration_statement and log_line_prefix settings, and update README with the new version badge.
+- Update opentelemetry-demo to version 0.6.1, enhance PostgreSQL logging configuration by adding log_min_duration_statement and log_line_prefix settings, and update README with the new version badge. by @abruneau
 
 ## [opentelemetry-demo-0.6.0] - 2026-01-14
 
 ### Changed
-- Enable postgresql log collection and log_statement all
-- Update opentelemetry-demo to version 0.40.0, enhancing PostgreSQL log collection with new pod annotations and image overrides for product-reviews component.
-- Update opentelemetry-demo to version 0.6.0, bump opentelemetry-kube-stack to version 0.2.15, and modify logging configuration to disable log collection while adding support for log volumes.
+- Enable postgresql log collection and log_statement all by @abruneau
+- Update opentelemetry-demo to version 0.40.0, enhancing PostgreSQL log collection with new pod annotations and image overrides for product-reviews component. by @abruneau
+- Update opentelemetry-demo to version 0.6.0, bump opentelemetry-kube-stack to version 0.2.15, and modify logging configuration to disable log collection while adding support for log volumes. by @abruneau
 
 ## [opentelemetry-demo-0.5.0] - 2026-01-06
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to 0.2.12 and bump chart version to 0.5.0
+- Update opentelemetry-kube-stack dependency to 0.2.12 and bump chart version to 0.5.0 by @abruneau
 
 ## [opentelemetry-demo-0.4.0] - 2026-01-05
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to 0.2.11 and bump chart version to 0.4.0
+- Update opentelemetry-kube-stack dependency to 0.2.11 and bump chart version to 0.4.0 by @abruneau
 
 ## [opentelemetry-demo-0.3.0] - 2026-01-05
 
 ### Changed
-- Bump chart version to 0.2.11 and update spanmetrics connector configuration
-- Update opentelemetry-kube-stack dependency to 0.2.11 and bump chart version to 0.3.0
+- Bump chart version to 0.2.11 and update spanmetrics connector configuration by @abruneau
+- Update opentelemetry-kube-stack dependency to 0.2.11 and bump chart version to 0.3.0 by @abruneau
 
 ## [opentelemetry-demo-0.2.0] - 2025-12-18
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to 0.2.10 and bump chart version to 0.2.0
+- Update opentelemetry-kube-stack dependency to 0.2.10 and bump chart version to 0.2.0 by @abruneau
 
 ## [opentelemetry-demo-0.1.4] - 2025-12-17
 
 ### Changed
-- Bump dependency version
+- Bump dependency version by @abruneau
 
 ## [opentelemetry-demo-0.1.3] - 2025-12-16
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to version 0.2.8 and add collectLogs option in values.yaml
+- Update opentelemetry-kube-stack dependency to version 0.2.8 and add collectLogs option in values.yaml by @abruneau
 
 ## [opentelemetry-demo-0.1.2] - 2025-12-15
 
 ### Changed
-- Update opentelemetry-kube-stack dependency version to 0.2.7 in Chart.yaml
-- Bump version
+- Update opentelemetry-kube-stack dependency version to 0.2.7 in Chart.yaml by @abruneau
+- Bump version by @abruneau
 
 ## [opentelemetry-demo-0.1.1] - 2025-12-12
 
 ### Changed
-- Add OpenTelemetry demo Helm chart
-- Add pod annotations for OpenTelemetry components in values.yaml
-- Add default example
-- Bump versions
-- Revert "Otel-demo-improvement"
-- Enhance OpenTelemetry demo chart and CI/CD configuration
-[opentelemetry-demo-0.9.7]: https://github.com///compare/opentelemetry-demo-0.9.6...opentelemetry-demo-0.9.7
+- Add OpenTelemetry demo Helm chart by @abruneau
+- Add pod annotations for OpenTelemetry components in values.yaml by @abruneau
+- Add default example by @abruneau
+- Bump versions by @abruneau
+- Revert "Otel-demo-improvement" by @abruneau
+- Enhance OpenTelemetry demo chart and CI/CD configuration by @abruneau
+[opentelemetry-demo-0.9.7]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.6...opentelemetry-demo-0.9.7
 
-[opentelemetry-demo-0.9.6]: https://github.com///compare/opentelemetry-demo-0.9.5...opentelemetry-demo-0.9.6
+[opentelemetry-demo-0.9.6]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.5...opentelemetry-demo-0.9.6
 
-[opentelemetry-demo-0.9.5]: https://github.com///compare/opentelemetry-demo-0.9.4...opentelemetry-demo-0.9.5
+[opentelemetry-demo-0.9.5]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.4...opentelemetry-demo-0.9.5
 
-[opentelemetry-demo-0.9.4]: https://github.com///compare/opentelemetry-demo-0.9.3...opentelemetry-demo-0.9.4
+[opentelemetry-demo-0.9.4]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.3...opentelemetry-demo-0.9.4
 
-[opentelemetry-demo-0.9.3]: https://github.com///compare/opentelemetry-demo-0.9.2...opentelemetry-demo-0.9.3
+[opentelemetry-demo-0.9.3]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.2...opentelemetry-demo-0.9.3
 
-[opentelemetry-demo-0.9.2]: https://github.com///compare/opentelemetry-demo-0.9.1...opentelemetry-demo-0.9.2
+[opentelemetry-demo-0.9.2]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.1...opentelemetry-demo-0.9.2
 
-[opentelemetry-demo-0.9.1]: https://github.com///compare/opentelemetry-demo-0.9.0...opentelemetry-demo-0.9.1
+[opentelemetry-demo-0.9.1]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.0...opentelemetry-demo-0.9.1
 
-[opentelemetry-demo-0.9.0]: https://github.com///compare/opentelemetry-demo-0.8.0...opentelemetry-demo-0.9.0
+[opentelemetry-demo-0.9.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.8.0...opentelemetry-demo-0.9.0
 
-[opentelemetry-demo-0.8.0]: https://github.com///compare/opentelemetry-demo-0.7.0...opentelemetry-demo-0.8.0
+[opentelemetry-demo-0.8.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.7.0...opentelemetry-demo-0.8.0
 
-[opentelemetry-demo-0.7.0]: https://github.com///compare/opentelemetry-demo-0.6.8...opentelemetry-demo-0.7.0
+[opentelemetry-demo-0.7.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.8...opentelemetry-demo-0.7.0
 
-[opentelemetry-demo-0.6.8]: https://github.com///compare/opentelemetry-demo-0.6.6...opentelemetry-demo-0.6.8
+[opentelemetry-demo-0.6.8]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.6...opentelemetry-demo-0.6.8
 
-[opentelemetry-demo-0.6.6]: https://github.com///compare/opentelemetry-demo-0.6.7...opentelemetry-demo-0.6.6
+[opentelemetry-demo-0.6.6]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.7...opentelemetry-demo-0.6.6
 
-[opentelemetry-demo-0.6.7]: https://github.com///compare/opentelemetry-demo-0.6.4...opentelemetry-demo-0.6.7
+[opentelemetry-demo-0.6.7]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.4...opentelemetry-demo-0.6.7
 
-[opentelemetry-demo-0.6.4]: https://github.com///compare/opentelemetry-demo-0.6.2...opentelemetry-demo-0.6.4
+[opentelemetry-demo-0.6.4]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.2...opentelemetry-demo-0.6.4
 
-[opentelemetry-demo-0.6.2]: https://github.com///compare/opentelemetry-demo-0.6.1...opentelemetry-demo-0.6.2
+[opentelemetry-demo-0.6.2]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.1...opentelemetry-demo-0.6.2
 
-[opentelemetry-demo-0.6.1]: https://github.com///compare/opentelemetry-demo-0.6.0...opentelemetry-demo-0.6.1
+[opentelemetry-demo-0.6.1]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.0...opentelemetry-demo-0.6.1
 
-[opentelemetry-demo-0.6.0]: https://github.com///compare/opentelemetry-demo-0.5.0...opentelemetry-demo-0.6.0
+[opentelemetry-demo-0.6.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.5.0...opentelemetry-demo-0.6.0
 
-[opentelemetry-demo-0.5.0]: https://github.com///compare/opentelemetry-demo-0.4.0...opentelemetry-demo-0.5.0
+[opentelemetry-demo-0.5.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.4.0...opentelemetry-demo-0.5.0
 
-[opentelemetry-demo-0.4.0]: https://github.com///compare/opentelemetry-demo-0.3.0...opentelemetry-demo-0.4.0
+[opentelemetry-demo-0.4.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.3.0...opentelemetry-demo-0.4.0
 
-[opentelemetry-demo-0.3.0]: https://github.com///compare/opentelemetry-demo-0.2.0...opentelemetry-demo-0.3.0
+[opentelemetry-demo-0.3.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.2.0...opentelemetry-demo-0.3.0
 
-[opentelemetry-demo-0.2.0]: https://github.com///compare/opentelemetry-demo-0.1.4...opentelemetry-demo-0.2.0
+[opentelemetry-demo-0.2.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.4...opentelemetry-demo-0.2.0
 
-[opentelemetry-demo-0.1.4]: https://github.com///compare/opentelemetry-demo-0.1.3...opentelemetry-demo-0.1.4
+[opentelemetry-demo-0.1.4]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.3...opentelemetry-demo-0.1.4
 
-[opentelemetry-demo-0.1.3]: https://github.com///compare/opentelemetry-demo-0.1.2...opentelemetry-demo-0.1.3
+[opentelemetry-demo-0.1.3]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.2...opentelemetry-demo-0.1.3
 
-[opentelemetry-demo-0.1.2]: https://github.com///compare/opentelemetry-demo-0.1.1...opentelemetry-demo-0.1.2
+[opentelemetry-demo-0.1.2]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.1...opentelemetry-demo-0.1.2
 
-[opentelemetry-demo-0.1.1]: https://github.com///compare/opentelemetry-demo-0.1.0...opentelemetry-demo-0.1.1
+[opentelemetry-demo-0.1.1]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.0...opentelemetry-demo-0.1.1
 
 <!-- generated by git-cliff -->

--- a/charts/opentelemetry-demo/CHANGELOG.md
+++ b/charts/opentelemetry-demo/CHANGELOG.md
@@ -5,208 +5,213 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [opentelemetry-demo-0.9.7] - 2026-06-17
+## [opentelemetry-demo-0.9.7] - 2026-06-18
 
 ### Added
-- Use the custom frontend image by default and expose frontend environment overrides for Faro configuration
+- Add Faro frontend image and env overrides
+
+## [opentelemetry-demo-0.9.6] - 2026-06-15
+
+### Changed
+- Generate values.schema.json for demo and spicy-gremlin (#99)
+- Change storage class to `standard` (#100)
+- Bump otel demo 0.9.6 (#101)
 
 ## [opentelemetry-demo-0.9.5] - 2026-06-15
 
 ### Added
-- Align demo and kube-stack with OTel naming conventions (#95) by @abruneau in [#95](https://github.com/tsuga-dev/helm-charts/pull/95)
+- Align demo and kube-stack with OTel naming conventions (#95)
 
 ## [opentelemetry-demo-0.9.4] - 2026-06-11
 
 ### Added
-- PostgreSQL deep monitoring via stored functions and receiver_creator (#90) by @abruneau in [#90](https://github.com/tsuga-dev/helm-charts/pull/90)
+- PostgreSQL deep monitoring via stored functions and receiver_creator (#90)
 
 ## [opentelemetry-demo-0.9.3] - 2026-06-08
 
 ### Added
-- Add PostgreSQL top queries metrics via sqlquery receiver (#88) by @abruneau in [#88](https://github.com/tsuga-dev/helm-charts/pull/88)
+- Add PostgreSQL top queries metrics via sqlquery receiver (#88)
 
 ## [opentelemetry-demo-0.9.2] - 2026-06-05
 
 ### Fixed
-- Fix sql statement (#87) by @abruneau in [#87](https://github.com/tsuga-dev/helm-charts/pull/87)
+- Fix sql statement (#87)
 
 ## [opentelemetry-demo-0.9.1] - 2026-06-05
 
 ### Fixed
-- Fix postgresql subPath volume mount conflict (#86) by @abruneau in [#86](https://github.com/tsuga-dev/helm-charts/pull/86)
+- Fix postgresql subPath volume mount conflict (#86)
 
 ## [opentelemetry-demo-0.9.0] - 2026-06-05
 
 ### Added
-- Add pod watch, memory metrics, bump to 0.7.0 (#84) by @abruneau in [#84](https://github.com/tsuga-dev/helm-charts/pull/84)
+- Add pod watch, memory metrics, bump to 0.7.0 (#84)
 
 ### Changed
-- Standardize YAML formatting checks (#82) by @abruneau in [#82](https://github.com/tsuga-dev/helm-charts/pull/82)
-- Update/opentelemetry demo deps 0.7.0 and pg stats (#85) by @abruneau in [#85](https://github.com/tsuga-dev/helm-charts/pull/85)
+- Standardize YAML formatting checks (#82)
+- Update/opentelemetry demo deps 0.7.0 and pg stats (#85)
 
 ## [opentelemetry-demo-0.8.0] - 2026-04-28
 
 ### Added
-- Add per-chart changelogs and release notes from git-cliff by @abruneau
-- Add k8s metrics and objects for otel demo by @kkontoudi
+- Add per-chart changelogs and release notes from git-cliff
+- Add k8s metrics and objects for otel demo
 
 ### Changed
-- Update changelog templates and enhance validation by @abruneau
-
-### New Contributors
-* @kkontoudi made their first contribution in [#79](https://github.com/tsuga-dev/helm-charts/pull/79)
+- Update changelog templates and enhance validation
 
 ## [opentelemetry-demo-0.7.0] - 2026-02-17
 
 ### Added
-- Add resourcedetection processor for cloud metadata by @abruneau
+- Add resourcedetection processor for cloud metadata
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to 0.4.0 and bump chart version to 0.7.0 by @abruneau
+- Update opentelemetry-kube-stack dependency to 0.4.0 and bump chart version to 0.7.0
 
 ## [opentelemetry-demo-0.6.8] - 2026-02-16
 
 ### Added
-- Add dynamic receiver discovery and multiline logs by @abruneau
+- Add dynamic receiver discovery and multiline logs
 
 ### Changed
-- Bump tsuga-spicy-gremlin to 0.1.2 by @abruneau
-- Bump chart version to 0.6.7 by @abruneau
-- Add metrics discovery for image-provider and valkey-cart services by @abruneau
-- Bump version by @abruneau
+- Bump tsuga-spicy-gremlin to 0.1.2
+- Bump chart version to 0.6.7
+- Add metrics discovery for image-provider and valkey-cart services
+- Bump version
 
 ## [opentelemetry-demo-0.6.6] - 2026-02-16
 
 ### Changed
-- Bump tsuga-spicy-gremlin verstion by @abruneau
-- Remove hardcoded OTEL env vars and add examples by @abruneau
-- Downgrade chart version to 0.6.6 and dependency version to 0.1.1 by @abruneau
+- Bump tsuga-spicy-gremlin verstion
+- Remove hardcoded OTEL env vars and add examples
+- Downgrade chart version to 0.6.6 and dependency version to 0.1.1
 
 ## [opentelemetry-demo-0.6.7] - 2026-02-16
 
 ### Changed
-- Leveraging new gremlin with o11y in it by @gus-tsuga
-- Using new spicy-gremlin version with o11y implemented by @gus-tsuga
-- Removing hard-coded env by @gus-tsuga
-- Cleaning custom env logic by @gus-tsuga
-- Making spicy gremlin run more often by @gus-tsuga
+- Leveraging new gremlin with o11y in it
+- Using new spicy-gremlin version with o11y implemented
+- Removing hard-coded env
+- Cleaning custom env logic
+- Making spicy gremlin run more often
 
 ## [opentelemetry-demo-0.6.4] - 2026-02-13
 
 ### Changed
-- Adding tsuga-spicy-gremlin by @gus-tsuga
-- Revert "Collecting more data out of kafka, redis, postgres, envoy" by @gus-tsuga
+- Adding tsuga-spicy-gremlin
+- Revert "Collecting more data out of kafka, redis, postgres, envoy"
 
 ## [opentelemetry-demo-0.6.2] - 2026-02-12
 
 ### Changed
-- Collecting more data out of kafka, redis, postgres, envoy by @gus-tsuga
-
-### New Contributors
-* @gus-tsuga made their first contribution in [#46](https://github.com/tsuga-dev/helm-charts/pull/46)
+- Collecting more data out of kafka, redis, postgres, envoy
 
 ## [opentelemetry-demo-0.6.1] - 2026-01-14
 
 ### Changed
-- Update opentelemetry-demo to version 0.6.1, enhance PostgreSQL logging configuration by adding log_min_duration_statement and log_line_prefix settings, and update README with the new version badge. by @abruneau
+- Update opentelemetry-demo to version 0.6.1, enhance PostgreSQL logging configuration by adding log_min_duration_statement and log_line_prefix settings, and update README with the new version badge.
 
 ## [opentelemetry-demo-0.6.0] - 2026-01-14
 
 ### Changed
-- Enable postgresql log collection and log_statement all by @abruneau
-- Update opentelemetry-demo to version 0.40.0, enhancing PostgreSQL log collection with new pod annotations and image overrides for product-reviews component. by @abruneau
-- Update opentelemetry-demo to version 0.6.0, bump opentelemetry-kube-stack to version 0.2.15, and modify logging configuration to disable log collection while adding support for log volumes. by @abruneau
+- Enable postgresql log collection and log_statement all
+- Update opentelemetry-demo to version 0.40.0, enhancing PostgreSQL log collection with new pod annotations and image overrides for product-reviews component.
+- Update opentelemetry-demo to version 0.6.0, bump opentelemetry-kube-stack to version 0.2.15, and modify logging configuration to disable log collection while adding support for log volumes.
 
 ## [opentelemetry-demo-0.5.0] - 2026-01-06
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to 0.2.12 and bump chart version to 0.5.0 by @abruneau
+- Update opentelemetry-kube-stack dependency to 0.2.12 and bump chart version to 0.5.0
 
 ## [opentelemetry-demo-0.4.0] - 2026-01-05
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to 0.2.11 and bump chart version to 0.4.0 by @abruneau
+- Update opentelemetry-kube-stack dependency to 0.2.11 and bump chart version to 0.4.0
 
 ## [opentelemetry-demo-0.3.0] - 2026-01-05
 
 ### Changed
-- Bump chart version to 0.2.11 and update spanmetrics connector configuration by @abruneau
-- Update opentelemetry-kube-stack dependency to 0.2.11 and bump chart version to 0.3.0 by @abruneau
+- Bump chart version to 0.2.11 and update spanmetrics connector configuration
+- Update opentelemetry-kube-stack dependency to 0.2.11 and bump chart version to 0.3.0
 
 ## [opentelemetry-demo-0.2.0] - 2025-12-18
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to 0.2.10 and bump chart version to 0.2.0 by @abruneau
+- Update opentelemetry-kube-stack dependency to 0.2.10 and bump chart version to 0.2.0
 
 ## [opentelemetry-demo-0.1.4] - 2025-12-17
 
 ### Changed
-- Bump dependency version by @abruneau
+- Bump dependency version
 
 ## [opentelemetry-demo-0.1.3] - 2025-12-16
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to version 0.2.8 and add collectLogs option in values.yaml by @abruneau
+- Update opentelemetry-kube-stack dependency to version 0.2.8 and add collectLogs option in values.yaml
 
 ## [opentelemetry-demo-0.1.2] - 2025-12-15
 
 ### Changed
-- Update opentelemetry-kube-stack dependency version to 0.2.7 in Chart.yaml by @abruneau
-- Bump version by @abruneau
+- Update opentelemetry-kube-stack dependency version to 0.2.7 in Chart.yaml
+- Bump version
 
 ## [opentelemetry-demo-0.1.1] - 2025-12-12
 
 ### Changed
-- Add OpenTelemetry demo Helm chart by @abruneau
-- Add pod annotations for OpenTelemetry components in values.yaml by @abruneau
-- Add default example by @abruneau
-- Bump versions by @abruneau
-- Revert "Otel-demo-improvement" by @abruneau
-- Enhance OpenTelemetry demo chart and CI/CD configuration by @abruneau
-[opentelemetry-demo-0.9.5]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.4...opentelemetry-demo-0.9.5
+- Add OpenTelemetry demo Helm chart
+- Add pod annotations for OpenTelemetry components in values.yaml
+- Add default example
+- Bump versions
+- Revert "Otel-demo-improvement"
+- Enhance OpenTelemetry demo chart and CI/CD configuration
+[opentelemetry-demo-0.9.7]: https://github.com///compare/opentelemetry-demo-0.9.6...opentelemetry-demo-0.9.7
 
-[opentelemetry-demo-0.9.4]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.3...opentelemetry-demo-0.9.4
+[opentelemetry-demo-0.9.6]: https://github.com///compare/opentelemetry-demo-0.9.5...opentelemetry-demo-0.9.6
 
-[opentelemetry-demo-0.9.3]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.2...opentelemetry-demo-0.9.3
+[opentelemetry-demo-0.9.5]: https://github.com///compare/opentelemetry-demo-0.9.4...opentelemetry-demo-0.9.5
 
-[opentelemetry-demo-0.9.2]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.1...opentelemetry-demo-0.9.2
+[opentelemetry-demo-0.9.4]: https://github.com///compare/opentelemetry-demo-0.9.3...opentelemetry-demo-0.9.4
 
-[opentelemetry-demo-0.9.1]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.0...opentelemetry-demo-0.9.1
+[opentelemetry-demo-0.9.3]: https://github.com///compare/opentelemetry-demo-0.9.2...opentelemetry-demo-0.9.3
 
-[opentelemetry-demo-0.9.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.8.0...opentelemetry-demo-0.9.0
+[opentelemetry-demo-0.9.2]: https://github.com///compare/opentelemetry-demo-0.9.1...opentelemetry-demo-0.9.2
 
-[opentelemetry-demo-0.8.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.7.0...opentelemetry-demo-0.8.0
+[opentelemetry-demo-0.9.1]: https://github.com///compare/opentelemetry-demo-0.9.0...opentelemetry-demo-0.9.1
 
-[opentelemetry-demo-0.7.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.8...opentelemetry-demo-0.7.0
+[opentelemetry-demo-0.9.0]: https://github.com///compare/opentelemetry-demo-0.8.0...opentelemetry-demo-0.9.0
 
-[opentelemetry-demo-0.6.8]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.6...opentelemetry-demo-0.6.8
+[opentelemetry-demo-0.8.0]: https://github.com///compare/opentelemetry-demo-0.7.0...opentelemetry-demo-0.8.0
 
-[opentelemetry-demo-0.6.6]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.7...opentelemetry-demo-0.6.6
+[opentelemetry-demo-0.7.0]: https://github.com///compare/opentelemetry-demo-0.6.8...opentelemetry-demo-0.7.0
 
-[opentelemetry-demo-0.6.7]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.4...opentelemetry-demo-0.6.7
+[opentelemetry-demo-0.6.8]: https://github.com///compare/opentelemetry-demo-0.6.6...opentelemetry-demo-0.6.8
 
-[opentelemetry-demo-0.6.4]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.2...opentelemetry-demo-0.6.4
+[opentelemetry-demo-0.6.6]: https://github.com///compare/opentelemetry-demo-0.6.7...opentelemetry-demo-0.6.6
 
-[opentelemetry-demo-0.6.2]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.1...opentelemetry-demo-0.6.2
+[opentelemetry-demo-0.6.7]: https://github.com///compare/opentelemetry-demo-0.6.4...opentelemetry-demo-0.6.7
 
-[opentelemetry-demo-0.6.1]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.0...opentelemetry-demo-0.6.1
+[opentelemetry-demo-0.6.4]: https://github.com///compare/opentelemetry-demo-0.6.2...opentelemetry-demo-0.6.4
 
-[opentelemetry-demo-0.6.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.5.0...opentelemetry-demo-0.6.0
+[opentelemetry-demo-0.6.2]: https://github.com///compare/opentelemetry-demo-0.6.1...opentelemetry-demo-0.6.2
 
-[opentelemetry-demo-0.5.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.4.0...opentelemetry-demo-0.5.0
+[opentelemetry-demo-0.6.1]: https://github.com///compare/opentelemetry-demo-0.6.0...opentelemetry-demo-0.6.1
 
-[opentelemetry-demo-0.4.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.3.0...opentelemetry-demo-0.4.0
+[opentelemetry-demo-0.6.0]: https://github.com///compare/opentelemetry-demo-0.5.0...opentelemetry-demo-0.6.0
 
-[opentelemetry-demo-0.3.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.2.0...opentelemetry-demo-0.3.0
+[opentelemetry-demo-0.5.0]: https://github.com///compare/opentelemetry-demo-0.4.0...opentelemetry-demo-0.5.0
 
-[opentelemetry-demo-0.2.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.4...opentelemetry-demo-0.2.0
+[opentelemetry-demo-0.4.0]: https://github.com///compare/opentelemetry-demo-0.3.0...opentelemetry-demo-0.4.0
 
-[opentelemetry-demo-0.1.4]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.3...opentelemetry-demo-0.1.4
+[opentelemetry-demo-0.3.0]: https://github.com///compare/opentelemetry-demo-0.2.0...opentelemetry-demo-0.3.0
 
-[opentelemetry-demo-0.1.3]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.2...opentelemetry-demo-0.1.3
+[opentelemetry-demo-0.2.0]: https://github.com///compare/opentelemetry-demo-0.1.4...opentelemetry-demo-0.2.0
 
-[opentelemetry-demo-0.1.2]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.1...opentelemetry-demo-0.1.2
+[opentelemetry-demo-0.1.4]: https://github.com///compare/opentelemetry-demo-0.1.3...opentelemetry-demo-0.1.4
 
-[opentelemetry-demo-0.1.1]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.0...opentelemetry-demo-0.1.1
+[opentelemetry-demo-0.1.3]: https://github.com///compare/opentelemetry-demo-0.1.2...opentelemetry-demo-0.1.3
+
+[opentelemetry-demo-0.1.2]: https://github.com///compare/opentelemetry-demo-0.1.1...opentelemetry-demo-0.1.2
+
+[opentelemetry-demo-0.1.1]: https://github.com///compare/opentelemetry-demo-0.1.0...opentelemetry-demo-0.1.1
 
 <!-- generated by git-cliff -->

--- a/charts/opentelemetry-demo/README.md
+++ b/charts/opentelemetry-demo/README.md
@@ -54,7 +54,7 @@ A Helm chart for Tsuga Observability Demo
 | opentelemetry-demo.components.frontend-proxy.podAnnotations."io.opentelemetry.discovery.logs/config" | string | `"include_file_path: true\noperators:\n  - type: container\n    id: container-parser\n"` |  |
 | opentelemetry-demo.components.frontend-proxy.podAnnotations."io.opentelemetry.discovery.logs/enabled" | string | `"true"` |  |
 | opentelemetry-demo.components.frontend-proxy.podAnnotations."resource.opentelemetry.io/team" | string | `"platform"` |  |
-| opentelemetry-demo.components.frontend.envOverrides | array | `[]` |  |
+| opentelemetry-demo.components.frontend.envOverrides | list | `[]` |  |
 | opentelemetry-demo.components.frontend.imageOverride.repository | string | `"014498635196.dkr.ecr.eu-central-1.amazonaws.com/tsuga-dev/otel-demo"` |  |
 | opentelemetry-demo.components.frontend.imageOverride.tag | string | `"2.2.0.2-frontend"` |  |
 | opentelemetry-demo.components.frontend.podAnnotations."io.opentelemetry.discovery.logs/config" | string | `"include_file_path: true\noperators:\n  - type: container\n    id: container-parser\n\n  # Recombine Next.js multi-line errors (stack traces)\n  - type: recombine\n    id: nextjs-multiline\n    combine_field: body\n    is_first_entry: body matches \"^Error:\"\n    source_identifier: attributes[\"log.file.path\"]\n    force_flush_period: 2s\n    max_log_size: 2MiB\n    preserve_leading_whitespaces: true\n"` |  |

--- a/charts/opentelemetry-demo/values.schema.json
+++ b/charts/opentelemetry-demo/values.schema.json
@@ -212,34 +212,7 @@
                             "type": "object",
                             "properties": {
                                 "envOverrides": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "name": {
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "type": "string"
-                                            },
-                                            "valueFrom": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "fieldRef": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "apiVersion": {
-                                                                "type": "string"
-                                                            },
-                                                            "fieldPath": {
-                                                                "type": "string"
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
+                                    "type": "array"
                                 },
                                 "imageOverride": {
                                     "type": "object",


### PR DESCRIPTION
## Summary

Brings the top-level README's chart list up to date and links each entry to its individual chart README.

- Added the missing **opentelemetry-database-monitoring** chart to the Available Charts list
- Refreshed each chart's one-line description from its `Chart.yaml`
- Linked every chart entry to its per-chart `README.md`

## Note

The pre-commit hooks (which cannot be bypassed in this repo) regenerated two unrelated artifacts for the `opentelemetry-demo` chart that had drifted on `main`:
- `values.schema.json` — re-synced to `values.yaml`
- `CHANGELOG.md` — normalized by git-cliff

These are tooling-generated and included because every commit in this repo runs them.

## Checklist
- [x] README chart list matches `charts/` directory
- [x] Each chart links to its README
- [ ] Manual review of bundled demo-chart regen