### PR TITLE
fix(kube-stack): render service.telemetry.resource as a map

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.3
+version: 0.7.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-kube-stack
 
-![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
+![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
 
 A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet + cluster receiver), secure credential management, and production-ready configurations for telemetry collection to Tsuga platform.
 

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
@@ -174,6 +174,4 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
-          attributes:
-          - name: service.instance.id
-            value: ${POD_UID}
+          service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/daemonset.yaml
@@ -271,6 +271,4 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
-          attributes:
-          - name: service.instance.id
-            value: ${POD_UID}
+          service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
@@ -174,6 +174,4 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
-          attributes:
-          - name: service.instance.id
-            value: ${POD_UID}
+          service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/daemonset.yaml
@@ -271,6 +271,4 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
-          attributes:
-          - name: service.instance.id
-            value: ${POD_UID}
+          service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
@@ -174,6 +174,4 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
-          attributes:
-          - name: service.instance.id
-            value: ${POD_UID}
+          service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
@@ -174,6 +174,4 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
-          attributes:
-          - name: service.instance.id
-            value: ${POD_UID}
+          service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/daemonset.yaml
@@ -271,6 +271,4 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
-          attributes:
-          - name: service.instance.id
-            value: ${POD_UID}
+          service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
@@ -174,6 +174,4 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
-          attributes:
-          - name: service.instance.id
-            value: ${POD_UID}
+          service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/daemonset.yaml
@@ -277,6 +277,4 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
-          attributes:
-          - name: service.instance.id
-            value: ${POD_UID}
+          service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
@@ -182,6 +182,4 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
-          attributes:
-          - name: service.instance.id
-            value: ${POD_UID}
+          service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/daemonset.yaml
@@ -271,6 +271,4 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
-          attributes:
-          - name: service.instance.id
-            value: ${POD_UID}
+          service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
@@ -182,6 +182,4 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
-          attributes:
-          - name: service.instance.id
-            value: ${POD_UID}
+          service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/daemonset.yaml
@@ -288,6 +288,4 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
-          attributes:
-          - name: service.instance.id
-            value: ${POD_UID}
+          service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/target-allocator/rendered/statefulset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/target-allocator/rendered/statefulset.yaml
@@ -175,6 +175,4 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
-          attributes:
-          - name: service.instance.id
-            value: ${POD_UID}
+          service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
@@ -149,6 +149,4 @@ spec:
           - k8s_cluster
       telemetry:
         resource:
-          attributes:
-          - name: service.instance.id
-            value: ${POD_UID}
+          service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/daemonset.yaml
@@ -246,6 +246,4 @@ spec:
           - otlp
       telemetry:
         resource:
-          attributes:
-          - name: service.instance.id
-            value: ${POD_UID}
+          service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/statefulset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/statefulset.yaml
@@ -150,6 +150,4 @@ spec:
           - prometheus
       telemetry:
         resource:
-          attributes:
-          - name: service.instance.id
-            value: ${POD_UID}
+          service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/templates/_config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_config.tpl
@@ -82,13 +82,10 @@ Generate Otel telemetry export
 {{- define "opentelemetry-kube-stack.otelTelemetry" -}}
 {{- include "opentelemetry-kube-stack.assertCollectorVersion" . -}}
 resource:
-  attributes:
-    {{- if .Values.clusterName }}
-    - name: k8s.cluster.name
-      value: {{ .Values.clusterName }}
-    {{- end}}
-    - name: service.instance.id
-      value: ${POD_UID}
+  {{- if .Values.clusterName }}
+  k8s.cluster.name: {{ .Values.clusterName }}
+  {{- end}}
+  service.instance.id: ${POD_UID}
 {{- if include "opentelemetry-kube-stack.tsugaEnabled" . }}
 metrics:
     readers:


### PR DESCRIPTION
## Problem

The OpenTelemetry Operator webhook rejects the generated collector CRs with:

```
failed to unmarshal telemetry configuration ... json: cannot unmarshal array
into Go struct field Telemetry.resource of type string
```

No `OpenTelemetryCollector` is created, so no collectors come up.

## Cause

The `otelTelemetry` helper (`templates/_config.tpl`) emitted `service.telemetry.resource` as an array of `{name, value}` objects:

```yaml
resource:
  attributes:
    - name: k8s.cluster.name
      value: <cluster>
    - name: service.instance.id
      value: ${POD_UID}
```

But the operator's v1beta1 config (through operator **v0.151.0**) unmarshals `service.telemetry` into a typed struct whose `resource` field is `map[string]string`. The array form fails admission.

## Fix

Render `resource` as a plain map — the only shape that both passes the operator webhook and parses in the collector:

```yaml
resource:
  k8s.cluster.name: <cluster>
  service.instance.id: ${POD_UID}
```

Note on the version tension: from **collector v0.151.0** the collector logs a deprecation warning preferring `resource.attributes` (the array) — but that array is exactly what the operator webhook (≤ v0.151.0) rejects. The map is accepted by the collector as the legacy inline form and is the only form that works across both. Operator v0.152.0+ drops the typed struct (`service.telemetry` becomes free-form), so both forms work there; the map remains the safe choice.

## Validation

Spun up a kind cluster with the bundled operator + CRDs and deployed the chart with `clusterName` set. Both `agent` (daemonset) and `cluster-receiver` collectors:
- passed the operator webhook (CRs created, no unmarshal error in operator logs)
- reached `Everything is ready. Begin running and processing data.` with `resource: {k8s.cluster.name, service.instance.id}` applied to internal telemetry

## Changes

- `templates/_config.tpl`: `resource` as map instead of `attributes` array
- Chart version `0.7.3` → `0.7.4` (+ README badge, re-rendered examples via pre-commit)

## Test plan

- [x] `helm unittest` — 34 tests pass
- [x] `helm template` renders `service.telemetry.resource` as a map
- [x] End-to-end on kind: operator accepts CRs, collectors run