### PR TITLE
Enable cluster.collectk8sobjects by default + memory limiter

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.4
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-kube-stack
 
-![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
 
 A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet + cluster receiver), secure credential management, and production-ready configurations for telemetry collection to Tsuga platform.
 
@@ -123,7 +123,7 @@ agent:
 
 **Default Receivers:**
 - **Kubernetes Cluster** (`k8s_cluster`): Collects cluster-level metrics and entity events
-- **Kubernetes Objects** (`k8s_objects`): Watches pods (only when `cluster.collectk8sobjects=true`)
+- **Kubernetes Objects** (`k8s_objects`): Watches pods (enabled by default, disable with `cluster.collectk8sobjects=false`)
 - **Prometheus (self)**: Scrapes the collector's own metrics from `localhost:8888`
 
 **Default Processors:**
@@ -344,7 +344,7 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | autoInstrumentation.nameOverride | string | "" | Override the name of the Instrumentation resource If empty, defaults to "<release-fullname>-instrumentation" |
 | autoInstrumentation.spec | object | {} | Instrumentation spec (full passthrough) This is passed directly to the Instrumentation Custom Resource spec. It can include (non-exhaustive): exporter, propagators, sampler, env, resource, and language blocks like java, nodejs, python, dotnet, go, apacheHttpd. Ref: https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#instrumentation |
 | cluster.affinity | object | {} | Cluster-specific affinity rules If not set, inherits from global affinity configuration |
-| cluster.collectk8sobjects | bool | `false` |  |
+| cluster.collectk8sobjects | bool | `true` |  |
 | cluster.config | object | `{"extraConnectors":{},"extraExporters":{},"extraProcessors":{},"extraReceivers":{},"extraTelemetry":{},"service":{"extraExtensions":[],"pipelines":{"extraPipelines":{},"logs":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"metrics":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"traces":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}}}}` | Gateway collector configuration (merge-based approach) Use this to extend the default configuration Default config includes: k8s_cluster receiver, k8s_attributes processor, resource processor |
 | cluster.config.extraConnectors | object | {} | Additional connectors to merge into the collector configuration These are merged with default connectors |
 | cluster.config.extraExporters | object | {} | Additional exporters to merge into the collector configuration These are merged with default exporters (otlp_http/tsuga) |

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-kube-stack
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
 
 A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet + cluster receiver), secure credential management, and production-ready configurations for telemetry collection to Tsuga platform.
 
@@ -127,6 +127,7 @@ agent:
 - **Prometheus (self)**: Scrapes the collector's own metrics from `localhost:8888`
 
 **Default Processors:**
+- **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit)
 - **Resource**: Adds `k8s.cluster.name` (only when `clusterName` is set)
 - **K8s Attributes**: Enriches telemetry with Kubernetes metadata and selected pod labels/annotations
 - **Batch**: Batches telemetry for efficient processing
@@ -135,8 +136,8 @@ agent:
 - **otlp_http/tsuga**: Forwards to the Tsuga endpoint (enabled unless `tsuga.enabledForClusterReceiver=false`)
 
 **Service Pipelines:**
-- **Metrics**: `k8s_cluster` → `resource`¹, `k8s_attributes`, `batch` → `otlp_http/tsuga`
-- **Entity Events (Logs)**: `k8s_cluster` (+`k8s_objects` when enabled) → `resource`¹, `k8s_attributes`, `batch` → `otlp_http/tsuga`
+- **Metrics**: `k8s_cluster` → `memory_limiter`, `resource`¹, `k8s_attributes`, `batch` → `otlp_http/tsuga`
+- **Entity Events (Logs)**: `k8s_cluster` (+`k8s_objects` when enabled) → `memory_limiter`, `resource`¹, `k8s_attributes`, `batch` → `otlp_http/tsuga`
 - **Metrics (collector self-telemetry)**: `prometheus/self` → `cumulativetodelta`, `resource/collector`, `batch` → `otlp_http/tsuga`
 
 ¹ The `resource` processor is only present when `clusterName` is set.

--- a/charts/opentelemetry-kube-stack/README.md.gotmpl
+++ b/charts/opentelemetry-kube-stack/README.md.gotmpl
@@ -117,6 +117,7 @@ agent:
 - **Prometheus (self)**: Scrapes the collector's own metrics from `localhost:8888`
 
 **Default Processors:**
+- **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit)
 - **Resource**: Adds `k8s.cluster.name` (only when `clusterName` is set)
 - **K8s Attributes**: Enriches telemetry with Kubernetes metadata and selected pod labels/annotations
 - **Batch**: Batches telemetry for efficient processing
@@ -125,8 +126,8 @@ agent:
 - **otlp_http/tsuga**: Forwards to the Tsuga endpoint (enabled unless `tsuga.enabledForClusterReceiver=false`)
 
 **Service Pipelines:**
-- **Metrics**: `k8s_cluster` → `resource`¹, `k8s_attributes`, `batch` → `otlp_http/tsuga`
-- **Entity Events (Logs)**: `k8s_cluster` (+`k8s_objects` when enabled) → `resource`¹, `k8s_attributes`, `batch` → `otlp_http/tsuga`
+- **Metrics**: `k8s_cluster` → `memory_limiter`, `resource`¹, `k8s_attributes`, `batch` → `otlp_http/tsuga`
+- **Entity Events (Logs)**: `k8s_cluster` (+`k8s_objects` when enabled) → `memory_limiter`, `resource`¹, `k8s_attributes`, `batch` → `otlp_http/tsuga`
 - **Metrics (collector self-telemetry)**: `prometheus/self` → `cumulativetodelta`, `resource/collector`, `batch` → `otlp_http/tsuga`
 
 ¹ The `resource` processor is only present when `clusterName` is set.

--- a/charts/opentelemetry-kube-stack/README.md.gotmpl
+++ b/charts/opentelemetry-kube-stack/README.md.gotmpl
@@ -113,7 +113,7 @@ agent:
 
 **Default Receivers:**
 - **Kubernetes Cluster** (`k8s_cluster`): Collects cluster-level metrics and entity events
-- **Kubernetes Objects** (`k8s_objects`): Watches pods (only when `cluster.collectk8sobjects=true`)
+- **Kubernetes Objects** (`k8s_objects`): Watches pods (enabled by default, disable with `cluster.collectk8sobjects=false`)
 - **Prometheus (self)**: Scrapes the collector's own metrics from `localhost:8888`
 
 **Default Processors:**

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
@@ -77,6 +77,13 @@ spec:
         - MemoryPressure
         - DiskPressure
         - PIDPressure
+      k8s_objects:
+        auth_type: serviceAccount
+        include_initial_state: true
+        objects:
+        - group: ""
+          mode: watch
+          name: pods
     processors:
       batch:
         send_batch_max_size: 5000
@@ -154,6 +161,7 @@ spec:
           - batch
           receivers:
           - k8s_cluster
+          - k8s_objects
         metrics:
           exporters:
           - otlp_http/tsuga

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
@@ -138,6 +138,10 @@ spec:
             name: k8s.pod.uid
         - sources:
           - from: connection
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
       resource/collector:
         attributes:
         - action: upsert
@@ -157,6 +161,7 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
+          - memory_limiter
           - k8s_attributes
           - batch
           receivers:
@@ -166,6 +171,7 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
+          - memory_limiter
           - k8s_attributes
           - batch
           receivers:

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
@@ -77,6 +77,13 @@ spec:
         - MemoryPressure
         - DiskPressure
         - PIDPressure
+      k8s_objects:
+        auth_type: serviceAccount
+        include_initial_state: true
+        objects:
+        - group: ""
+          mode: watch
+          name: pods
     processors:
       batch:
         send_batch_max_size: 5000
@@ -154,6 +161,7 @@ spec:
           - batch
           receivers:
           - k8s_cluster
+          - k8s_objects
         metrics:
           exporters:
           - otlp_http/tsuga

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
@@ -138,6 +138,10 @@ spec:
             name: k8s.pod.uid
         - sources:
           - from: connection
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
       resource/collector:
         attributes:
         - action: upsert
@@ -157,6 +161,7 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
+          - memory_limiter
           - k8s_attributes
           - batch
           receivers:
@@ -166,6 +171,7 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
+          - memory_limiter
           - k8s_attributes
           - batch
           receivers:

--- a/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
@@ -77,6 +77,13 @@ spec:
         - MemoryPressure
         - DiskPressure
         - PIDPressure
+      k8s_objects:
+        auth_type: serviceAccount
+        include_initial_state: true
+        objects:
+        - group: ""
+          mode: watch
+          name: pods
     processors:
       batch:
         send_batch_max_size: 5000
@@ -154,6 +161,7 @@ spec:
           - batch
           receivers:
           - k8s_cluster
+          - k8s_objects
         metrics:
           exporters:
           - otlp_http/tsuga

--- a/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
@@ -138,6 +138,10 @@ spec:
             name: k8s.pod.uid
         - sources:
           - from: connection
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
       resource/collector:
         attributes:
         - action: upsert
@@ -157,6 +161,7 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
+          - memory_limiter
           - k8s_attributes
           - batch
           receivers:
@@ -166,6 +171,7 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
+          - memory_limiter
           - k8s_attributes
           - batch
           receivers:

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
@@ -77,6 +77,13 @@ spec:
         - MemoryPressure
         - DiskPressure
         - PIDPressure
+      k8s_objects:
+        auth_type: serviceAccount
+        include_initial_state: true
+        objects:
+        - group: ""
+          mode: watch
+          name: pods
     processors:
       batch:
         send_batch_max_size: 5000
@@ -154,6 +161,7 @@ spec:
           - batch
           receivers:
           - k8s_cluster
+          - k8s_objects
         metrics:
           exporters:
           - otlp_http/tsuga

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
@@ -138,6 +138,10 @@ spec:
             name: k8s.pod.uid
         - sources:
           - from: connection
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
       resource/collector:
         attributes:
         - action: upsert
@@ -157,6 +161,7 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
+          - memory_limiter
           - k8s_attributes
           - batch
           receivers:
@@ -166,6 +171,7 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
+          - memory_limiter
           - k8s_attributes
           - batch
           receivers:

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
@@ -77,6 +77,13 @@ spec:
         - MemoryPressure
         - DiskPressure
         - PIDPressure
+      k8s_objects:
+        auth_type: serviceAccount
+        include_initial_state: true
+        objects:
+        - group: ""
+          mode: watch
+          name: pods
     processors:
       batch:
         send_batch_max_size: 5000
@@ -154,6 +161,7 @@ spec:
           - batch
           receivers:
           - k8s_cluster
+          - k8s_objects
         metrics:
           exporters:
           - otlp_http/tsuga

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
@@ -138,6 +138,10 @@ spec:
             name: k8s.pod.uid
         - sources:
           - from: connection
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
       resource/collector:
         attributes:
         - action: upsert
@@ -157,6 +161,7 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
+          - memory_limiter
           - k8s_attributes
           - batch
           receivers:
@@ -166,6 +171,7 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
+          - memory_limiter
           - k8s_attributes
           - batch
           receivers:

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
@@ -138,6 +138,10 @@ spec:
             name: k8s.pod.uid
         - sources:
           - from: connection
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
       resource/collector:
         attributes:
         - action: upsert
@@ -157,6 +161,7 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
+          - memory_limiter
           - k8s_attributes
           - batch
           receivers:
@@ -166,6 +171,7 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
+          - memory_limiter
           - k8s_attributes
           - batch
           receivers:

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
@@ -138,6 +138,10 @@ spec:
             name: k8s.pod.uid
         - sources:
           - from: connection
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
       resource/collector:
         attributes:
         - action: upsert
@@ -157,6 +161,7 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
+          - memory_limiter
           - k8s_attributes
           - batch
           receivers:
@@ -166,6 +171,7 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
+          - memory_limiter
           - k8s_attributes
           - batch
           receivers:

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
@@ -128,6 +128,10 @@ spec:
             name: k8s.pod.uid
         - sources:
           - from: connection
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
       resource/collector:
         attributes:
         - action: upsert
@@ -142,6 +146,7 @@ spec:
           exporters:
           - debug
           processors:
+          - memory_limiter
           - k8s_attributes
           - batch
           receivers:
@@ -151,6 +156,7 @@ spec:
           exporters:
           - debug
           processors:
+          - memory_limiter
           - k8s_attributes
           - batch
           receivers:

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
@@ -67,6 +67,13 @@ spec:
         - MemoryPressure
         - DiskPressure
         - PIDPressure
+      k8s_objects:
+        auth_type: serviceAccount
+        include_initial_state: true
+        objects:
+        - group: ""
+          mode: watch
+          name: pods
     processors:
       batch:
         send_batch_max_size: 5000
@@ -139,6 +146,7 @@ spec:
           - batch
           receivers:
           - k8s_cluster
+          - k8s_objects
         metrics:
           exporters:
           - debug

--- a/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
@@ -17,6 +17,10 @@ receivers:
         mode: watch
 {{- end }}
 processors:
+  memory_limiter:
+    check_interval: 5s
+    limit_percentage: 80
+    spike_limit_percentage: 25
   batch:
     # Trigger a send when the batch reaches 1000 items.
     send_batch_size: 5000
@@ -111,6 +115,7 @@ service:
         - k8s_objects
 {{- end }}
       processors:
+        - memory_limiter
         {{- if .Values.clusterName }}
         - resource
         {{- end }}
@@ -124,6 +129,7 @@ service:
       receivers:
         - k8s_cluster
       processors:
+        - memory_limiter
         {{- if .Values.clusterName }}
         - resource
         {{- end }}

--- a/charts/opentelemetry-kube-stack/tests/cluster-receiver_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/cluster-receiver_test.yaml
@@ -33,3 +33,36 @@ tests:
       - equal:
           path: spec.config.service.pipelines.logs.exporters
           value: []
+
+  - it: should collect k8s objects by default
+    set:
+      cluster.enabled: true
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - isKind:
+          of: OpenTelemetryCollector
+      - isNotNull:
+          path: spec.config.receivers.k8s_objects
+      - contains:
+          path: spec.config.service.pipelines.logs.receivers
+          content: k8s_objects
+
+  - it: should not collect k8s objects when disabled
+    set:
+      cluster.enabled: true
+      cluster.collectk8sobjects: false
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - isKind:
+          of: OpenTelemetryCollector
+      - isNull:
+          path: spec.config.receivers.k8s_objects
+      - notContains:
+          path: spec.config.service.pipelines.logs.receivers
+          content: k8s_objects

--- a/charts/opentelemetry-kube-stack/tests/cluster-receiver_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/cluster-receiver_test.yaml
@@ -66,3 +66,22 @@ tests:
       - notContains:
           path: spec.config.service.pipelines.logs.receivers
           content: k8s_objects
+
+  - it: should guard logs and metrics pipelines with memory_limiter first
+    set:
+      cluster.enabled: true
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - isKind:
+          of: OpenTelemetryCollector
+      - isNotNull:
+          path: spec.config.processors.memory_limiter
+      - equal:
+          path: spec.config.service.pipelines.logs.processors[0]
+          value: memory_limiter
+      - equal:
+          path: spec.config.service.pipelines.metrics.processors[0]
+          value: memory_limiter

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -248,7 +248,7 @@ cluster:
   # @default -- {}
   customConfig: {}
   # This is used in the Kubernetes view to show pod configuration
-  collectk8sobjects: false
+  collectk8sobjects: true
   # -- Gateway collector configuration (merge-based approach)
   # Use this to extend the default configuration
   # Default config includes: k8s_cluster receiver, k8s_attributes processor, resource processor


### PR DESCRIPTION
## Summary
Enables `cluster.collectk8sobjects` by default so the Kubernetes resource side panels in Tsuga are powered with k8s object configuration out of the box.

Also adds a `memory_limiter` processor to the cluster receiver pipelines, matching the agent DaemonSet and target allocator, since the extra `k8s_objects` watch load has no OOM guard otherwise.