### PR TITLE
fix(otel-demo): mount postgres PVC at the real PGDATA path

### DIFF
--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.9
+version: 0.9.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-demo/README.md
+++ b/charts/opentelemetry-demo/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-demo
 
-![Version: 0.9.9](https://img.shields.io/badge/Version-0.9.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.0](https://img.shields.io/badge/AppVersion-0.40.0-informational?style=flat-square)
+![Version: 0.9.10](https://img.shields.io/badge/Version-0.9.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.40.0](https://img.shields.io/badge/AppVersion-0.40.0-informational?style=flat-square)
 
 A Helm chart for Tsuga Observability Demo
 
@@ -73,7 +73,7 @@ A Helm chart for Tsuga Observability Demo
 | opentelemetry-demo.components.load-generator.podAnnotations."io.opentelemetry.discovery.logs/enabled" | string | `"true"` |  |
 | opentelemetry-demo.components.load-generator.podAnnotations."resource.opentelemetry.io/team" | string | `"platform"` |  |
 | opentelemetry-demo.components.payment.podAnnotations."resource.opentelemetry.io/team" | string | `"services"` |  |
-| opentelemetry-demo.components.postgresql.additionalVolumeMounts[0].mountPath | string | `"/var/lib/postgres/data"` |  |
+| opentelemetry-demo.components.postgresql.additionalVolumeMounts[0].mountPath | string | `"/var/lib/postgresql/data"` |  |
 | opentelemetry-demo.components.postgresql.additionalVolumeMounts[0].name | string | `"db-data"` |  |
 | opentelemetry-demo.components.postgresql.additionalVolumes[0].name | string | `"db-data"` |  |
 | opentelemetry-demo.components.postgresql.additionalVolumes[0].persistentVolumeClaim.claimName | string | `"db-persistent-volume-claim"` |  |

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -264,7 +264,7 @@ opentelemetry-demo:
           persistentVolumeClaim:
             claimName: db-persistent-volume-claim
       additionalVolumeMounts:
-        - mountPath: /var/lib/postgres/data
+        - mountPath: /var/lib/postgresql/data
           name: db-data
     valkey-cart:
       podAnnotations:


### PR DESCRIPTION
## Problem

Database monitoring on the demo postgres is broken: the injected collector sidecar fails every scrape with

```
pq: password authentication failed for user "otel_monitor" (28P01)
```

Investigation showed the `otel_monitor` role **does not exist** in the DB (postgres reports `28P01` over the wire rather than "role missing"). It went missing after the postgres container was **OOMKilled and restarted** (`2026-07-06 06:36`; `pg_postmaster_start_time` confirms a fresh init).

## Root cause

The `db-data` PVC is mounted at `/var/lib/postgres/data`, but the postgres image writes to `/var/lib/postgresql/data` (default `PGDATA`, note the `ql`). On the live pod:

- `/var/lib/postgres/data` (the PVC) → **0 bytes**
- `/var/lib/postgresql/data` (ephemeral container layer) → **67M** actual data

So PGDATA never persisted. Any container restart reinitializes the DB. On reinit, `root` (POSTGRES_USER) and `otelu` (from `init.sql`) are recreated, but `otel_monitor` is **not** — that role is created by the `dbm` setup Job, which Argo Events only triggers on **pod creation**, not a bare container restart. Hence the role stays gone and the collector can never authenticate.

## Fix

Mount the PVC at `/var/lib/postgresql/data` so PGDATA actually persists across restarts. `otel_monitor` then survives, and monitoring stays healthy.

Chart version bumped `0.9.9` → `0.9.10`; README regenerated by helm-docs.

## Notes / follow-ups (not in this PR)

- **Immediate recovery on the live cluster:** the fix only takes effect on the next pod (re)creation. Delete the postgres pod (or let the new chart version roll it) so Argo Events re-fires the setup Job and recreates `otel_monitor`.
- The OOMKill itself is worth addressing separately (postgres memory limit) — it was the trigger, though with this fix a restart is no longer destructive.

## Test plan

- [ ] Deploy `0.9.10`, confirm `df`/`du` shows data under `/var/lib/postgresql/data` on the PVC.
- [ ] Restart the postgres container; confirm the DB (and `otel_monitor`) persists.
- [ ] Confirm the collector sidecar scrapes cleanly (no `28P01`).