### PR TITLE
fix(dbm): fail setup Job unless otel_monitor is usable on the reached endpoint

### DIFF
--- a/charts/opentelemetry-database-monitoring/Chart.yaml
+++ b/charts/opentelemetry-database-monitoring/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-database-monitoring/README.md
+++ b/charts/opentelemetry-database-monitoring/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-database-monitoring
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 A Helm chart that deploys OpenTelemetry-based deep monitoring for PostgreSQL using a sidecar collector pattern. It installs stored functions on the target database, creates a dedicated monitoring user, and runs an `OpenTelemetryCollector` sidecar that emits metrics via OTLP.
 

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-eventbus.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-eventbus.yaml
@@ -5,7 +5,7 @@ kind: EventBus
 metadata:
   name: default
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-events-rbac.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-events-rbac.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-database-monitoring-argo-eventsource
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -17,7 +17,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-database-monitoring-argo-sensor
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -30,7 +30,7 @@ metadata:
   name: example-opentelemetry-database-monitoring-argo-eventsource
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -46,7 +46,7 @@ kind: Role
 metadata:
   name: example-opentelemetry-database-monitoring-argo-sensor
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -63,7 +63,7 @@ metadata:
   name: example-opentelemetry-database-monitoring-argo-eventsource
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -83,7 +83,7 @@ kind: RoleBinding
 metadata:
   name: example-opentelemetry-database-monitoring-argo-sensor
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-eventsource.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-eventsource.yaml
@@ -5,7 +5,7 @@ kind: EventSource
 metadata:
   name: example-opentelemetry-database-monitoring-pod-created
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-sensor.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-sensor.yaml
@@ -5,7 +5,7 @@ kind: Sensor
 metadata:
   name: example-opentelemetry-database-monitoring-postgresql-setup
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -39,7 +39,7 @@ spec:
                 generateName: postgresql-postgresql-monitoring-setup-
                 namespace: default
                 labels:
-                  helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+                  helm.sh/chart: opentelemetry-database-monitoring-0.1.2
                   app.kubernetes.io/name: opentelemetry-database-monitoring
                   app.kubernetes.io/instance: example
                   app.kubernetes.io/version: "1.16.0"
@@ -64,9 +64,13 @@ spec:
                           - /bin/sh
                           - -c
                           - |
+                            set -e
                             until pg_isready -h postgresql -p 5432 -U root; do sleep 2; done
-                            PGPASSWORD=otel psql -h postgresql -p 5432 -U root -d otel -f /scripts/monitoring-setup.sql
-                            PGPASSWORD=otel psql -h postgresql -p 5432 -U root -d otel -c "ALTER USER otel_monitor WITH PASSWORD '$OTEL_MONITOR_PASSWORD'"
+                            PGPASSWORD=otel psql -v ON_ERROR_STOP=1 -h postgresql -p 5432 -U root -d otel -f /scripts/monitoring-setup.sql
+                            PGPASSWORD=otel psql -v ON_ERROR_STOP=1 -h postgresql -p 5432 -U root -d otel -c "ALTER USER otel_monitor WITH PASSWORD '$OTEL_MONITOR_PASSWORD'"
+                            # Confirm the monitoring role is actually usable on the endpoint we reached;
+                            # fail (and let backoffLimit retry) if the setup did not land where the collector connects.
+                            PGPASSWORD="$OTEL_MONITOR_PASSWORD" psql -v ON_ERROR_STOP=1 -h postgresql -p 5432 -U otel_monitor -d otel -c "SELECT 1" > /dev/null
                         env:
                           - name: OTEL_MONITOR_PASSWORD
                             valueFrom:
@@ -87,7 +91,7 @@ kind: Sensor
 metadata:
   name: example-opentelemetry-database-monitoring-postgresql2-setup
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -121,7 +125,7 @@ spec:
                 generateName: postgresql2-postgresql-monitoring-setup-
                 namespace: default
                 labels:
-                  helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+                  helm.sh/chart: opentelemetry-database-monitoring-0.1.2
                   app.kubernetes.io/name: opentelemetry-database-monitoring
                   app.kubernetes.io/instance: example
                   app.kubernetes.io/version: "1.16.0"
@@ -146,9 +150,13 @@ spec:
                           - /bin/sh
                           - -c
                           - |
+                            set -e
                             until pg_isready -h postgresql2 -p 5432 -U root; do sleep 2; done
-                            PGPASSWORD=otel psql -h postgresql2 -p 5432 -U root -d otel -f /scripts/monitoring-setup.sql
-                            PGPASSWORD=otel psql -h postgresql2 -p 5432 -U root -d otel -c "ALTER USER otel_monitor WITH PASSWORD '$OTEL_MONITOR_PASSWORD'"
+                            PGPASSWORD=otel psql -v ON_ERROR_STOP=1 -h postgresql2 -p 5432 -U root -d otel -f /scripts/monitoring-setup.sql
+                            PGPASSWORD=otel psql -v ON_ERROR_STOP=1 -h postgresql2 -p 5432 -U root -d otel -c "ALTER USER otel_monitor WITH PASSWORD '$OTEL_MONITOR_PASSWORD'"
+                            # Confirm the monitoring role is actually usable on the endpoint we reached;
+                            # fail (and let backoffLimit retry) if the setup did not land where the collector connects.
+                            PGPASSWORD="$OTEL_MONITOR_PASSWORD" psql -v ON_ERROR_STOP=1 -h postgresql2 -p 5432 -U otel_monitor -d otel -c "SELECT 1" > /dev/null
                         env:
                           - name: OTEL_MONITOR_PASSWORD
                             valueFrom:

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/postgres-dbm-sidecar.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/postgres-dbm-sidecar.yaml
@@ -8,7 +8,7 @@ metadata:
     meta.helm.sh/release-name: "example"
     meta.helm.sh/release-namespace: "default"
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -460,7 +460,7 @@ metadata:
     meta.helm.sh/release-name: "example"
     meta.helm.sh/release-namespace: "default"
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/secret-pg-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/secret-pg-monitoring.yaml
@@ -6,7 +6,7 @@ metadata:
   name: postgresql-pg-monitor-credentials
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -23,7 +23,7 @@ metadata:
   name: postgresql2-pg-monitor-credentials
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-eventbus.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-eventbus.yaml
@@ -5,7 +5,7 @@ kind: EventBus
 metadata:
   name: default
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-events-rbac.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-events-rbac.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-database-monitoring-argo-eventsource
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -17,7 +17,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-database-monitoring-argo-sensor
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -30,7 +30,7 @@ metadata:
   name: example-opentelemetry-database-monitoring-argo-eventsource
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -46,7 +46,7 @@ kind: Role
 metadata:
   name: example-opentelemetry-database-monitoring-argo-sensor
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -63,7 +63,7 @@ metadata:
   name: example-opentelemetry-database-monitoring-argo-eventsource
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -83,7 +83,7 @@ kind: RoleBinding
 metadata:
   name: example-opentelemetry-database-monitoring-argo-sensor
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-eventsource.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-eventsource.yaml
@@ -5,7 +5,7 @@ kind: EventSource
 metadata:
   name: example-opentelemetry-database-monitoring-pod-created
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-sensor.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-sensor.yaml
@@ -5,7 +5,7 @@ kind: Sensor
 metadata:
   name: example-opentelemetry-database-monitoring-postgresql-setup
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -39,7 +39,7 @@ spec:
                 generateName: postgresql-postgresql-monitoring-setup-
                 namespace: default
                 labels:
-                  helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+                  helm.sh/chart: opentelemetry-database-monitoring-0.1.2
                   app.kubernetes.io/name: opentelemetry-database-monitoring
                   app.kubernetes.io/instance: example
                   app.kubernetes.io/version: "1.16.0"
@@ -64,9 +64,13 @@ spec:
                           - /bin/sh
                           - -c
                           - |
+                            set -e
                             until pg_isready -h postgresql -p 5432 -U root; do sleep 2; done
-                            PGPASSWORD=otel psql -h postgresql -p 5432 -U root -d otel -f /scripts/monitoring-setup.sql
-                            PGPASSWORD=otel psql -h postgresql -p 5432 -U root -d otel -c "ALTER USER otel_monitor WITH PASSWORD '$OTEL_MONITOR_PASSWORD'"
+                            PGPASSWORD=otel psql -v ON_ERROR_STOP=1 -h postgresql -p 5432 -U root -d otel -f /scripts/monitoring-setup.sql
+                            PGPASSWORD=otel psql -v ON_ERROR_STOP=1 -h postgresql -p 5432 -U root -d otel -c "ALTER USER otel_monitor WITH PASSWORD '$OTEL_MONITOR_PASSWORD'"
+                            # Confirm the monitoring role is actually usable on the endpoint we reached;
+                            # fail (and let backoffLimit retry) if the setup did not land where the collector connects.
+                            PGPASSWORD="$OTEL_MONITOR_PASSWORD" psql -v ON_ERROR_STOP=1 -h postgresql -p 5432 -U otel_monitor -d otel -c "SELECT 1" > /dev/null
                         env:
                           - name: OTEL_MONITOR_PASSWORD
                             valueFrom:

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/postgres-dbm-sidecar.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/postgres-dbm-sidecar.yaml
@@ -8,7 +8,7 @@ metadata:
     meta.helm.sh/release-name: "example"
     meta.helm.sh/release-namespace: "default"
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/secret-pg-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/secret-pg-monitoring.yaml
@@ -6,7 +6,7 @@ metadata:
   name: postgresql-pg-monitor-credentials
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.1
+    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"

--- a/charts/opentelemetry-database-monitoring/templates/_job.tpl
+++ b/charts/opentelemetry-database-monitoring/templates/_job.tpl
@@ -41,9 +41,13 @@ spec:
             - /bin/sh
             - -c
             - |
+              set -e
               until pg_isready -h {{ $dbHost }} -p {{ $db.port }} -U {{ $db.user }}; do sleep 2; done
-              PGPASSWORD={{ $db.pwd }} psql -h {{ $dbHost }} -p {{ $db.port }} -U {{ $db.user }} -d otel -f /scripts/monitoring-setup.sql
-              PGPASSWORD={{ $db.pwd }} psql -h {{ $dbHost }} -p {{ $db.port }} -U {{ $db.user }} -d otel -c "ALTER USER otel_monitor WITH PASSWORD '$OTEL_MONITOR_PASSWORD'"
+              PGPASSWORD={{ $db.pwd }} psql -v ON_ERROR_STOP=1 -h {{ $dbHost }} -p {{ $db.port }} -U {{ $db.user }} -d otel -f /scripts/monitoring-setup.sql
+              PGPASSWORD={{ $db.pwd }} psql -v ON_ERROR_STOP=1 -h {{ $dbHost }} -p {{ $db.port }} -U {{ $db.user }} -d otel -c "ALTER USER otel_monitor WITH PASSWORD '$OTEL_MONITOR_PASSWORD'"
+              # Confirm the monitoring role is actually usable on the endpoint we reached;
+              # fail (and let backoffLimit retry) if the setup did not land where the collector connects.
+              PGPASSWORD="$OTEL_MONITOR_PASSWORD" psql -v ON_ERROR_STOP=1 -h {{ $dbHost }} -p {{ $db.port }} -U otel_monitor -d otel -c "SELECT 1" > /dev/null
           env:
             - name: OTEL_MONITOR_PASSWORD
               valueFrom:

--- a/charts/opentelemetry-database-monitoring/templates/job-pg-monitoring-setup.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/job-pg-monitoring-setup.yaml
@@ -32,9 +32,13 @@ spec:
             - /bin/sh
             - -c
             - |
+              set -e
               until pg_isready -h {{ $dbHost }} -p {{ $db.port }} -U {{ $db.user }}; do sleep 2; done
-              PGPASSWORD={{ $db.pwd }} psql -h {{ $dbHost }} -p {{ $db.port }} -U {{ $db.user }} -d otel -f /scripts/monitoring-setup.sql
-              PGPASSWORD={{ $db.pwd }} psql -h {{ $dbHost }} -p {{ $db.port }} -U {{ $db.user }} -d otel -c "ALTER USER otel_monitor WITH PASSWORD '$OTEL_MONITOR_PASSWORD'"
+              PGPASSWORD={{ $db.pwd }} psql -v ON_ERROR_STOP=1 -h {{ $dbHost }} -p {{ $db.port }} -U {{ $db.user }} -d otel -f /scripts/monitoring-setup.sql
+              PGPASSWORD={{ $db.pwd }} psql -v ON_ERROR_STOP=1 -h {{ $dbHost }} -p {{ $db.port }} -U {{ $db.user }} -d otel -c "ALTER USER otel_monitor WITH PASSWORD '$OTEL_MONITOR_PASSWORD'"
+              # Confirm the monitoring role is actually usable on the endpoint we reached;
+              # fail (and let backoffLimit retry) if the setup did not land where the collector connects.
+              PGPASSWORD="$OTEL_MONITOR_PASSWORD" psql -v ON_ERROR_STOP=1 -h {{ $dbHost }} -p {{ $db.port }} -U otel_monitor -d otel -c "SELECT 1" > /dev/null
           env:
             - name: OTEL_MONITOR_PASSWORD
               valueFrom:


### PR DESCRIPTION
## Background

Follow-up to #108. On the demo cluster, DB monitoring was down: the injected collector failed every scrape with

```
pq: password authentication failed for user "otel_monitor" (28P01)
```

`otel_monitor` did not exist on the live postgres, even though the monitoring **setup Job showed `Complete`**. Its pod log printed `DO` … `ALTER ROLE` — all "success".

## Why the Job lied

Two problems in the setup Job command (present in both the Argo Events path `_job.tpl` and the Helm-hook fallback `job-pg-monitoring-setup.yaml`):

1. **No `ON_ERROR_STOP`.** `psql -f …` exits `0` even when statements inside error out, so a genuinely failed setup still reports success.
2. **`DO` / `ALTER ROLE` succeed as no-ops.** The Job connects via the `postgresql` **Service**. During a rolling pod replacement, the Service can still route to the *terminating* pod (which already had the role): the `DO` create-block is a no-op, `ALTER ROLE` sets a password on the doomed pod, the Job exits `0` — and the **new** pod that takes over the endpoint never gets `otel_monitor`. Job Complete, monitoring broken.

## Change

Harden both Job paths:

- `set -e` + `psql -v ON_ERROR_STOP=1` on every psql call, so real SQL/connection errors fail the Job (and `backoffLimit` retries).
- A **verification step**: log in *as* `otel_monitor` with the intended password and run `SELECT 1`. Now a green Job means the monitoring role is actually usable on the endpoint the Job reached; otherwise it fails and retries.

Bumps chart `0.1.1` → `0.1.2`. README + rendered examples regenerated by the pre-commit hooks.

## Honest scope / limitation

This makes Job success **truthful** and adds a retry path — it does not fully eliminate the rolling-replacement race. If the verification connection *also* lands on the terminating pod, the Job can still pass while the new pod lacks the role, until a later trigger corrects it. Fully closing the race needs targeting the specific new pod (or a collector-driven re-trigger) and is out of scope here. The value of this PR: no more silent false-success, and self-healing via retries in the common case.

## Test plan

- [ ] Install `0.1.2`; confirm the setup Job completes and `otel_monitor` can `SELECT 1`.
- [ ] Point the Job at a DB where `otel_monitor` is missing/wrong-password; confirm the Job **fails** and retries (previously it passed).
- [ ] Confirm the collector sidecar scrapes cleanly (no `28P01`).