### PR TITLE
chore(opentelemetry-demo): Bump to 0.9.8 and remove image overrides

### DIFF
--- a/charts/opentelemetry-demo/CHANGELOG.md
+++ b/charts/opentelemetry-demo/CHANGELOG.md
@@ -8,219 +8,210 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [opentelemetry-demo-0.9.7] - 2026-06-18
 
 ### Added
-- Add Faro frontend image and env overrides by @dussault-antoine
-
-### New Contributors
-* @dussault-antoine made their first contribution in [#102](https://github.com/tsuga-dev/helm-charts/pull/102)
+- Add Faro frontend image and env overrides
 
 ## [opentelemetry-demo-0.9.6] - 2026-06-15
 
 ### Changed
-- Generate values.schema.json for demo and spicy-gremlin (#99) by @abruneau in [#99](https://github.com/tsuga-dev/helm-charts/pull/99)
-- Change storage class to `standard` (#100) by @abruneau in [#100](https://github.com/tsuga-dev/helm-charts/pull/100)
-- Bump otel demo 0.9.6 (#101) by @abruneau in [#101](https://github.com/tsuga-dev/helm-charts/pull/101)
+- Generate values.schema.json for demo and spicy-gremlin (#99)
+- Change storage class to `standard` (#100)
+- Bump otel demo 0.9.6 (#101)
 
 ## [opentelemetry-demo-0.9.5] - 2026-06-15
 
 ### Added
-- Align demo and kube-stack with OTel naming conventions (#95) by @abruneau in [#95](https://github.com/tsuga-dev/helm-charts/pull/95)
+- Align demo and kube-stack with OTel naming conventions (#95)
 
 ## [opentelemetry-demo-0.9.4] - 2026-06-11
 
 ### Added
-- PostgreSQL deep monitoring via stored functions and receiver_creator (#90) by @abruneau in [#90](https://github.com/tsuga-dev/helm-charts/pull/90)
+- PostgreSQL deep monitoring via stored functions and receiver_creator (#90)
 
 ## [opentelemetry-demo-0.9.3] - 2026-06-08
 
 ### Added
-- Add PostgreSQL top queries metrics via sqlquery receiver (#88) by @abruneau in [#88](https://github.com/tsuga-dev/helm-charts/pull/88)
+- Add PostgreSQL top queries metrics via sqlquery receiver (#88)
 
 ## [opentelemetry-demo-0.9.2] - 2026-06-05
 
 ### Fixed
-- Fix sql statement (#87) by @abruneau in [#87](https://github.com/tsuga-dev/helm-charts/pull/87)
+- Fix sql statement (#87)
 
 ## [opentelemetry-demo-0.9.1] - 2026-06-05
 
 ### Fixed
-- Fix postgresql subPath volume mount conflict (#86) by @abruneau in [#86](https://github.com/tsuga-dev/helm-charts/pull/86)
+- Fix postgresql subPath volume mount conflict (#86)
 
 ## [opentelemetry-demo-0.9.0] - 2026-06-05
 
 ### Added
-- Add pod watch, memory metrics, bump to 0.7.0 (#84) by @abruneau in [#84](https://github.com/tsuga-dev/helm-charts/pull/84)
+- Add pod watch, memory metrics, bump to 0.7.0 (#84)
 
 ### Changed
-- Standardize YAML formatting checks (#82) by @abruneau in [#82](https://github.com/tsuga-dev/helm-charts/pull/82)
-- Update/opentelemetry demo deps 0.7.0 and pg stats (#85) by @abruneau in [#85](https://github.com/tsuga-dev/helm-charts/pull/85)
+- Standardize YAML formatting checks (#82)
+- Update/opentelemetry demo deps 0.7.0 and pg stats (#85)
 
 ## [opentelemetry-demo-0.8.0] - 2026-04-28
 
 ### Added
-- Add per-chart changelogs and release notes from git-cliff by @abruneau
-- Add k8s metrics and objects for otel demo by @kkontoudi
+- Add per-chart changelogs and release notes from git-cliff
+- Add k8s metrics and objects for otel demo
 
 ### Changed
-- Update changelog templates and enhance validation by @abruneau
-
-### New Contributors
-* @kkontoudi made their first contribution in [#79](https://github.com/tsuga-dev/helm-charts/pull/79)
+- Update changelog templates and enhance validation
 
 ## [opentelemetry-demo-0.7.0] - 2026-02-17
 
 ### Added
-- Add resourcedetection processor for cloud metadata by @abruneau
+- Add resourcedetection processor for cloud metadata
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to 0.4.0 and bump chart version to 0.7.0 by @abruneau
+- Update opentelemetry-kube-stack dependency to 0.4.0 and bump chart version to 0.7.0
 
 ## [opentelemetry-demo-0.6.8] - 2026-02-16
 
 ### Added
-- Add dynamic receiver discovery and multiline logs by @abruneau
+- Add dynamic receiver discovery and multiline logs
 
 ### Changed
-- Bump tsuga-spicy-gremlin to 0.1.2 by @abruneau
-- Bump chart version to 0.6.7 by @abruneau
-- Add metrics discovery for image-provider and valkey-cart services by @abruneau
-- Bump version by @abruneau
+- Bump tsuga-spicy-gremlin to 0.1.2
+- Bump chart version to 0.6.7
+- Add metrics discovery for image-provider and valkey-cart services
+- Bump version
 
 ## [opentelemetry-demo-0.6.6] - 2026-02-16
 
 ### Changed
-- Bump tsuga-spicy-gremlin verstion by @abruneau
-- Remove hardcoded OTEL env vars and add examples by @abruneau
-- Downgrade chart version to 0.6.6 and dependency version to 0.1.1 by @abruneau
+- Bump tsuga-spicy-gremlin verstion
+- Remove hardcoded OTEL env vars and add examples
+- Downgrade chart version to 0.6.6 and dependency version to 0.1.1
 
 ## [opentelemetry-demo-0.6.7] - 2026-02-16
 
 ### Changed
-- Leveraging new gremlin with o11y in it by @gus-tsuga
-- Using new spicy-gremlin version with o11y implemented by @gus-tsuga
-- Removing hard-coded env by @gus-tsuga
-- Cleaning custom env logic by @gus-tsuga
-- Making spicy gremlin run more often by @gus-tsuga
+- Leveraging new gremlin with o11y in it
+- Using new spicy-gremlin version with o11y implemented
+- Removing hard-coded env
+- Cleaning custom env logic
+- Making spicy gremlin run more often
 
 ## [opentelemetry-demo-0.6.4] - 2026-02-13
 
 ### Changed
-- Adding tsuga-spicy-gremlin by @gus-tsuga
-- Revert "Collecting more data out of kafka, redis, postgres, envoy" by @gus-tsuga
+- Adding tsuga-spicy-gremlin
+- Revert "Collecting more data out of kafka, redis, postgres, envoy"
 
 ## [opentelemetry-demo-0.6.2] - 2026-02-12
 
 ### Changed
-- Collecting more data out of kafka, redis, postgres, envoy by @gus-tsuga
-
-### New Contributors
-* @gus-tsuga made their first contribution in [#46](https://github.com/tsuga-dev/helm-charts/pull/46)
+- Collecting more data out of kafka, redis, postgres, envoy
 
 ## [opentelemetry-demo-0.6.1] - 2026-01-14
 
 ### Changed
-- Update opentelemetry-demo to version 0.6.1, enhance PostgreSQL logging configuration by adding log_min_duration_statement and log_line_prefix settings, and update README with the new version badge. by @abruneau
+- Update opentelemetry-demo to version 0.6.1, enhance PostgreSQL logging configuration by adding log_min_duration_statement and log_line_prefix settings, and update README with the new version badge.
 
 ## [opentelemetry-demo-0.6.0] - 2026-01-14
 
 ### Changed
-- Enable postgresql log collection and log_statement all by @abruneau
-- Update opentelemetry-demo to version 0.40.0, enhancing PostgreSQL log collection with new pod annotations and image overrides for product-reviews component. by @abruneau
-- Update opentelemetry-demo to version 0.6.0, bump opentelemetry-kube-stack to version 0.2.15, and modify logging configuration to disable log collection while adding support for log volumes. by @abruneau
+- Enable postgresql log collection and log_statement all
+- Update opentelemetry-demo to version 0.40.0, enhancing PostgreSQL log collection with new pod annotations and image overrides for product-reviews component.
+- Update opentelemetry-demo to version 0.6.0, bump opentelemetry-kube-stack to version 0.2.15, and modify logging configuration to disable log collection while adding support for log volumes.
 
 ## [opentelemetry-demo-0.5.0] - 2026-01-06
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to 0.2.12 and bump chart version to 0.5.0 by @abruneau
+- Update opentelemetry-kube-stack dependency to 0.2.12 and bump chart version to 0.5.0
 
 ## [opentelemetry-demo-0.4.0] - 2026-01-05
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to 0.2.11 and bump chart version to 0.4.0 by @abruneau
+- Update opentelemetry-kube-stack dependency to 0.2.11 and bump chart version to 0.4.0
 
 ## [opentelemetry-demo-0.3.0] - 2026-01-05
 
 ### Changed
-- Bump chart version to 0.2.11 and update spanmetrics connector configuration by @abruneau
-- Update opentelemetry-kube-stack dependency to 0.2.11 and bump chart version to 0.3.0 by @abruneau
+- Bump chart version to 0.2.11 and update spanmetrics connector configuration
+- Update opentelemetry-kube-stack dependency to 0.2.11 and bump chart version to 0.3.0
 
 ## [opentelemetry-demo-0.2.0] - 2025-12-18
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to 0.2.10 and bump chart version to 0.2.0 by @abruneau
+- Update opentelemetry-kube-stack dependency to 0.2.10 and bump chart version to 0.2.0
 
 ## [opentelemetry-demo-0.1.4] - 2025-12-17
 
 ### Changed
-- Bump dependency version by @abruneau
+- Bump dependency version
 
 ## [opentelemetry-demo-0.1.3] - 2025-12-16
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to version 0.2.8 and add collectLogs option in values.yaml by @abruneau
+- Update opentelemetry-kube-stack dependency to version 0.2.8 and add collectLogs option in values.yaml
 
 ## [opentelemetry-demo-0.1.2] - 2025-12-15
 
 ### Changed
-- Update opentelemetry-kube-stack dependency version to 0.2.7 in Chart.yaml by @abruneau
-- Bump version by @abruneau
+- Update opentelemetry-kube-stack dependency version to 0.2.7 in Chart.yaml
+- Bump version
 
 ## [opentelemetry-demo-0.1.1] - 2025-12-12
 
 ### Changed
-- Add OpenTelemetry demo Helm chart by @abruneau
-- Add pod annotations for OpenTelemetry components in values.yaml by @abruneau
-- Add default example by @abruneau
-- Bump versions by @abruneau
-- Revert "Otel-demo-improvement" by @abruneau
-- Enhance OpenTelemetry demo chart and CI/CD configuration by @abruneau
-[opentelemetry-demo-0.9.7]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.6...opentelemetry-demo-0.9.7
+- Add OpenTelemetry demo Helm chart
+- Add pod annotations for OpenTelemetry components in values.yaml
+- Add default example
+- Bump versions
+- Revert "Otel-demo-improvement"
+- Enhance OpenTelemetry demo chart and CI/CD configuration
+[opentelemetry-demo-0.9.7]: https://github.com///compare/opentelemetry-demo-0.9.6...opentelemetry-demo-0.9.7
 
-[opentelemetry-demo-0.9.6]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.5...opentelemetry-demo-0.9.6
+[opentelemetry-demo-0.9.6]: https://github.com///compare/opentelemetry-demo-0.9.5...opentelemetry-demo-0.9.6
 
-[opentelemetry-demo-0.9.5]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.4...opentelemetry-demo-0.9.5
+[opentelemetry-demo-0.9.5]: https://github.com///compare/opentelemetry-demo-0.9.4...opentelemetry-demo-0.9.5
 
-[opentelemetry-demo-0.9.4]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.3...opentelemetry-demo-0.9.4
+[opentelemetry-demo-0.9.4]: https://github.com///compare/opentelemetry-demo-0.9.3...opentelemetry-demo-0.9.4
 
-[opentelemetry-demo-0.9.3]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.2...opentelemetry-demo-0.9.3
+[opentelemetry-demo-0.9.3]: https://github.com///compare/opentelemetry-demo-0.9.2...opentelemetry-demo-0.9.3
 
-[opentelemetry-demo-0.9.2]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.1...opentelemetry-demo-0.9.2
+[opentelemetry-demo-0.9.2]: https://github.com///compare/opentelemetry-demo-0.9.1...opentelemetry-demo-0.9.2
 
-[opentelemetry-demo-0.9.1]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.0...opentelemetry-demo-0.9.1
+[opentelemetry-demo-0.9.1]: https://github.com///compare/opentelemetry-demo-0.9.0...opentelemetry-demo-0.9.1
 
-[opentelemetry-demo-0.9.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.8.0...opentelemetry-demo-0.9.0
+[opentelemetry-demo-0.9.0]: https://github.com///compare/opentelemetry-demo-0.8.0...opentelemetry-demo-0.9.0
 
-[opentelemetry-demo-0.8.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.7.0...opentelemetry-demo-0.8.0
+[opentelemetry-demo-0.8.0]: https://github.com///compare/opentelemetry-demo-0.7.0...opentelemetry-demo-0.8.0
 
-[opentelemetry-demo-0.7.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.8...opentelemetry-demo-0.7.0
+[opentelemetry-demo-0.7.0]: https://github.com///compare/opentelemetry-demo-0.6.8...opentelemetry-demo-0.7.0
 
-[opentelemetry-demo-0.6.8]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.6...opentelemetry-demo-0.6.8
+[opentelemetry-demo-0.6.8]: https://github.com///compare/opentelemetry-demo-0.6.6...opentelemetry-demo-0.6.8
 
-[opentelemetry-demo-0.6.6]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.7...opentelemetry-demo-0.6.6
+[opentelemetry-demo-0.6.6]: https://github.com///compare/opentelemetry-demo-0.6.7...opentelemetry-demo-0.6.6
 
-[opentelemetry-demo-0.6.7]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.4...opentelemetry-demo-0.6.7
+[opentelemetry-demo-0.6.7]: https://github.com///compare/opentelemetry-demo-0.6.4...opentelemetry-demo-0.6.7
 
-[opentelemetry-demo-0.6.4]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.2...opentelemetry-demo-0.6.4
+[opentelemetry-demo-0.6.4]: https://github.com///compare/opentelemetry-demo-0.6.2...opentelemetry-demo-0.6.4
 
-[opentelemetry-demo-0.6.2]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.1...opentelemetry-demo-0.6.2
+[opentelemetry-demo-0.6.2]: https://github.com///compare/opentelemetry-demo-0.6.1...opentelemetry-demo-0.6.2
 
-[opentelemetry-demo-0.6.1]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.0...opentelemetry-demo-0.6.1
+[opentelemetry-demo-0.6.1]: https://github.com///compare/opentelemetry-demo-0.6.0...opentelemetry-demo-0.6.1
 
-[opentelemetry-demo-0.6.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.5.0...opentelemetry-demo-0.6.0
+[opentelemetry-demo-0.6.0]: https://github.com///compare/opentelemetry-demo-0.5.0...opentelemetry-demo-0.6.0
 
-[opentelemetry-demo-0.5.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.4.0...opentelemetry-demo-0.5.0
+[opentelemetry-demo-0.5.0]: https://github.com///compare/opentelemetry-demo-0.4.0...opentelemetry-demo-0.5.0
 
-[opentelemetry-demo-0.4.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.3.0...opentelemetry-demo-0.4.0
+[opentelemetry-demo-0.4.0]: https://github.com///compare/opentelemetry-demo-0.3.0...opentelemetry-demo-0.4.0
 
-[opentelemetry-demo-0.3.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.2.0...opentelemetry-demo-0.3.0
+[opentelemetry-demo-0.3.0]: https://github.com///compare/opentelemetry-demo-0.2.0...opentelemetry-demo-0.3.0
 
-[opentelemetry-demo-0.2.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.4...opentelemetry-demo-0.2.0
+[opentelemetry-demo-0.2.0]: https://github.com///compare/opentelemetry-demo-0.1.4...opentelemetry-demo-0.2.0
 
-[opentelemetry-demo-0.1.4]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.3...opentelemetry-demo-0.1.4
+[opentelemetry-demo-0.1.4]: https://github.com///compare/opentelemetry-demo-0.1.3...opentelemetry-demo-0.1.4
 
-[opentelemetry-demo-0.1.3]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.2...opentelemetry-demo-0.1.3
+[opentelemetry-demo-0.1.3]: https://github.com///compare/opentelemetry-demo-0.1.2...opentelemetry-demo-0.1.3
 
-[opentelemetry-demo-0.1.2]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.1...opentelemetry-demo-0.1.2
+[opentelemetry-demo-0.1.2]: https://github.com///compare/opentelemetry-demo-0.1.1...opentelemetry-demo-0.1.2
 
-[opentelemetry-demo-0.1.1]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.0...opentelemetry-demo-0.1.1
+[opentelemetry-demo-0.1.1]: https://github.com///compare/opentelemetry-demo-0.1.0...opentelemetry-demo-0.1.1
 
 <!-- generated by git-cliff -->

--- a/charts/opentelemetry-demo/CHANGELOG.md
+++ b/charts/opentelemetry-demo/CHANGELOG.md
@@ -8,210 +8,219 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [opentelemetry-demo-0.9.7] - 2026-06-18
 
 ### Added
-- Add Faro frontend image and env overrides
+- Add Faro frontend image and env overrides by @dussault-antoine
+
+### New Contributors
+* @dussault-antoine made their first contribution in [#102](https://github.com/tsuga-dev/helm-charts/pull/102)
 
 ## [opentelemetry-demo-0.9.6] - 2026-06-15
 
 ### Changed
-- Generate values.schema.json for demo and spicy-gremlin (#99)
-- Change storage class to `standard` (#100)
-- Bump otel demo 0.9.6 (#101)
+- Generate values.schema.json for demo and spicy-gremlin (#99) by @abruneau in [#99](https://github.com/tsuga-dev/helm-charts/pull/99)
+- Change storage class to `standard` (#100) by @abruneau in [#100](https://github.com/tsuga-dev/helm-charts/pull/100)
+- Bump otel demo 0.9.6 (#101) by @abruneau in [#101](https://github.com/tsuga-dev/helm-charts/pull/101)
 
 ## [opentelemetry-demo-0.9.5] - 2026-06-15
 
 ### Added
-- Align demo and kube-stack with OTel naming conventions (#95)
+- Align demo and kube-stack with OTel naming conventions (#95) by @abruneau in [#95](https://github.com/tsuga-dev/helm-charts/pull/95)
 
 ## [opentelemetry-demo-0.9.4] - 2026-06-11
 
 ### Added
-- PostgreSQL deep monitoring via stored functions and receiver_creator (#90)
+- PostgreSQL deep monitoring via stored functions and receiver_creator (#90) by @abruneau in [#90](https://github.com/tsuga-dev/helm-charts/pull/90)
 
 ## [opentelemetry-demo-0.9.3] - 2026-06-08
 
 ### Added
-- Add PostgreSQL top queries metrics via sqlquery receiver (#88)
+- Add PostgreSQL top queries metrics via sqlquery receiver (#88) by @abruneau in [#88](https://github.com/tsuga-dev/helm-charts/pull/88)
 
 ## [opentelemetry-demo-0.9.2] - 2026-06-05
 
 ### Fixed
-- Fix sql statement (#87)
+- Fix sql statement (#87) by @abruneau in [#87](https://github.com/tsuga-dev/helm-charts/pull/87)
 
 ## [opentelemetry-demo-0.9.1] - 2026-06-05
 
 ### Fixed
-- Fix postgresql subPath volume mount conflict (#86)
+- Fix postgresql subPath volume mount conflict (#86) by @abruneau in [#86](https://github.com/tsuga-dev/helm-charts/pull/86)
 
 ## [opentelemetry-demo-0.9.0] - 2026-06-05
 
 ### Added
-- Add pod watch, memory metrics, bump to 0.7.0 (#84)
+- Add pod watch, memory metrics, bump to 0.7.0 (#84) by @abruneau in [#84](https://github.com/tsuga-dev/helm-charts/pull/84)
 
 ### Changed
-- Standardize YAML formatting checks (#82)
-- Update/opentelemetry demo deps 0.7.0 and pg stats (#85)
+- Standardize YAML formatting checks (#82) by @abruneau in [#82](https://github.com/tsuga-dev/helm-charts/pull/82)
+- Update/opentelemetry demo deps 0.7.0 and pg stats (#85) by @abruneau in [#85](https://github.com/tsuga-dev/helm-charts/pull/85)
 
 ## [opentelemetry-demo-0.8.0] - 2026-04-28
 
 ### Added
-- Add per-chart changelogs and release notes from git-cliff
-- Add k8s metrics and objects for otel demo
+- Add per-chart changelogs and release notes from git-cliff by @abruneau
+- Add k8s metrics and objects for otel demo by @kkontoudi
 
 ### Changed
-- Update changelog templates and enhance validation
+- Update changelog templates and enhance validation by @abruneau
+
+### New Contributors
+* @kkontoudi made their first contribution in [#79](https://github.com/tsuga-dev/helm-charts/pull/79)
 
 ## [opentelemetry-demo-0.7.0] - 2026-02-17
 
 ### Added
-- Add resourcedetection processor for cloud metadata
+- Add resourcedetection processor for cloud metadata by @abruneau
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to 0.4.0 and bump chart version to 0.7.0
+- Update opentelemetry-kube-stack dependency to 0.4.0 and bump chart version to 0.7.0 by @abruneau
 
 ## [opentelemetry-demo-0.6.8] - 2026-02-16
 
 ### Added
-- Add dynamic receiver discovery and multiline logs
+- Add dynamic receiver discovery and multiline logs by @abruneau
 
 ### Changed
-- Bump tsuga-spicy-gremlin to 0.1.2
-- Bump chart version to 0.6.7
-- Add metrics discovery for image-provider and valkey-cart services
-- Bump version
+- Bump tsuga-spicy-gremlin to 0.1.2 by @abruneau
+- Bump chart version to 0.6.7 by @abruneau
+- Add metrics discovery for image-provider and valkey-cart services by @abruneau
+- Bump version by @abruneau
 
 ## [opentelemetry-demo-0.6.6] - 2026-02-16
 
 ### Changed
-- Bump tsuga-spicy-gremlin verstion
-- Remove hardcoded OTEL env vars and add examples
-- Downgrade chart version to 0.6.6 and dependency version to 0.1.1
+- Bump tsuga-spicy-gremlin verstion by @abruneau
+- Remove hardcoded OTEL env vars and add examples by @abruneau
+- Downgrade chart version to 0.6.6 and dependency version to 0.1.1 by @abruneau
 
 ## [opentelemetry-demo-0.6.7] - 2026-02-16
 
 ### Changed
-- Leveraging new gremlin with o11y in it
-- Using new spicy-gremlin version with o11y implemented
-- Removing hard-coded env
-- Cleaning custom env logic
-- Making spicy gremlin run more often
+- Leveraging new gremlin with o11y in it by @gus-tsuga
+- Using new spicy-gremlin version with o11y implemented by @gus-tsuga
+- Removing hard-coded env by @gus-tsuga
+- Cleaning custom env logic by @gus-tsuga
+- Making spicy gremlin run more often by @gus-tsuga
 
 ## [opentelemetry-demo-0.6.4] - 2026-02-13
 
 ### Changed
-- Adding tsuga-spicy-gremlin
-- Revert "Collecting more data out of kafka, redis, postgres, envoy"
+- Adding tsuga-spicy-gremlin by @gus-tsuga
+- Revert "Collecting more data out of kafka, redis, postgres, envoy" by @gus-tsuga
 
 ## [opentelemetry-demo-0.6.2] - 2026-02-12
 
 ### Changed
-- Collecting more data out of kafka, redis, postgres, envoy
+- Collecting more data out of kafka, redis, postgres, envoy by @gus-tsuga
+
+### New Contributors
+* @gus-tsuga made their first contribution in [#46](https://github.com/tsuga-dev/helm-charts/pull/46)
 
 ## [opentelemetry-demo-0.6.1] - 2026-01-14
 
 ### Changed
-- Update opentelemetry-demo to version 0.6.1, enhance PostgreSQL logging configuration by adding log_min_duration_statement and log_line_prefix settings, and update README with the new version badge.
+- Update opentelemetry-demo to version 0.6.1, enhance PostgreSQL logging configuration by adding log_min_duration_statement and log_line_prefix settings, and update README with the new version badge. by @abruneau
 
 ## [opentelemetry-demo-0.6.0] - 2026-01-14
 
 ### Changed
-- Enable postgresql log collection and log_statement all
-- Update opentelemetry-demo to version 0.40.0, enhancing PostgreSQL log collection with new pod annotations and image overrides for product-reviews component.
-- Update opentelemetry-demo to version 0.6.0, bump opentelemetry-kube-stack to version 0.2.15, and modify logging configuration to disable log collection while adding support for log volumes.
+- Enable postgresql log collection and log_statement all by @abruneau
+- Update opentelemetry-demo to version 0.40.0, enhancing PostgreSQL log collection with new pod annotations and image overrides for product-reviews component. by @abruneau
+- Update opentelemetry-demo to version 0.6.0, bump opentelemetry-kube-stack to version 0.2.15, and modify logging configuration to disable log collection while adding support for log volumes. by @abruneau
 
 ## [opentelemetry-demo-0.5.0] - 2026-01-06
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to 0.2.12 and bump chart version to 0.5.0
+- Update opentelemetry-kube-stack dependency to 0.2.12 and bump chart version to 0.5.0 by @abruneau
 
 ## [opentelemetry-demo-0.4.0] - 2026-01-05
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to 0.2.11 and bump chart version to 0.4.0
+- Update opentelemetry-kube-stack dependency to 0.2.11 and bump chart version to 0.4.0 by @abruneau
 
 ## [opentelemetry-demo-0.3.0] - 2026-01-05
 
 ### Changed
-- Bump chart version to 0.2.11 and update spanmetrics connector configuration
-- Update opentelemetry-kube-stack dependency to 0.2.11 and bump chart version to 0.3.0
+- Bump chart version to 0.2.11 and update spanmetrics connector configuration by @abruneau
+- Update opentelemetry-kube-stack dependency to 0.2.11 and bump chart version to 0.3.0 by @abruneau
 
 ## [opentelemetry-demo-0.2.0] - 2025-12-18
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to 0.2.10 and bump chart version to 0.2.0
+- Update opentelemetry-kube-stack dependency to 0.2.10 and bump chart version to 0.2.0 by @abruneau
 
 ## [opentelemetry-demo-0.1.4] - 2025-12-17
 
 ### Changed
-- Bump dependency version
+- Bump dependency version by @abruneau
 
 ## [opentelemetry-demo-0.1.3] - 2025-12-16
 
 ### Changed
-- Update opentelemetry-kube-stack dependency to version 0.2.8 and add collectLogs option in values.yaml
+- Update opentelemetry-kube-stack dependency to version 0.2.8 and add collectLogs option in values.yaml by @abruneau
 
 ## [opentelemetry-demo-0.1.2] - 2025-12-15
 
 ### Changed
-- Update opentelemetry-kube-stack dependency version to 0.2.7 in Chart.yaml
-- Bump version
+- Update opentelemetry-kube-stack dependency version to 0.2.7 in Chart.yaml by @abruneau
+- Bump version by @abruneau
 
 ## [opentelemetry-demo-0.1.1] - 2025-12-12
 
 ### Changed
-- Add OpenTelemetry demo Helm chart
-- Add pod annotations for OpenTelemetry components in values.yaml
-- Add default example
-- Bump versions
-- Revert "Otel-demo-improvement"
-- Enhance OpenTelemetry demo chart and CI/CD configuration
-[opentelemetry-demo-0.9.7]: https://github.com///compare/opentelemetry-demo-0.9.6...opentelemetry-demo-0.9.7
+- Add OpenTelemetry demo Helm chart by @abruneau
+- Add pod annotations for OpenTelemetry components in values.yaml by @abruneau
+- Add default example by @abruneau
+- Bump versions by @abruneau
+- Revert "Otel-demo-improvement" by @abruneau
+- Enhance OpenTelemetry demo chart and CI/CD configuration by @abruneau
+[opentelemetry-demo-0.9.7]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.6...opentelemetry-demo-0.9.7
 
-[opentelemetry-demo-0.9.6]: https://github.com///compare/opentelemetry-demo-0.9.5...opentelemetry-demo-0.9.6
+[opentelemetry-demo-0.9.6]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.5...opentelemetry-demo-0.9.6
 
-[opentelemetry-demo-0.9.5]: https://github.com///compare/opentelemetry-demo-0.9.4...opentelemetry-demo-0.9.5
+[opentelemetry-demo-0.9.5]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.4...opentelemetry-demo-0.9.5
 
-[opentelemetry-demo-0.9.4]: https://github.com///compare/opentelemetry-demo-0.9.3...opentelemetry-demo-0.9.4
+[opentelemetry-demo-0.9.4]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.3...opentelemetry-demo-0.9.4
 
-[opentelemetry-demo-0.9.3]: https://github.com///compare/opentelemetry-demo-0.9.2...opentelemetry-demo-0.9.3
+[opentelemetry-demo-0.9.3]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.2...opentelemetry-demo-0.9.3
 
-[opentelemetry-demo-0.9.2]: https://github.com///compare/opentelemetry-demo-0.9.1...opentelemetry-demo-0.9.2
+[opentelemetry-demo-0.9.2]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.1...opentelemetry-demo-0.9.2
 
-[opentelemetry-demo-0.9.1]: https://github.com///compare/opentelemetry-demo-0.9.0...opentelemetry-demo-0.9.1
+[opentelemetry-demo-0.9.1]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.9.0...opentelemetry-demo-0.9.1
 
-[opentelemetry-demo-0.9.0]: https://github.com///compare/opentelemetry-demo-0.8.0...opentelemetry-demo-0.9.0
+[opentelemetry-demo-0.9.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.8.0...opentelemetry-demo-0.9.0
 
-[opentelemetry-demo-0.8.0]: https://github.com///compare/opentelemetry-demo-0.7.0...opentelemetry-demo-0.8.0
+[opentelemetry-demo-0.8.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.7.0...opentelemetry-demo-0.8.0
 
-[opentelemetry-demo-0.7.0]: https://github.com///compare/opentelemetry-demo-0.6.8...opentelemetry-demo-0.7.0
+[opentelemetry-demo-0.7.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.8...opentelemetry-demo-0.7.0
 
-[opentelemetry-demo-0.6.8]: https://github.com///compare/opentelemetry-demo-0.6.6...opentelemetry-demo-0.6.8
+[opentelemetry-demo-0.6.8]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.6...opentelemetry-demo-0.6.8
 
-[opentelemetry-demo-0.6.6]: https://github.com///compare/opentelemetry-demo-0.6.7...opentelemetry-demo-0.6.6
+[opentelemetry-demo-0.6.6]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.7...opentelemetry-demo-0.6.6
 
-[opentelemetry-demo-0.6.7]: https://github.com///compare/opentelemetry-demo-0.6.4...opentelemetry-demo-0.6.7
+[opentelemetry-demo-0.6.7]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.4...opentelemetry-demo-0.6.7
 
-[opentelemetry-demo-0.6.4]: https://github.com///compare/opentelemetry-demo-0.6.2...opentelemetry-demo-0.6.4
+[opentelemetry-demo-0.6.4]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.2...opentelemetry-demo-0.6.4
 
-[opentelemetry-demo-0.6.2]: https://github.com///compare/opentelemetry-demo-0.6.1...opentelemetry-demo-0.6.2
+[opentelemetry-demo-0.6.2]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.1...opentelemetry-demo-0.6.2
 
-[opentelemetry-demo-0.6.1]: https://github.com///compare/opentelemetry-demo-0.6.0...opentelemetry-demo-0.6.1
+[opentelemetry-demo-0.6.1]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.6.0...opentelemetry-demo-0.6.1
 
-[opentelemetry-demo-0.6.0]: https://github.com///compare/opentelemetry-demo-0.5.0...opentelemetry-demo-0.6.0
+[opentelemetry-demo-0.6.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.5.0...opentelemetry-demo-0.6.0
 
-[opentelemetry-demo-0.5.0]: https://github.com///compare/opentelemetry-demo-0.4.0...opentelemetry-demo-0.5.0
+[opentelemetry-demo-0.5.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.4.0...opentelemetry-demo-0.5.0
 
-[opentelemetry-demo-0.4.0]: https://github.com///compare/opentelemetry-demo-0.3.0...opentelemetry-demo-0.4.0
+[opentelemetry-demo-0.4.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.3.0...opentelemetry-demo-0.4.0
 
-[opentelemetry-demo-0.3.0]: https://github.com///compare/opentelemetry-demo-0.2.0...opentelemetry-demo-0.3.0
+[opentelemetry-demo-0.3.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.2.0...opentelemetry-demo-0.3.0
 
-[opentelemetry-demo-0.2.0]: https://github.com///compare/opentelemetry-demo-0.1.4...opentelemetry-demo-0.2.0
+[opentelemetry-demo-0.2.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.4...opentelemetry-demo-0.2.0
 
-[opentelemetry-demo-0.1.4]: https://github.com///compare/opentelemetry-demo-0.1.3...opentelemetry-demo-0.1.4
+[opentelemetry-demo-0.1.4]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.3...opentelemetry-demo-0.1.4
 
-[opentelemetry-demo-0.1.3]: https://github.com///compare/opentelemetry-demo-0.1.2...opentelemetry-demo-0.1.3
+[opentelemetry-demo-0.1.3]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.2...opentelemetry-demo-0.1.3
 
-[opentelemetry-demo-0.1.2]: https://github.com///compare/opentelemetry-demo-0.1.1...opentelemetry-demo-0.1.2
+[opentelemetry-demo-0.1.2]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.1...opentelemetry-demo-0.1.2
 
-[opentelemetry-demo-0.1.1]: https://github.com///compare/opentelemetry-demo-0.1.0...opentelemetry-demo-0.1.1
+[opentelemetry-demo-0.1.1]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-demo-0.1.0...opentelemetry-demo-0.1.1
 
 <!-- generated by git-cliff -->

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.7
+version: 0.9.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-demo/README.md
+++ b/charts/opentelemetry-demo/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-demo
 
-![Version: 0.9.7](https://img.shields.io/badge/Version-0.9.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.0](https://img.shields.io/badge/AppVersion-0.40.0-informational?style=flat-square)
+![Version: 0.9.8](https://img.shields.io/badge/Version-0.9.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.0](https://img.shields.io/badge/AppVersion-0.40.0-informational?style=flat-square)
 
 A Helm chart for Tsuga Observability Demo
 
@@ -55,12 +55,10 @@ A Helm chart for Tsuga Observability Demo
 | opentelemetry-demo.components.frontend-proxy.podAnnotations."io.opentelemetry.discovery.logs/enabled" | string | `"true"` |  |
 | opentelemetry-demo.components.frontend-proxy.podAnnotations."resource.opentelemetry.io/team" | string | `"platform"` |  |
 | opentelemetry-demo.components.frontend.envOverrides | list | `[]` |  |
-| opentelemetry-demo.components.frontend.imageOverride.repository | string | `"014498635196.dkr.ecr.eu-central-1.amazonaws.com/tsuga-dev/otel-demo"` |  |
-| opentelemetry-demo.components.frontend.imageOverride.tag | string | `"2.2.0.2-frontend"` |  |
 | opentelemetry-demo.components.frontend.podAnnotations."io.opentelemetry.discovery.logs/config" | string | `"include_file_path: true\noperators:\n  - type: container\n    id: container-parser\n\n  # Recombine Next.js multi-line errors (stack traces)\n  - type: recombine\n    id: nextjs-multiline\n    combine_field: body\n    is_first_entry: body matches \"^Error:\"\n    source_identifier: attributes[\"log.file.path\"]\n    force_flush_period: 2s\n    max_log_size: 2MiB\n    preserve_leading_whitespaces: true\n"` |  |
 | opentelemetry-demo.components.frontend.podAnnotations."io.opentelemetry.discovery.logs/enabled" | string | `"true"` |  |
 | opentelemetry-demo.components.frontend.podAnnotations."resource.opentelemetry.io/service.name" | string | `"frontend"` |  |
-| opentelemetry-demo.components.frontend.podAnnotations."resource.opentelemetry.io/team" | string | `"app"` |  |
+| opentelemetry-demo.components.frontend.podAnnotations."resource.opentelemetry.io/team" | string | `"frontend"` |  |
 | opentelemetry-demo.components.image-provider.podAnnotations."io.opentelemetry.discovery.logs/config" | string | `"include_file_path: true\noperators:\n  - type: container\n    id: container-parser\n\n  # Recombine Envoy/nginx multi-line logs (continuation lines without timestamp)\n  - type: recombine\n    id: envoy-multiline\n    combine_field: body\n    is_first_entry: body matches \"^\\\\[\\\\d{4}-\\\\d{2}-\\\\d{2} \\\\d{2}:\\\\d{2}:\\\\d{2}\\\\.\\\\d{3}\\\\]\"\n    source_identifier: attributes[\"log.file.path\"]\n    force_flush_period: 2s\n    max_log_size: 2MiB\n    preserve_leading_whitespaces: true\n"` |  |
 | opentelemetry-demo.components.image-provider.podAnnotations."io.opentelemetry.discovery.logs/enabled" | string | `"true"` |  |
 | opentelemetry-demo.components.image-provider.podAnnotations."io.opentelemetry.discovery.metrics.8081/config" | string | `"endpoint: \"http://`endpoint`/status\"\ncollection_interval: 10s\n"` |  |
@@ -102,8 +100,6 @@ A Helm chart for Tsuga Observability Demo
 | opentelemetry-demo.components.product-catalog.podAnnotations."io.opentelemetry.discovery.logs/config" | string | `"include_file_path: true\noperators:\n  - type: container\n    id: container-parser\n"` |  |
 | opentelemetry-demo.components.product-catalog.podAnnotations."io.opentelemetry.discovery.logs/enabled" | string | `"true"` |  |
 | opentelemetry-demo.components.product-catalog.podAnnotations."resource.opentelemetry.io/team" | string | `"services"` |  |
-| opentelemetry-demo.components.product-reviews.imageOverride.repository | string | `"014498635196.dkr.ecr.eu-central-1.amazonaws.com/tsuga-dev/otel-demo"` |  |
-| opentelemetry-demo.components.product-reviews.imageOverride.tag | string | `"2.2.0-product-reviews"` |  |
 | opentelemetry-demo.components.product-reviews.podAnnotations."io.opentelemetry.discovery.logs/config" | string | `"include_file_path: true\noperators:\n  - type: container\n    id: container-parser\n"` |  |
 | opentelemetry-demo.components.product-reviews.podAnnotations."io.opentelemetry.discovery.logs/enabled" | string | `"true"` |  |
 | opentelemetry-demo.components.product-reviews.podAnnotations."resource.opentelemetry.io/team" | string | `"services"` |  |

--- a/charts/opentelemetry-demo/values.schema.json
+++ b/charts/opentelemetry-demo/values.schema.json
@@ -214,17 +214,6 @@
                                 "envOverrides": {
                                     "type": "array"
                                 },
-                                "imageOverride": {
-                                    "type": "object",
-                                    "properties": {
-                                        "repository": {
-                                            "type": "string"
-                                        },
-                                        "tag": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
                                 "podAnnotations": {
                                     "type": "object",
                                     "properties": {
@@ -457,17 +446,6 @@
                         "product-reviews": {
                             "type": "object",
                             "properties": {
-                                "imageOverride": {
-                                    "type": "object",
-                                    "properties": {
-                                        "repository": {
-                                            "type": "string"
-                                        },
-                                        "tag": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
                                 "podAnnotations": {
                                     "type": "object",
                                     "properties": {

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -90,11 +90,8 @@ opentelemetry-demo:
               id: container-parser
     frontend:
       envOverrides: []
-      imageOverride:
-        repository: "014498635196.dkr.ecr.eu-central-1.amazonaws.com/tsuga-dev/otel-demo"
-        tag: "2.2.0.2-frontend"
       podAnnotations:
-        resource.opentelemetry.io/team: app
+        resource.opentelemetry.io/team: frontend
         resource.opentelemetry.io/service.name: frontend
         io.opentelemetry.discovery.logs/enabled: "true"
         io.opentelemetry.discovery.logs/config: |
@@ -182,9 +179,6 @@ opentelemetry-demo:
           operators:
             - type: container
               id: container-parser
-      imageOverride:
-        repository: "014498635196.dkr.ecr.eu-central-1.amazonaws.com/tsuga-dev/otel-demo"
-        tag: "2.2.0-product-reviews"
     quote:
       podAnnotations:
         resource.opentelemetry.io/team: services


### PR DESCRIPTION
## Summary

- Bump `opentelemetry-demo` chart version from `0.9.7` to `0.9.8`
- Remove custom ECR `imageOverride` entries for `frontend` and `product-reviews`, reverting to upstream default images
- Set frontend `resource.opentelemetry.io/team` annotation to `frontend` (was `app`)

## Motivation

Custom image overrides are no longer needed now that Faro frontend support is merged upstream. This release cleans up the chart defaults and aligns team metadata with the frontend service.

## Test plan

- [ ] `helm lint charts/opentelemetry-demo` passes
- [ ] `helm template` renders frontend and product-reviews without custom image overrides
- [ ] Frontend pods carry `resource.opentelemetry.io/team: frontend`


Made with [Cursor](https://cursor.com)