### PR TITLE
feat(kube-stack)!: require clusterName, and fix collector pipeline defaults

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,14 @@ jobs:
 
       - name: Lint Helm chart
         run: |
-          helm lint charts/${{ matrix.chart }}
+          CHART="charts/${{ matrix.chart }}"
+          # Charts with required values (e.g. kube-stack's clusterName) cannot be
+          # linted against their own defaults, which are intentionally invalid.
+          if [ -f "$CHART/values_ci_test.yaml" ]; then
+            helm lint "$CHART" -f "$CHART/values_ci_test.yaml"
+          else
+            helm lint "$CHART"
+          fi
 
   unittest:
     needs: detect-charts

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releas
 **Option B: Install with this chart** by setting `opentelemetry-operator.enabled=true` in your `values.yaml` file or on the command line when installing:
 ```bash
 helm install my-opentelemetry-kube-stack tsuga-charts/opentelemetry-kube-stack \
+  --set clusterName="<CLUSTER_NAME>" \
   --set opentelemetry-operator.enabled=true
 ```
 
@@ -68,6 +69,7 @@ It is recommended to create a secret for the Tsuga API key and use it in the `va
 
 ```bash
 helm install my-otel-stack ./charts/opentelemetry-kube-stack \
+  --set clusterName="<CLUSTER_NAME>" \
   --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
   --set tsuga.apiKey="<TSUGA_API_KEY>"
 ```
@@ -75,6 +77,7 @@ helm install my-otel-stack ./charts/opentelemetry-kube-stack \
 **Option B: Use existing secret**
 ```bash
 helm install my-otel-stack ./charts/opentelemetry-kube-stack \
+  --set clusterName="<CLUSTER_NAME>" \
   --set secret.create=false \
   --set secret.name="my-existing-secret" \
   --set secret.keyMapping.TSUGA_API_KEY="<API_KEY_SECRET_KEY>" \
@@ -86,7 +89,8 @@ helm install my-otel-stack ./charts/opentelemetry-kube-stack \
 To install the opentelemetry-kube-stack chart:
 
 ```bash
-helm install my-opentelemetry-kube-stack tsuga-charts/opentelemetry-kube-stack
+helm install my-opentelemetry-kube-stack tsuga-charts/opentelemetry-kube-stack \
+  --set clusterName="<CLUSTER_NAME>"
 ```
 
 To uninstall the chart:

--- a/charts/opentelemetry-kube-stack/CHANGELOG.md
+++ b/charts/opentelemetry-kube-stack/CHANGELOG.md
@@ -15,24 +15,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [opentelemetry-kube-stack-0.7.4] - 2026-07-13
 
-### Changed
-- Making placeholders explicits by @gus-tsuga
-
 ### Fixed
 - Render service.telemetry.resource as a map (#111) by @abruneau in [#111](https://github.com/tsuga-dev/helm-charts/pull/111)
+
+### Changed
+- Making placeholders explicits by @gus-tsuga
 
 ## [opentelemetry-kube-stack-0.7.3] - 2026-07-01
 
 ### Added
 - Align demo and kube-stack with OTel naming conventions (#95) by @abruneau in [#95](https://github.com/tsuga-dev/helm-charts/pull/95)
 
+### Fixed
+- List-form telemetry headers + collector version guard (#107) by @abruneau in [#107](https://github.com/tsuga-dev/helm-charts/pull/107)
+
 ### Changed
 - Fix Old otel conventions (#98) by @abruneau in [#98](https://github.com/tsuga-dev/helm-charts/pull/98)
 - Docs/readme charts update (#104) by @abruneau in [#104](https://github.com/tsuga-dev/helm-charts/pull/104)
 - Remove payment log pod annotation and default to contrib image (#106) by @abruneau in [#106](https://github.com/tsuga-dev/helm-charts/pull/106)
-
-### Fixed
-- List-form telemetry headers + collector version guard (#107) by @abruneau in [#107](https://github.com/tsuga-dev/helm-charts/pull/107)
 
 ## [opentelemetry-kube-stack-0.7.2] - 2026-06-11
 
@@ -107,10 +107,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add schema for targetAllocator and statefulset values by @abruneau
 - Add target-allocator example by @abruneau
 
-### Changed
-- Add statefulset collector-TA link tests by @abruneau
-- Bump version by @abruneau
-
 ### Fixed
 - Make replicas conditional, document TA coupling by @abruneau
 - Guard TargetAllocator serviceAccount on serviceAccount.create by @abruneau
@@ -124,6 +120,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add net.host.name and cumulativetodelta to statefulset collector by @abruneau
 - Fix tolerations type for agent and cluster by @abruneau
 
+### Changed
+- Add statefulset collector-TA link tests by @abruneau
+- Bump version by @abruneau
+
 ## [opentelemetry-kube-stack-0.4.0] - 2026-02-17
 
 ### Added
@@ -131,13 +131,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make clusterName optional with warning by @abruneau
 - Document operator and cert-manager requirements by @abruneau
 
+### Fixed
+- Update gitignore and operator condition by @abruneau
+
 ### Changed
 - Add auto-instrumentation examples and testing framework by @abruneau
 - Remove unused otel-crds dependency by @abruneau
 - Bump version by @abruneau
-
-### Fixed
-- Update gitignore and operator condition by @abruneau
 
 ## [opentelemetry-kube-stack-0.3.0] - 2026-02-02
 
@@ -161,12 +161,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [opentelemetry-kube-stack-0.2.14] - 2026-01-12
 
+### Fixed
+- Fix custom config not being taken in count by @abruneau
+
 ### Changed
 - Enhance OpenTelemetry configuration by adding k8s_observer extension for improved Kubernetes resource observation. Update daemonset and service templates to include new logging receiver and adjust extraExtensions handling. by @abruneau
 - Bump version by @abruneau
-
-### Fixed
-- Fix custom config not being taken in count by @abruneau
 
 ## [opentelemetry-kube-stack-0.2.13] - 2026-01-12
 

--- a/charts/opentelemetry-kube-stack/CHANGELOG.md
+++ b/charts/opentelemetry-kube-stack/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [opentelemetry-kube-stack-0.9.0] - 2026-07-16
+
+### Added
+- Enable cluster.collectk8sobjects by default by @gus-tsuga
+
+### Fixed
+- Guard cluster receiver pipelines with memory_limiter by @gus-tsuga
+
+## [opentelemetry-kube-stack-0.7.4] - 2026-07-13
+
+### Changed
+- Making placeholders explicits by @gus-tsuga
+
+### Fixed
+- Render service.telemetry.resource as a map (#111) by @abruneau in [#111](https://github.com/tsuga-dev/helm-charts/pull/111)
+
 ## [opentelemetry-kube-stack-0.7.3] - 2026-07-01
 
 ### Added
@@ -242,6 +258,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - First commit by @abruneau
 - Add Makefile for example generation and validation; update Helm chart configurations by @abruneau
+[opentelemetry-kube-stack-0.9.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.7.4...opentelemetry-kube-stack-0.9.0
+
+[opentelemetry-kube-stack-0.7.4]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.7.3...opentelemetry-kube-stack-0.7.4
+
 [opentelemetry-kube-stack-0.7.3]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.7.2...opentelemetry-kube-stack-0.7.3
 
 [opentelemetry-kube-stack-0.7.2]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.7.1...opentelemetry-kube-stack-0.7.2

--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.9.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.1
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-kube-stack/Makefile
+++ b/charts/opentelemetry-kube-stack/Makefile
@@ -71,6 +71,7 @@ clean:
 install:
 	@echo "Installing chart with test values..."
 	helm install otel-test . \
+		--set clusterName="test-cluster" \
 		--set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
 		--set tsuga.apiKey="<TSUGA_API_KEY>" \
 		--wait --timeout=300s
@@ -84,6 +85,7 @@ uninstall:
 template:
 	@echo "Templating chart..."
 	helm template otel-test . \
+		--set clusterName="test-cluster" \
 		--set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
 		--set tsuga.apiKey="<TSUGA_API_KEY>"
 
@@ -91,6 +93,7 @@ template:
 dry-run:
 	@echo "Dry run installation..."
 	helm install otel-test . \
+		--set clusterName="test-cluster" \
 		--set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
 		--set tsuga.apiKey="<TSUGA_API_KEY>" \
 		--dry-run --debug

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-kube-stack
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
+![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
 
 A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet + cluster receiver), secure credential management, and production-ready configurations for telemetry collection to Tsuga platform.
 
@@ -51,18 +51,17 @@ The chart implements the recommended OpenTelemetry architecture with two main co
 - Uses host networking for optimal performance (configurable)
 
 **Default Receivers:**
-- **Host Metrics**: CPU, memory, disk, filesystem, load, paging, optional network and process metrics
-- **Kubelet Stats**: Node and pod metrics via kubelet
+- **Host Metrics** (`host_metrics`): CPU, memory, disk, filesystem, load, paging, optional network and process metrics. Pseudo filesystems (overlay, tmpfs, cgroup2, …) and container mount points are excluded to keep series counts sane.
+- **Kubelet Stats** (`kubelet_stats`): Node and pod metrics via kubelet
 - **OTLP**: Receives traces, metrics, and logs over gRPC (`:4317`) and HTTP (`:4318`)
-- **Prometheus (self)**: Scrapes the collector's own metrics from `localhost:8888`
-- **File Logs**: Collects container logs from `/var/log/pods/*/*/*.log` (controlled by `agent.collectLogs`)
+- **File Logs** (`file_log`): Collects container logs from `/var/log/pods/*/*/*.log` (controlled by `agent.collectLogs`)
 
 **Default Processors:**
-- **K8s Attributes**: Enriches telemetry with Kubernetes metadata and selected pod labels/annotations
-- **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit)
-- **Batch**: Batches telemetry for efficient processing (`send_batch_size`/`send_batch_max_size` = 5000)
+- **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit). Always first, so load is shed before the pipeline spends work on data it is about to reject.
+- **K8s Attributes** (`k8s_attributes`): Enriches telemetry with Kubernetes metadata and selected pod labels/annotations
+- **Resource**: Adds `k8s.node.name`, so host metrics are attributable to a node, plus `k8s.cluster.name` when `clusterName` is set
 - **Cumulative To Delta**: Converts cumulative counters to delta where applicable
-- **Resource**: Adds `k8s.cluster.name` (only when `clusterName` is set)
+- **Batch**: Batches telemetry for efficient processing (`send_batch_size`/`send_batch_max_size` = 5000). Always last.
 
 **Default Connectors:**
 - **Spanmetrics**: Generates RED metrics from spans (see dimensions below)
@@ -71,12 +70,11 @@ The chart implements the recommended OpenTelemetry architecture with two main co
 - **otlp_http/tsuga**: Forwards all telemetry to the Tsuga endpoint with authentication (enabled unless `tsuga.enabledForDaemonset=false`)
 
 **Service Pipelines:**
-- **Logs**: `otlp` (+`filelog` when `agent.collectLogs`) → `k8s_attributes`, `memory_limiter`, `batch`, `resource`¹ → `otlp_http/tsuga`
-- **Metrics**: `otlp`, `kubelet_stats`, `spanmetrics`, `host_metrics` → `k8s_attributes`, `memory_limiter`, `cumulativetodelta`, `resource`¹, `batch` → `otlp_http/tsuga`
-- **Traces**: `otlp` → `k8s_attributes`, `memory_limiter`, `resource`¹, `batch` → `otlp_http/tsuga`, `spanmetrics`
-- **Metrics (collector self-telemetry)**: `prometheus/self` → `memory_limiter`, `cumulativetodelta`, `resource/collector`, `batch` → `otlp_http/tsuga`
+- **Logs**: `otlp` (+`file_log` when `agent.collectLogs`) → `memory_limiter`, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`
+- **Metrics**: `otlp`, `kubelet_stats`, `span_metrics`, `host_metrics` → `memory_limiter`, `k8s_attributes`, `resource`, `cumulativetodelta`, `batch` → `otlp_http/tsuga`
+- **Traces**: `otlp` → `memory_limiter`, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`, `span_metrics`
 
-¹ The `resource` processor is only present when `clusterName` is set.
+Collector self-telemetry is exported through `service::telemetry`, not a pipeline.
 
 **Default Spanmetrics Dimensions:**
 - `http.request.method`
@@ -120,11 +118,11 @@ agent:
 ### Cluster Receiver (Deployment)
 
 - Collects cluster metrics and events using the Kubernetes API server
+- **Pinned to a single replica.** `k8s_cluster` and `k8s_objects` do not use leader election here, so a second replica would report the same cluster state again: every cluster metric counted twice and every object ingested twice. The replica count is set in the `OpenTelemetryCollector` resource, so a manual `kubectl scale` is reconciled back to 1.
 
 **Default Receivers:**
 - **Kubernetes Cluster** (`k8s_cluster`): Collects cluster-level metrics and entity events
 - **Kubernetes Objects** (`k8s_objects`): Watches pods (enabled by default, disable with `cluster.collectk8sobjects=false`)
-- **Prometheus (self)**: Scrapes the collector's own metrics from `localhost:8888`
 
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit)
@@ -138,9 +136,8 @@ agent:
 **Service Pipelines:**
 - **Metrics**: `k8s_cluster` → `memory_limiter`, `resource`¹, `k8s_attributes`, `batch` → `otlp_http/tsuga`
 - **Entity Events (Logs)**: `k8s_cluster` (+`k8s_objects` when enabled) → `memory_limiter`, `resource`¹, `k8s_attributes`, `batch` → `otlp_http/tsuga`
-- **Metrics (collector self-telemetry)**: `prometheus/self` → `cumulativetodelta`, `resource/collector`, `batch` → `otlp_http/tsuga`
 
-¹ The `resource` processor is only present when `clusterName` is set.
+¹ Only present when `clusterName` is set.
 
 ## Quick Start
 

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-kube-stack
 
-![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
 
 A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet + cluster receiver), secure credential management, and production-ready configurations for telemetry collection to Tsuga platform.
 
@@ -374,7 +374,7 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | cluster.nodeSelector | object | {} | Cluster-specific node selector If not set, inherits from global nodeSelector configuration |
 | cluster.resources | object | {} | Cluster-specific resource limits and requests If not set, inherits from global resources configuration |
 | cluster.tolerations | list | [] | Cluster-specific tolerations If not set, inherits from global tolerations configuration |
-| clusterName | string | "" | The name of the cluster to be used in the resource attributes This value is added to all telemetry data as k8s.cluster.name RECOMMENDED: Set this value to identify your cluster in telemetry data If not set, the k8s.cluster.name attribute will be omitted from telemetry |
+| clusterName | string | "" (must be set) | REQUIRED. The name of the cluster, added to all telemetry as k8s.cluster.name.  Installation fails if this is empty. Telemetry from a cluster that does not name itself cannot be told apart from any other cluster's once it reaches Tsuga, and the omission only becomes visible during an incident, which is the worst time to discover it.    --set clusterName=<name>  |
 | fullnameOverride | string | "" | Override the full name used in resource naming |
 | image | string | "" | Default OpenTelemetry Collector image Used as fallback when cluster.image or agent.image are not set Format: registry/repository:tag |
 | nameOverride | string | "" | Override the chart name used in resource naming |

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -59,7 +59,7 @@ The chart implements the recommended OpenTelemetry architecture with two main co
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit). Always first, so load is shed before the pipeline spends work on data it is about to reject.
 - **K8s Attributes** (`k8s_attributes`): Enriches telemetry with Kubernetes metadata and selected pod labels/annotations
-- **Resource**: Adds `k8s.node.name`, so host metrics are attributable to a node, plus `k8s.cluster.name` when `clusterName` is set
+- **Resource**: Adds `k8s.node.name`, so host metrics are attributable to a node, and `k8s.cluster.name`
 - **Cumulative To Delta**: Converts cumulative counters to delta where applicable
 - **Batch**: Batches telemetry for efficient processing (`send_batch_size`/`send_batch_max_size` = 5000). Always last.
 
@@ -126,7 +126,7 @@ agent:
 
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit)
-- **Resource**: Adds `k8s.cluster.name` (only when `clusterName` is set)
+- **Resource**: Adds `k8s.cluster.name`
 - **K8s Attributes**: Enriches telemetry with Kubernetes metadata and selected pod labels/annotations
 - **Batch**: Batches telemetry for efficient processing
 
@@ -134,10 +134,8 @@ agent:
 - **otlp_http/tsuga**: Forwards to the Tsuga endpoint (enabled unless `tsuga.enabledForClusterReceiver=false`)
 
 **Service Pipelines:**
-- **Metrics**: `k8s_cluster` → `memory_limiter`, `resource`¹, `k8s_attributes`, `batch` → `otlp_http/tsuga`
-- **Entity Events (Logs)**: `k8s_cluster` (+`k8s_objects` when enabled) → `memory_limiter`, `resource`¹, `k8s_attributes`, `batch` → `otlp_http/tsuga`
-
-¹ Only present when `clusterName` is set.
+- **Metrics**: `k8s_cluster` → `memory_limiter`, `resource`, `k8s_attributes`, `batch` → `otlp_http/tsuga`
+- **Entity Events (Logs)**: `k8s_cluster` (+`k8s_objects` when enabled) → `memory_limiter`, `resource`, `k8s_attributes`, `batch` → `otlp_http/tsuga`
 
 ## Quick Start
 
@@ -180,6 +178,7 @@ opentelemetry-operator:
 Or via command line:
 ```bash
 helm install my-otel-stack tsuga-charts/opentelemetry-kube-stack \
+  --set clusterName="<CLUSTER_NAME>" \
   --set opentelemetry-operator.enabled=true
 ```
 
@@ -197,6 +196,11 @@ kubectl wait --for=condition=Ready pods -l app.kubernetes.io/name=opentelemetry-
 ```
 
 ## Installation
+
+> **`clusterName` is required.** Installs and upgrades fail without it — it is
+> what distinguishes this cluster's telemetry from every other cluster's in
+> Tsuga. Existing installs that never set it must add
+> `--set clusterName=<name>` when upgrading.
 
 ## Auto-instrumentation (APM)
 
@@ -259,6 +263,7 @@ helm repo update
 
 # Install with Tsuga configuration
 helm install my-otel-stack tsuga-charts/opentelemetry-kube-stack \
+  --set clusterName="<CLUSTER_NAME>" \
   --set secret.create=true \
   --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
   --set tsuga.apiKey="<TSUGA_API_KEY>"
@@ -269,6 +274,7 @@ helm install my-otel-stack tsuga-charts/opentelemetry-kube-stack \
 ```bash
 # Install directly from the chart directory
 helm install my-otel-stack ./opentelemetry-kube-stack \
+  --set clusterName="<CLUSTER_NAME>" \
   --set secret.create=true \
   --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
   --set tsuga.apiKey="<TSUGA_API_KEY>"
@@ -279,6 +285,7 @@ helm install my-otel-stack ./opentelemetry-kube-stack \
 ```bash
 # Create a values file
 cat > my-values.yaml << EOF
+clusterName: "<CLUSTER_NAME>"
 tsuga:
   otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
   apiKey: "<TSUGA_API_KEY>"
@@ -510,7 +517,7 @@ helm lint .
 # Test rendering
 make template
 # or
-helm template test . --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" --set tsuga.apiKey="<TSUGA_API_KEY>"
+helm template test . --set clusterName="<CLUSTER_NAME>" --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" --set tsuga.apiKey="<TSUGA_API_KEY>"
 ```
 
 ### Documentation

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -51,7 +51,7 @@ The chart implements the recommended OpenTelemetry architecture with two main co
 - Uses host networking for optimal performance (configurable)
 
 **Default Receivers:**
-- **Host Metrics** (`host_metrics`): CPU, memory, disk, filesystem, load, paging, optional network and process metrics. Pseudo filesystems (overlay, tmpfs, cgroup2, …) and container mount points are excluded to keep series counts sane.
+- **Host Metrics** (`host_metrics`): CPU, memory, disk, filesystem, load, paging, optional network and process metrics. Kernel pseudo filesystems (overlay, cgroup2, proc, …) and container mount points are excluded to keep series counts sane — upstream's `fs_types`, with anchored mount-point regexes. `tmpfs` is kept: `/run` usage is worth watching.
 - **Kubelet Stats** (`kubelet_stats`): Node and pod metrics via kubelet
 - **OTLP**: Receives traces, metrics, and logs over gRPC (`:4317`) and HTTP (`:4318`)
 - **File Logs** (`file_log`): Collects container logs from `/var/log/pods/*/*/*.log` (controlled by `agent.collectLogs`)
@@ -59,7 +59,8 @@ The chart implements the recommended OpenTelemetry architecture with two main co
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit). Always first, so load is shed before the pipeline spends work on data it is about to reject.
 - **K8s Attributes** (`k8s_attributes`): Enriches telemetry with Kubernetes metadata and selected pod labels/annotations
-- **Resource**: Adds `k8s.node.name`, so host metrics are attributable to a node, and `k8s.cluster.name`
+- **Resource**: Adds `k8s.cluster.name` to everything
+- **Resource/node** (`resource/node`): Adds `k8s.node.name` from the downward API. Wired only into the node-local pipelines (`metrics/node`, `logs/node`), whose receivers read this node's kernel and log files. It is deliberately absent from the `otlp` pipelines: OTLP arrives over a Service that load-balances across every agent, so the receiving node is not the sending pod's node. `kubelet_stats` sets `k8s.node.name` itself and needs no stamp.
 - **Cumulative To Delta**: Converts cumulative counters to delta where applicable
 - **Batch**: Batches telemetry for efficient processing (`send_batch_size`/`send_batch_max_size` = 5000). Always last.
 
@@ -70,8 +71,10 @@ The chart implements the recommended OpenTelemetry architecture with two main co
 - **otlp_http/tsuga**: Forwards all telemetry to the Tsuga endpoint with authentication (enabled unless `tsuga.enabledForDaemonset=false`)
 
 **Service Pipelines:**
-- **Logs**: `otlp` (+`file_log` when `agent.collectLogs`) → `memory_limiter`, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`
-- **Metrics**: `otlp`, `kubelet_stats`, `span_metrics`, `host_metrics` → `memory_limiter`, `k8s_attributes`, `resource`, `cumulativetodelta`, `batch` → `otlp_http/tsuga`
+- **Logs**: `otlp` → `memory_limiter`, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`
+- **Logs/node** (when `agent.collectLogs`): `file_log` → `memory_limiter`, `k8s_attributes`, `resource`, `resource/node`, `batch` → `otlp_http/tsuga`
+- **Metrics**: `otlp`, `kubelet_stats`, `span_metrics` → `memory_limiter`, `k8s_attributes`, `resource`, `cumulativetodelta`, `batch` → `otlp_http/tsuga`
+- **Metrics/node**: `host_metrics` → `memory_limiter`, `k8s_attributes`, `resource`, `resource/node`, `cumulativetodelta`, `batch` → `otlp_http/tsuga`
 - **Traces**: `otlp` → `memory_limiter`, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`, `span_metrics`
 
 Collector self-telemetry is exported through `service::telemetry`, not a pipeline.
@@ -128,13 +131,14 @@ agent:
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit)
 - **Resource**: Adds `k8s.cluster.name`
 - **K8s Attributes**: Enriches telemetry with Kubernetes metadata and selected pod labels/annotations
+- **Cumulative To Delta**: Converts `k8s_cluster`'s cumulative counters to delta before export
 - **Batch**: Batches telemetry for efficient processing
 
 **Default Exporters:**
 - **otlp_http/tsuga**: Forwards to the Tsuga endpoint (enabled unless `tsuga.enabledForClusterReceiver=false`)
 
 **Service Pipelines:**
-- **Metrics**: `k8s_cluster` → `memory_limiter`, `resource`, `k8s_attributes`, `batch` → `otlp_http/tsuga`
+- **Metrics**: `k8s_cluster` → `memory_limiter`, `resource`, `k8s_attributes`, `cumulativetodelta`, `batch` → `otlp_http/tsuga`
 - **Entity Events (Logs)**: `k8s_cluster` (+`k8s_objects` when enabled) → `memory_limiter`, `resource`, `k8s_attributes`, `batch` → `otlp_http/tsuga`
 
 ## Quick Start
@@ -306,31 +310,39 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | affinity | object | {} | Affinity rules for pod scheduling Used as default when agent.affinity is not set |
 | agent.addLogsVolumes | bool | true | Add logs volumes to the agent When true, adds volumes for log collection Even if collectLogs is false, the volumes are added |
 | agent.affinity | object | {} | Agent-specific affinity rules If not set, inherits from global affinity configuration |
-| agent.collectLogs | bool | true | Collect logs from the host and containers When true, enables filelog receiver to collect logs from /var/log/pods Also mounts required volumes for log collection |
+| agent.collectLogs | bool | true | Collect logs from the host and containers When true, enables the file_log receiver to collect logs from /var/log/pods Also mounts required volumes for log collection |
 | agent.collectNetwork | bool | false | Collect host network metrics When true, enables network scraper in hostmetrics receiver |
 | agent.collectOtelLogs | bool | false | Collect OpenTelemetry collector logs When false (default), excludes the collector's own container logs to avoid a self-ingestion feedback loop that produces container-parser errors |
 | agent.collectProcesses | bool | false | Collect host processes metrics When true, enables processes and process scrapers in hostmetrics receiver |
-| agent.config | object | `{"extraConnectors":{},"extraExporters":{},"extraExtensions":{},"extraProcessors":{},"extraReceivers":{},"extraTelemetry":{},"service":{"extraExtensions":[],"pipelines":{"extraPipelines":{},"logs":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"metrics":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"traces":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}}}}` | Agent collector configuration (merge-based approach) Use this to extend the default configuration Default config includes: filelog, kubelet_stats, host_metrics, otlp, prometheus/self receivers Default processors: k8s_attributes, memory_limiter, batch, cumulativetodelta, resource |
+| agent.config | object | `{"extraConnectors":{},"extraExporters":{},"extraExtensions":{},"extraProcessors":{},"extraReceivers":{},"extraTelemetry":{},"service":{"extraExtensions":[],"pipelines":{"extraPipelines":{},"logs":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"logs/node":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"metrics":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"metrics/node":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"traces":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}}}}` | Agent collector configuration (merge-based approach) Use this to extend the default configuration Default receivers: file_log (when agent.collectLogs), kubelet_stats, host_metrics, otlp Default processors: memory_limiter, k8s_attributes, resource, resource/node, cumulativetodelta, batch Default connectors: span_metrics |
 | agent.config.extraConnectors | object | {} | Additional connectors to merge into the collector configuration These are merged with default connectors |
 | agent.config.extraExporters | object | {} | Additional exporters to merge into the collector configuration These are merged with default exporters (otlp_http/tsuga) |
 | agent.config.extraExtensions | object | {} | Additional extensions to merge into the collector configuration These are merged with default extensions (health_check) |
 | agent.config.extraProcessors | object | {} | Additional processors to merge into the collector configuration These are merged with default processors |
 | agent.config.extraReceivers | object | {} | Additional receivers to merge into the collector configuration These are merged with default receivers |
 | agent.config.extraTelemetry | object | {} | Additional telemetry to merge into the collector configuration Merges with default telemetry (Prometheus metrics on port 8888) |
-| agent.config.service | object | `{"extraExtensions":[],"pipelines":{"extraPipelines":{},"logs":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"metrics":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"traces":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}}}` | Service configuration |
+| agent.config.service | object | `{"extraExtensions":[],"pipelines":{"extraPipelines":{},"logs":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"logs/node":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"metrics":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"metrics/node":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"traces":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}}}` | Service configuration |
 | agent.config.service.extraExtensions | list | [] | Additional extensions to add to the service configuration Added to default extensions (health_check) |
-| agent.config.service.pipelines | object | `{"extraPipelines":{},"logs":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"metrics":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"traces":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}}` | Pipeline configuration |
-| agent.config.service.pipelines.logs | object | `{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}` | Logs pipeline configuration |
+| agent.config.service.pipelines | object | `{"extraPipelines":{},"logs":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"logs/node":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"metrics":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"metrics/node":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"traces":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}}` | Pipeline configuration |
+| agent.config.service.pipelines.logs | object | `{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}` | Logs pipeline configuration (otlp only; node-local log sources live in the logs/node pipeline) |
 | agent.config.service.pipelines.logs.extraExporters | list | [] | Additional exporters to add to the logs pipeline Added to default exporter (otlp_http/tsuga) |
-| agent.config.service.pipelines.logs.extraProcessors | list | [] | Additional processors to add to the logs pipeline Added to default processors (k8s_attributes, memory_limiter, batch, resource) |
-| agent.config.service.pipelines.logs.extraReceivers | list | [] | Additional receivers to add to the logs pipeline Added to default receivers (otlp, filelog) |
-| agent.config.service.pipelines.metrics | object | `{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}` | Metrics pipeline configuration |
+| agent.config.service.pipelines.logs.extraProcessors | list | [] | Additional processors to add to the logs pipeline Added to default processors (memory_limiter, k8s_attributes, resource, batch) |
+| agent.config.service.pipelines.logs.extraReceivers | list | [] | Additional receivers to add to the logs pipeline Added to default receivers (otlp) |
+| agent.config.service.pipelines.logs/node | object | `{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}` | Node-local logs pipeline configuration (rendered only when agent.collectLogs is true) |
+| agent.config.service.pipelines.logs/node.extraExporters | list | [] | Additional exporters to add to the logs/node pipeline Added to default exporter (otlp_http/tsuga) |
+| agent.config.service.pipelines.logs/node.extraProcessors | list | [] | Additional processors to add to the logs/node pipeline Added to default processors (memory_limiter, k8s_attributes, resource, resource/node, batch) |
+| agent.config.service.pipelines.logs/node.extraReceivers | list | [] | Additional receivers to add to the logs/node pipeline Added to default receivers (file_log) |
+| agent.config.service.pipelines.metrics | object | `{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}` | Metrics pipeline configuration (node-local metric sources live in the metrics/node pipeline) |
 | agent.config.service.pipelines.metrics.extraExporters | list | [] | Additional exporters to add to the metrics pipeline Added to default exporter (otlp_http/tsuga) |
-| agent.config.service.pipelines.metrics.extraProcessors | list | [] | Additional processors to add to the metrics pipeline Added to default processors (k8s_attributes, memory_limiter, batch, cumulativetodelta, resource) |
-| agent.config.service.pipelines.metrics.extraReceivers | list | [] | Additional receivers to add to the metrics pipeline Added to default receivers (otlp, kubelet_stats, spanmetrics, host_metrics) |
+| agent.config.service.pipelines.metrics.extraProcessors | list | [] | Additional processors to add to the metrics pipeline Added to default processors (memory_limiter, k8s_attributes, resource, cumulativetodelta, batch) |
+| agent.config.service.pipelines.metrics.extraReceivers | list | [] | Additional receivers to add to the metrics pipeline Added to default receivers (otlp, kubelet_stats, span_metrics) |
+| agent.config.service.pipelines.metrics/node | object | `{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}` | Node-local metrics pipeline configuration |
+| agent.config.service.pipelines.metrics/node.extraExporters | list | [] | Additional exporters to add to the metrics/node pipeline Added to default exporter (otlp_http/tsuga) |
+| agent.config.service.pipelines.metrics/node.extraProcessors | list | [] | Additional processors to add to the metrics/node pipeline Added to default processors (memory_limiter, k8s_attributes, resource, resource/node, cumulativetodelta, batch) |
+| agent.config.service.pipelines.metrics/node.extraReceivers | list | [] | Additional receivers to add to the metrics/node pipeline Added to default receivers (host_metrics) |
 | agent.config.service.pipelines.traces | object | `{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}` | Traces pipeline configuration |
-| agent.config.service.pipelines.traces.extraExporters | list | [] | Additional exporters to add to the traces pipeline Added to default exporters (otlp_http/tsuga, spanmetrics) |
-| agent.config.service.pipelines.traces.extraProcessors | list | [] | Additional processors to add to the traces pipeline Added to default processors (k8s_attributes, memory_limiter, batch, resource) |
+| agent.config.service.pipelines.traces.extraExporters | list | [] | Additional exporters to add to the traces pipeline Added to default exporters (otlp_http/tsuga, span_metrics) |
+| agent.config.service.pipelines.traces.extraProcessors | list | [] | Additional processors to add to the traces pipeline Added to default processors (memory_limiter, k8s_attributes, resource, batch) |
 | agent.config.service.pipelines.traces.extraReceivers | list | [] | Additional receivers to add to the traces pipeline Added to default receivers (otlp) |
 | agent.customConfig | object | {} | Replace default config with complete custom configuration When set, this completely replaces the default collector configuration Use this for full control over the OpenTelemetry Collector config See cluster.customConfig for example format |
 | agent.enabled | bool | true | Enable agent daemonset deployment |
@@ -350,11 +362,11 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | autoInstrumentation.spec | object | {} | Instrumentation spec (full passthrough) This is passed directly to the Instrumentation Custom Resource spec. It can include (non-exhaustive): exporter, propagators, sampler, env, resource, and language blocks like java, nodejs, python, dotnet, go, apacheHttpd. Ref: https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#instrumentation |
 | cluster.affinity | object | {} | Cluster-specific affinity rules If not set, inherits from global affinity configuration |
 | cluster.collectk8sobjects | bool | `true` |  |
-| cluster.config | object | `{"extraConnectors":{},"extraExporters":{},"extraProcessors":{},"extraReceivers":{},"extraTelemetry":{},"service":{"extraExtensions":[],"pipelines":{"extraPipelines":{},"logs":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"metrics":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"traces":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}}}}` | Gateway collector configuration (merge-based approach) Use this to extend the default configuration Default config includes: k8s_cluster receiver, k8s_attributes processor, resource processor |
+| cluster.config | object | `{"extraConnectors":{},"extraExporters":{},"extraProcessors":{},"extraReceivers":{},"extraTelemetry":{},"service":{"extraExtensions":[],"pipelines":{"extraPipelines":{},"logs":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"metrics":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"traces":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}}}}` | Gateway collector configuration (merge-based approach) Use this to extend the default configuration Default receivers: k8s_cluster, k8s_objects (when cluster.collectk8sobjects) Default processors: memory_limiter, resource, k8s_attributes, cumulativetodelta, batch |
 | cluster.config.extraConnectors | object | {} | Additional connectors to merge into the collector configuration These are merged with default connectors |
 | cluster.config.extraExporters | object | {} | Additional exporters to merge into the collector configuration These are merged with default exporters (otlp_http/tsuga) |
-| cluster.config.extraProcessors | object | {} | Additional processors to merge into the collector configuration These are merged with default processors (k8s_attributes, resource) |
-| cluster.config.extraReceivers | object | {} | Additional receivers to merge into the collector configuration These are merged with default receivers (k8s_cluster) Example:   extraReceivers:     prometheus:       config:         scrape_configs:           - job_name: 'my-service' |
+| cluster.config.extraProcessors | object | {} | Additional processors to merge into the collector configuration These are merged with default processors (memory_limiter, resource, k8s_attributes, cumulativetodelta, batch) |
+| cluster.config.extraReceivers | object | {} | Additional receivers to merge into the collector configuration These are merged with default receivers (k8s_cluster, k8s_objects) Example:   extraReceivers:     prometheus:       config:         scrape_configs:           - job_name: 'my-service' |
 | cluster.config.extraTelemetry | object | {} | Additional telemetry to merge into the collector configuration Merges with default telemetry |
 | cluster.config.service | object | `{"extraExtensions":[],"pipelines":{"extraPipelines":{},"logs":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"metrics":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"traces":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}}}` | Service configuration |
 | cluster.config.service.extraExtensions | list | [] | Additional extensions to add to the service configuration Added to default extensions |

--- a/charts/opentelemetry-kube-stack/README.md.gotmpl
+++ b/charts/opentelemetry-kube-stack/README.md.gotmpl
@@ -41,7 +41,7 @@ The chart implements the recommended OpenTelemetry architecture with two main co
 - Uses host networking for optimal performance (configurable)
 
 **Default Receivers:**
-- **Host Metrics** (`host_metrics`): CPU, memory, disk, filesystem, load, paging, optional network and process metrics. Pseudo filesystems (overlay, tmpfs, cgroup2, …) and container mount points are excluded to keep series counts sane.
+- **Host Metrics** (`host_metrics`): CPU, memory, disk, filesystem, load, paging, optional network and process metrics. Kernel pseudo filesystems (overlay, cgroup2, proc, …) and container mount points are excluded to keep series counts sane — upstream's `fs_types`, with anchored mount-point regexes. `tmpfs` is kept: `/run` usage is worth watching.
 - **Kubelet Stats** (`kubelet_stats`): Node and pod metrics via kubelet
 - **OTLP**: Receives traces, metrics, and logs over gRPC (`:4317`) and HTTP (`:4318`)
 - **File Logs** (`file_log`): Collects container logs from `/var/log/pods/*/*/*.log` (controlled by `agent.collectLogs`)
@@ -49,7 +49,8 @@ The chart implements the recommended OpenTelemetry architecture with two main co
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit). Always first, so load is shed before the pipeline spends work on data it is about to reject.
 - **K8s Attributes** (`k8s_attributes`): Enriches telemetry with Kubernetes metadata and selected pod labels/annotations
-- **Resource**: Adds `k8s.node.name`, so host metrics are attributable to a node, and `k8s.cluster.name`
+- **Resource**: Adds `k8s.cluster.name` to everything
+- **Resource/node** (`resource/node`): Adds `k8s.node.name` from the downward API. Wired only into the node-local pipelines (`metrics/node`, `logs/node`), whose receivers read this node's kernel and log files. It is deliberately absent from the `otlp` pipelines: OTLP arrives over a Service that load-balances across every agent, so the receiving node is not the sending pod's node. `kubelet_stats` sets `k8s.node.name` itself and needs no stamp.
 - **Cumulative To Delta**: Converts cumulative counters to delta where applicable
 - **Batch**: Batches telemetry for efficient processing (`send_batch_size`/`send_batch_max_size` = 5000). Always last.
 
@@ -60,8 +61,10 @@ The chart implements the recommended OpenTelemetry architecture with two main co
 - **otlp_http/tsuga**: Forwards all telemetry to the Tsuga endpoint with authentication (enabled unless `tsuga.enabledForDaemonset=false`)
 
 **Service Pipelines:**
-- **Logs**: `otlp` (+`file_log` when `agent.collectLogs`) → `memory_limiter`, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`
-- **Metrics**: `otlp`, `kubelet_stats`, `span_metrics`, `host_metrics` → `memory_limiter`, `k8s_attributes`, `resource`, `cumulativetodelta`, `batch` → `otlp_http/tsuga`
+- **Logs**: `otlp` → `memory_limiter`, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`
+- **Logs/node** (when `agent.collectLogs`): `file_log` → `memory_limiter`, `k8s_attributes`, `resource`, `resource/node`, `batch` → `otlp_http/tsuga`
+- **Metrics**: `otlp`, `kubelet_stats`, `span_metrics` → `memory_limiter`, `k8s_attributes`, `resource`, `cumulativetodelta`, `batch` → `otlp_http/tsuga`
+- **Metrics/node**: `host_metrics` → `memory_limiter`, `k8s_attributes`, `resource`, `resource/node`, `cumulativetodelta`, `batch` → `otlp_http/tsuga`
 - **Traces**: `otlp` → `memory_limiter`, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`, `span_metrics`
 
 Collector self-telemetry is exported through `service::telemetry`, not a pipeline.
@@ -118,13 +121,14 @@ agent:
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit)
 - **Resource**: Adds `k8s.cluster.name`
 - **K8s Attributes**: Enriches telemetry with Kubernetes metadata and selected pod labels/annotations
+- **Cumulative To Delta**: Converts `k8s_cluster`'s cumulative counters to delta before export
 - **Batch**: Batches telemetry for efficient processing
 
 **Default Exporters:**
 - **otlp_http/tsuga**: Forwards to the Tsuga endpoint (enabled unless `tsuga.enabledForClusterReceiver=false`)
 
 **Service Pipelines:**
-- **Metrics**: `k8s_cluster` → `memory_limiter`, `resource`, `k8s_attributes`, `batch` → `otlp_http/tsuga`
+- **Metrics**: `k8s_cluster` → `memory_limiter`, `resource`, `k8s_attributes`, `cumulativetodelta`, `batch` → `otlp_http/tsuga`
 - **Entity Events (Logs)**: `k8s_cluster` (+`k8s_objects` when enabled) → `memory_limiter`, `resource`, `k8s_attributes`, `batch` → `otlp_http/tsuga`
 
 ## Quick Start

--- a/charts/opentelemetry-kube-stack/README.md.gotmpl
+++ b/charts/opentelemetry-kube-stack/README.md.gotmpl
@@ -49,7 +49,7 @@ The chart implements the recommended OpenTelemetry architecture with two main co
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit). Always first, so load is shed before the pipeline spends work on data it is about to reject.
 - **K8s Attributes** (`k8s_attributes`): Enriches telemetry with Kubernetes metadata and selected pod labels/annotations
-- **Resource**: Adds `k8s.node.name`, so host metrics are attributable to a node, plus `k8s.cluster.name` when `clusterName` is set
+- **Resource**: Adds `k8s.node.name`, so host metrics are attributable to a node, and `k8s.cluster.name`
 - **Cumulative To Delta**: Converts cumulative counters to delta where applicable
 - **Batch**: Batches telemetry for efficient processing (`send_batch_size`/`send_batch_max_size` = 5000). Always last.
 
@@ -116,7 +116,7 @@ agent:
 
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit)
-- **Resource**: Adds `k8s.cluster.name` (only when `clusterName` is set)
+- **Resource**: Adds `k8s.cluster.name`
 - **K8s Attributes**: Enriches telemetry with Kubernetes metadata and selected pod labels/annotations
 - **Batch**: Batches telemetry for efficient processing
 
@@ -124,10 +124,8 @@ agent:
 - **otlp_http/tsuga**: Forwards to the Tsuga endpoint (enabled unless `tsuga.enabledForClusterReceiver=false`)
 
 **Service Pipelines:**
-- **Metrics**: `k8s_cluster` → `memory_limiter`, `resource`¹, `k8s_attributes`, `batch` → `otlp_http/tsuga`
-- **Entity Events (Logs)**: `k8s_cluster` (+`k8s_objects` when enabled) → `memory_limiter`, `resource`¹, `k8s_attributes`, `batch` → `otlp_http/tsuga`
-
-¹ Only present when `clusterName` is set.
+- **Metrics**: `k8s_cluster` → `memory_limiter`, `resource`, `k8s_attributes`, `batch` → `otlp_http/tsuga`
+- **Entity Events (Logs)**: `k8s_cluster` (+`k8s_objects` when enabled) → `memory_limiter`, `resource`, `k8s_attributes`, `batch` → `otlp_http/tsuga`
 
 ## Quick Start
 
@@ -170,6 +168,7 @@ opentelemetry-operator:
 Or via command line:
 ```bash
 helm install my-otel-stack tsuga-charts/opentelemetry-kube-stack \
+  --set clusterName="<CLUSTER_NAME>" \
   --set opentelemetry-operator.enabled=true
 ```
 
@@ -187,6 +186,12 @@ kubectl wait --for=condition=Ready pods -l app.kubernetes.io/name=opentelemetry-
 ```
 
 ## Installation
+
+> **`clusterName` is required.** Installs and upgrades fail without it — it is
+> what distinguishes this cluster's telemetry from every other cluster's in
+> Tsuga. Existing installs that never set it must add
+> `--set clusterName=<name>` when upgrading.
+
 
 ## Auto-instrumentation (APM)
 
@@ -249,6 +254,7 @@ helm repo update
 
 # Install with Tsuga configuration
 helm install my-otel-stack tsuga-charts/opentelemetry-kube-stack \
+  --set clusterName="<CLUSTER_NAME>" \
   --set secret.create=true \
   --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
   --set tsuga.apiKey="<TSUGA_API_KEY>"
@@ -259,6 +265,7 @@ helm install my-otel-stack tsuga-charts/opentelemetry-kube-stack \
 ```bash
 # Install directly from the chart directory
 helm install my-otel-stack ./opentelemetry-kube-stack \
+  --set clusterName="<CLUSTER_NAME>" \
   --set secret.create=true \
   --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
   --set tsuga.apiKey="<TSUGA_API_KEY>"
@@ -269,6 +276,7 @@ helm install my-otel-stack ./opentelemetry-kube-stack \
 ```bash
 # Create a values file
 cat > my-values.yaml << EOF
+clusterName: "<CLUSTER_NAME>"
 tsuga:
   otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
   apiKey: "<TSUGA_API_KEY>"
@@ -349,7 +357,7 @@ helm lint .
 # Test rendering
 make template
 # or
-helm template test . --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" --set tsuga.apiKey="<TSUGA_API_KEY>"
+helm template test . --set clusterName="<CLUSTER_NAME>" --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" --set tsuga.apiKey="<TSUGA_API_KEY>"
 ```
 
 ### Documentation

--- a/charts/opentelemetry-kube-stack/README.md.gotmpl
+++ b/charts/opentelemetry-kube-stack/README.md.gotmpl
@@ -41,18 +41,17 @@ The chart implements the recommended OpenTelemetry architecture with two main co
 - Uses host networking for optimal performance (configurable)
 
 **Default Receivers:**
-- **Host Metrics**: CPU, memory, disk, filesystem, load, paging, optional network and process metrics
-- **Kubelet Stats**: Node and pod metrics via kubelet
+- **Host Metrics** (`host_metrics`): CPU, memory, disk, filesystem, load, paging, optional network and process metrics. Pseudo filesystems (overlay, tmpfs, cgroup2, …) and container mount points are excluded to keep series counts sane.
+- **Kubelet Stats** (`kubelet_stats`): Node and pod metrics via kubelet
 - **OTLP**: Receives traces, metrics, and logs over gRPC (`:4317`) and HTTP (`:4318`)
-- **Prometheus (self)**: Scrapes the collector's own metrics from `localhost:8888`
-- **File Logs**: Collects container logs from `/var/log/pods/*/*/*.log` (controlled by `agent.collectLogs`)
+- **File Logs** (`file_log`): Collects container logs from `/var/log/pods/*/*/*.log` (controlled by `agent.collectLogs`)
 
 **Default Processors:**
-- **K8s Attributes**: Enriches telemetry with Kubernetes metadata and selected pod labels/annotations
-- **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit)
-- **Batch**: Batches telemetry for efficient processing (`send_batch_size`/`send_batch_max_size` = 5000)
+- **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit). Always first, so load is shed before the pipeline spends work on data it is about to reject.
+- **K8s Attributes** (`k8s_attributes`): Enriches telemetry with Kubernetes metadata and selected pod labels/annotations
+- **Resource**: Adds `k8s.node.name`, so host metrics are attributable to a node, plus `k8s.cluster.name` when `clusterName` is set
 - **Cumulative To Delta**: Converts cumulative counters to delta where applicable
-- **Resource**: Adds `k8s.cluster.name` (only when `clusterName` is set)
+- **Batch**: Batches telemetry for efficient processing (`send_batch_size`/`send_batch_max_size` = 5000). Always last.
 
 **Default Connectors:**
 - **Spanmetrics**: Generates RED metrics from spans (see dimensions below)
@@ -61,12 +60,11 @@ The chart implements the recommended OpenTelemetry architecture with two main co
 - **otlp_http/tsuga**: Forwards all telemetry to the Tsuga endpoint with authentication (enabled unless `tsuga.enabledForDaemonset=false`)
 
 **Service Pipelines:**
-- **Logs**: `otlp` (+`filelog` when `agent.collectLogs`) → `k8s_attributes`, `memory_limiter`, `batch`, `resource`¹ → `otlp_http/tsuga`
-- **Metrics**: `otlp`, `kubelet_stats`, `spanmetrics`, `host_metrics` → `k8s_attributes`, `memory_limiter`, `cumulativetodelta`, `resource`¹, `batch` → `otlp_http/tsuga`
-- **Traces**: `otlp` → `k8s_attributes`, `memory_limiter`, `resource`¹, `batch` → `otlp_http/tsuga`, `spanmetrics`
-- **Metrics (collector self-telemetry)**: `prometheus/self` → `memory_limiter`, `cumulativetodelta`, `resource/collector`, `batch` → `otlp_http/tsuga`
+- **Logs**: `otlp` (+`file_log` when `agent.collectLogs`) → `memory_limiter`, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`
+- **Metrics**: `otlp`, `kubelet_stats`, `span_metrics`, `host_metrics` → `memory_limiter`, `k8s_attributes`, `resource`, `cumulativetodelta`, `batch` → `otlp_http/tsuga`
+- **Traces**: `otlp` → `memory_limiter`, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`, `span_metrics`
 
-¹ The `resource` processor is only present when `clusterName` is set.
+Collector self-telemetry is exported through `service::telemetry`, not a pipeline.
 
 **Default Spanmetrics Dimensions:**
 - `http.request.method`
@@ -110,11 +108,11 @@ agent:
 ### Cluster Receiver (Deployment)
 
 - Collects cluster metrics and events using the Kubernetes API server
+- **Pinned to a single replica.** `k8s_cluster` and `k8s_objects` do not use leader election here, so a second replica would report the same cluster state again: every cluster metric counted twice and every object ingested twice. The replica count is set in the `OpenTelemetryCollector` resource, so a manual `kubectl scale` is reconciled back to 1.
 
 **Default Receivers:**
 - **Kubernetes Cluster** (`k8s_cluster`): Collects cluster-level metrics and entity events
 - **Kubernetes Objects** (`k8s_objects`): Watches pods (enabled by default, disable with `cluster.collectk8sobjects=false`)
-- **Prometheus (self)**: Scrapes the collector's own metrics from `localhost:8888`
 
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit)
@@ -128,9 +126,8 @@ agent:
 **Service Pipelines:**
 - **Metrics**: `k8s_cluster` → `memory_limiter`, `resource`¹, `k8s_attributes`, `batch` → `otlp_http/tsuga`
 - **Entity Events (Logs)**: `k8s_cluster` (+`k8s_objects` when enabled) → `memory_limiter`, `resource`¹, `k8s_attributes`, `batch` → `otlp_http/tsuga`
-- **Metrics (collector self-telemetry)**: `prometheus/self` → `cumulativetodelta`, `resource/collector`, `batch` → `otlp_http/tsuga`
 
-¹ The `resource` processor is only present when `clusterName` is set.
+¹ Only present when `clusterName` is set.
 
 ## Quick Start
 

--- a/charts/opentelemetry-kube-stack/cliff.toml
+++ b/charts/opentelemetry-kube-stack/cliff.toml
@@ -24,9 +24,12 @@ https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
 ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {%- for group, commits in grouped_commits %}
 
-### {{ group | upper_first }}
+### {{ group | striptags | trim | upper_first }}
 {%- for commit in commits %}
-- {{ commit.message | split(pat="\n") | first | upper_first | trim }}{% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}{% if commit.remote.pr_number %} in [#{{ commit.remote.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.remote.pr_number }}){% endif %}
+- {% if commit.breaking %}**BREAKING** {% endif %}{{ commit.message | split(pat="\n") | first | upper_first | trim }}{% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}{% if commit.remote.pr_number %} in [#{{ commit.remote.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.remote.pr_number }}){% endif %}
+{%- if commit.breaking and commit.breaking_description and commit.breaking_description != commit.message %}
+  {{ commit.breaking_description | split(pat="\n") | first | upper_first | trim }}
+{%- endif %}
 {%- endfor %}
 {%- endfor %}
 {%- if first_time_contributors | length != 0 %}
@@ -63,16 +66,20 @@ exclude_paths = ["charts/opentelemetry-kube-stack/CHANGELOG.md", "charts/opentel
 # Tags created by helm chart-releaser for this chart (e.g. opentelemetry-kube-stack-0.6.1)
 tag_pattern = "opentelemetry-kube-stack-[0-9].*"
 commit_parsers = [
-  { message = "^feat", group = "Added" },
-  { message = "^fix", group = "Fixed" },
-  { message = "^docs", group = "Added" },
-  { message = "^perf", group = "Changed" },
-  { message = "^refactor", group = "Changed" },
-  { message = "^style", group = "Changed" },
-  { message = "^test", group = "Changed" },
-  { message = "^chore", group = "Changed" },
-  { message = "^ci", group = "Changed" },
-  { message = "^.*", group = "Changed" },
+  # Breaking changes get their own group, whether flagged with `type!:` or a
+  # `BREAKING CHANGE:` footer. Must come first: parsing stops at the first match.
+  { message = "^[a-zA-Z]+(\\(.*\\))?!:", group = "<!-- 0 -->Breaking Changes" },
+  { footer = "^BREAKING[ -]CHANGE:", group = "<!-- 0 -->Breaking Changes" },
+  { message = "^feat", group = "<!-- 1 -->Added" },
+  { message = "^fix", group = "<!-- 2 -->Fixed" },
+  { message = "^docs", group = "<!-- 1 -->Added" },
+  { message = "^perf", group = "<!-- 3 -->Changed" },
+  { message = "^refactor", group = "<!-- 3 -->Changed" },
+  { message = "^style", group = "<!-- 3 -->Changed" },
+  { message = "^test", group = "<!-- 3 -->Changed" },
+  { message = "^chore", group = "<!-- 3 -->Changed" },
+  { message = "^ci", group = "<!-- 3 -->Changed" },
+  { message = "^.*", group = "<!-- 3 -->Changed" },
 ]
 filter_commits = false
 topo_order = false

--- a/charts/opentelemetry-kube-stack/deploy.sh
+++ b/charts/opentelemetry-kube-stack/deploy.sh
@@ -537,7 +537,7 @@ show_next_steps() {
     
     echo -e "\n${CYAN}Useful Commands:${NC}"
     echo -e "• Uninstall: ${BLUE}helm uninstall $RELEASE_NAME -n $NAMESPACE${NC}"
-    echo -e "• Upgrade: ${BLUE}helm upgrade $RELEASE_NAME . -n $NAMESPACE${NC}"
+    echo -e "• Upgrade: ${BLUE}helm upgrade $RELEASE_NAME . -n $NAMESPACE --reuse-values${NC}"
     echo -e "• Status: ${BLUE}helm status $RELEASE_NAME -n $NAMESPACE${NC}"
 }
 

--- a/charts/opentelemetry-kube-stack/docs/collector-internal-metrics.md
+++ b/charts/opentelemetry-kube-stack/docs/collector-internal-metrics.md
@@ -27,32 +27,28 @@ the webhook replaces `service.telemetry.metrics.readers` with its own prometheus
 port 8888, discarding any user-configured periodic/OTLP reader. This was confirmed by inspecting
 the live ConfigMap after deployment with operator v0.152.0.
 
-## Solution: self-scrape pipeline
+## Current approach: `service::telemetry`
 
-Because the operator always exposes collector internal metrics on `localhost:8888` (Prometheus
-format), the reliable workaround is to have each collector scrape itself and forward the result
-through a normal pipeline.
+There is no self-scrape pipeline. Internal telemetry is configured through `service::telemetry`
+alone, rendered by the `opentelemetry-kube-stack.otelTelemetry` helper in `templates/_config.tpl`
+and included by all three default configs (`_default-deamonset-config.tpl`,
+`_default-statefulset-config.tpl`, `_default-cluster-receiver-config.tpl`).
 
-Each default collector config (`_default-deamonset-config.tpl`, `_default-statefulset-config.tpl`,
-`_default-cluster-receiver-config.tpl`) includes:
+The helper emits two things:
 
-**Receiver** — `prometheus/self` scrapes `localhost:8888` every 10 seconds. Named with the `/self`
-suffix to avoid colliding with the statefulset's existing `prometheus` receiver (used by the Target
-Allocator for dynamic scrape discovery).
+**`telemetry.resource`** — a map of `k8s.cluster.name` (from `clusterName`) and
+`service.instance.id: ${POD_UID}` (see below).
 
-**Processor chain** — matches the main metrics pipeline:
-1. `memory_limiter` — backpressure safety (daemonset and statefulset only; cluster-receiver follows
-   its existing pattern of omitting this processor)
-2. `cumulativetodelta` — Prometheus exposes all counters as cumulative monotonic sums; this
-   converts them to delta before export so Tsuga receives the expected incremental values
-3. `resource/collector` — enriches every data point with:
-   - `service.instance.id: ${POD_UID}` — globally unique per pod across the cluster and across
-     time (see below)
-   - `k8s.cluster.name` — set when `clusterName` is configured, same as the main pipeline
-4. `batch` — standard batching before export
+**`telemetry.metrics.readers`** — a single `periodic` reader with an OTLP `http/protobuf` exporter
+pointed at `${TSUGA_OTLP_ENDPOINT}/v1/metrics` with a bearer-token header. Emitted only when the
+Tsuga exporter is enabled; without credentials there is nowhere to push.
 
-**Pipeline** — `metrics/collector` is a dedicated named pipeline so it stays isolated from
-application metrics and can be toggled or modified independently.
+This is the configuration the chart *asks* for. As described above, the operator webhook still
+replaces `readers` with its own Prometheus pull reader on `:8888`, so in practice internal metrics
+are exposed for scraping rather than pushed. The block is kept so the intended behaviour lands as
+soon as the operator stops overriding it. Getting those metrics into Tsuga today requires scraping
+`:8888` yourself — e.g. a `prometheus` receiver added via `agent.config.extraReceivers` plus a
+matching pipeline, or the Target Allocator statefulset.
 
 ## Why POD_UID, not POD_NAME
 
@@ -69,6 +65,5 @@ using a UUID or a platform-specific ID that is tightly coupled to the service in
 
 `POD_UID` is assigned by the Kubernetes API server, is unique across the entire cluster, and is
 never reused — even after the pod is deleted and recreated with the same name. It is injected via
-the downward API (`metadata.uid`) and referenced as `${POD_UID}` in both the `resource/collector`
-processor and the `service.telemetry.resource` block (the latter is currently overridden by the
-operator webhook but is kept for forward compatibility).
+the downward API (`metadata.uid`) and referenced as `${POD_UID}` in the
+`service.telemetry.resource` block.

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
@@ -148,6 +148,11 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -163,6 +168,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -173,6 +179,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -189,4 +196,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
@@ -15,6 +15,12 @@ metadata:
     meta.helm.sh/release-namespace: "default"
 spec:
   mode: deployment
+  # Pinned, and deliberately not configurable. k8s_cluster and k8s_objects have
+  # no leader election here, so every extra replica reports the same cluster
+  # state again: two replicas means every cluster metric counted twice and
+  # every Kubernetes object ingested twice. Setting it in the CR also means a
+  # manual `kubectl scale` is reconciled back to 1.
+  replicas: 1
   image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   resources:
     limits:
@@ -142,11 +148,6 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
-      resource/collector:
-        attributes:
-        - action: upsert
-          key: service.instance.id
-          value: ${POD_UID}
     exporters:
       otlp_http/tsuga:
         compression: gzip

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
@@ -181,6 +181,7 @@ spec:
           - memory_limiter
           - resource
           - k8s_attributes
+          - cumulativetodelta
           - batch
           receivers:
           - k8s_cluster

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/daemonset.yaml
@@ -110,6 +110,42 @@ spec:
                 enabled: true
           disk: null
           filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - ^/dev($|/)
+              - ^/proc($|/)
+              - ^/sys($|/)
+              - ^/run/k3s/containerd($|/)
+              - ^/var/lib/docker($|/)
+              - ^/var/lib/kubelet($|/)
+              - ^/snap($|/)
             metrics:
               system.filesystem.utilization:
                 enabled: true
@@ -200,11 +236,11 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
-      resource/collector:
+      resource:
         attributes:
-        - action: upsert
-          key: service.instance.id
-          value: ${POD_UID}
+        - action: insert
+          key: k8s.node.name
+          value: ${env:K8S_NODE_NAME}
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -230,8 +266,9 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
-          - k8s_attributes
           - memory_limiter
+          - k8s_attributes
+          - resource
           - batch
           receivers:
           - otlp
@@ -240,8 +277,9 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
-          - k8s_attributes
           - memory_limiter
+          - k8s_attributes
+          - resource
           - cumulativetodelta
           - batch
           receivers:
@@ -254,8 +292,9 @@ spec:
           - otlp_http/tsuga
           - span_metrics
           processors:
-          - k8s_attributes
           - memory_limiter
+          - k8s_attributes
+          - resource
           - batch
           receivers:
           - otlp

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/daemonset.yaml
@@ -238,12 +238,14 @@ spec:
         spike_limit_percentage: 25
       resource:
         attributes:
-        - action: insert
-          key: k8s.node.name
-          value: ${env:K8S_NODE_NAME}
         - action: upsert
           key: k8s.cluster.name
           value: test-cluster
+      resource/node:
+        attributes:
+        - action: upsert
+          key: k8s.node.name
+          value: ${env:K8S_NODE_NAME}
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -275,6 +277,16 @@ spec:
           - batch
           receivers:
           - otlp
+        logs/node:
+          exporters:
+          - otlp_http/tsuga
+          processors:
+          - memory_limiter
+          - k8s_attributes
+          - resource
+          - resource/node
+          - batch
+          receivers:
           - file_log
         metrics:
           exporters:
@@ -289,6 +301,17 @@ spec:
           - otlp
           - kubelet_stats
           - span_metrics
+        metrics/node:
+          exporters:
+          - otlp_http/tsuga
+          processors:
+          - memory_limiter
+          - k8s_attributes
+          - resource
+          - resource/node
+          - cumulativetodelta
+          - batch
+          receivers:
           - host_metrics
         traces:
           exporters:

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/daemonset.yaml
@@ -241,6 +241,9 @@ spec:
         - action: insert
           key: k8s.node.name
           value: ${env:K8S_NODE_NAME}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -310,4 +313,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/values.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 # yaml-language-server: $schema=../../values.schema.json
 tsuga:
   otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
@@ -148,6 +148,11 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -163,6 +168,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -173,6 +179,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -189,4 +196,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
@@ -15,6 +15,12 @@ metadata:
     meta.helm.sh/release-namespace: "default"
 spec:
   mode: deployment
+  # Pinned, and deliberately not configurable. k8s_cluster and k8s_objects have
+  # no leader election here, so every extra replica reports the same cluster
+  # state again: two replicas means every cluster metric counted twice and
+  # every Kubernetes object ingested twice. Setting it in the CR also means a
+  # manual `kubectl scale` is reconciled back to 1.
+  replicas: 1
   image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   resources:
     limits:
@@ -142,11 +148,6 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
-      resource/collector:
-        attributes:
-        - action: upsert
-          key: service.instance.id
-          value: ${POD_UID}
     exporters:
       otlp_http/tsuga:
         compression: gzip

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
@@ -181,6 +181,7 @@ spec:
           - memory_limiter
           - resource
           - k8s_attributes
+          - cumulativetodelta
           - batch
           receivers:
           - k8s_cluster

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/daemonset.yaml
@@ -110,6 +110,42 @@ spec:
                 enabled: true
           disk: null
           filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - ^/dev($|/)
+              - ^/proc($|/)
+              - ^/sys($|/)
+              - ^/run/k3s/containerd($|/)
+              - ^/var/lib/docker($|/)
+              - ^/var/lib/kubelet($|/)
+              - ^/snap($|/)
             metrics:
               system.filesystem.utilization:
                 enabled: true
@@ -200,11 +236,11 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
-      resource/collector:
+      resource:
         attributes:
-        - action: upsert
-          key: service.instance.id
-          value: ${POD_UID}
+        - action: insert
+          key: k8s.node.name
+          value: ${env:K8S_NODE_NAME}
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -230,8 +266,9 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
-          - k8s_attributes
           - memory_limiter
+          - k8s_attributes
+          - resource
           - batch
           receivers:
           - otlp
@@ -240,8 +277,9 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
-          - k8s_attributes
           - memory_limiter
+          - k8s_attributes
+          - resource
           - cumulativetodelta
           - batch
           receivers:
@@ -254,8 +292,9 @@ spec:
           - otlp_http/tsuga
           - span_metrics
           processors:
-          - k8s_attributes
           - memory_limiter
+          - k8s_attributes
+          - resource
           - batch
           receivers:
           - otlp

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/daemonset.yaml
@@ -238,12 +238,14 @@ spec:
         spike_limit_percentage: 25
       resource:
         attributes:
-        - action: insert
-          key: k8s.node.name
-          value: ${env:K8S_NODE_NAME}
         - action: upsert
           key: k8s.cluster.name
           value: test-cluster
+      resource/node:
+        attributes:
+        - action: upsert
+          key: k8s.node.name
+          value: ${env:K8S_NODE_NAME}
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -275,6 +277,16 @@ spec:
           - batch
           receivers:
           - otlp
+        logs/node:
+          exporters:
+          - otlp_http/tsuga
+          processors:
+          - memory_limiter
+          - k8s_attributes
+          - resource
+          - resource/node
+          - batch
+          receivers:
           - file_log
         metrics:
           exporters:
@@ -289,6 +301,17 @@ spec:
           - otlp
           - kubelet_stats
           - span_metrics
+        metrics/node:
+          exporters:
+          - otlp_http/tsuga
+          processors:
+          - memory_limiter
+          - k8s_attributes
+          - resource
+          - resource/node
+          - cumulativetodelta
+          - batch
+          receivers:
           - host_metrics
         traces:
           exporters:

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/daemonset.yaml
@@ -241,6 +241,9 @@ spec:
         - action: insert
           key: k8s.node.name
           value: ${env:K8S_NODE_NAME}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -310,4 +313,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/create-secret/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/values.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 tsuga:
   otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
   apiKey: "<TSUGA_API_KEY>"

--- a/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
@@ -148,6 +148,11 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -163,6 +168,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -173,6 +179,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -189,4 +196,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
@@ -15,6 +15,12 @@ metadata:
     meta.helm.sh/release-namespace: "default"
 spec:
   mode: deployment
+  # Pinned, and deliberately not configurable. k8s_cluster and k8s_objects have
+  # no leader election here, so every extra replica reports the same cluster
+  # state again: two replicas means every cluster metric counted twice and
+  # every Kubernetes object ingested twice. Setting it in the CR also means a
+  # manual `kubectl scale` is reconciled back to 1.
+  replicas: 1
   image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   resources:
     limits:
@@ -142,11 +148,6 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
-      resource/collector:
-        attributes:
-        - action: upsert
-          key: service.instance.id
-          value: ${POD_UID}
     exporters:
       otlp_http/tsuga:
         compression: gzip

--- a/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
@@ -181,6 +181,7 @@ spec:
           - memory_limiter
           - resource
           - k8s_attributes
+          - cumulativetodelta
           - batch
           receivers:
           - k8s_cluster

--- a/charts/opentelemetry-kube-stack/examples/custom-config/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/custom-config/values.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 # yaml-language-server: $schema=../../values.schema.json
 agent:
   image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
@@ -148,6 +148,11 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -163,6 +168,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -173,6 +179,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -189,4 +196,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
@@ -15,6 +15,12 @@ metadata:
     meta.helm.sh/release-namespace: "default"
 spec:
   mode: deployment
+  # Pinned, and deliberately not configurable. k8s_cluster and k8s_objects have
+  # no leader election here, so every extra replica reports the same cluster
+  # state again: two replicas means every cluster metric counted twice and
+  # every Kubernetes object ingested twice. Setting it in the CR also means a
+  # manual `kubectl scale` is reconciled back to 1.
+  replicas: 1
   image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   resources:
     limits:
@@ -142,11 +148,6 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
-      resource/collector:
-        attributes:
-        - action: upsert
-          key: service.instance.id
-          value: ${POD_UID}
     exporters:
       otlp_http/tsuga:
         compression: gzip

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
@@ -181,6 +181,7 @@ spec:
           - memory_limiter
           - resource
           - k8s_attributes
+          - cumulativetodelta
           - batch
           receivers:
           - k8s_cluster

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/daemonset.yaml
@@ -110,6 +110,42 @@ spec:
                 enabled: true
           disk: null
           filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - ^/dev($|/)
+              - ^/proc($|/)
+              - ^/sys($|/)
+              - ^/run/k3s/containerd($|/)
+              - ^/var/lib/docker($|/)
+              - ^/var/lib/kubelet($|/)
+              - ^/snap($|/)
             metrics:
               system.filesystem.utilization:
                 enabled: true
@@ -200,11 +236,11 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
-      resource/collector:
+      resource:
         attributes:
-        - action: upsert
-          key: service.instance.id
-          value: ${POD_UID}
+        - action: insert
+          key: k8s.node.name
+          value: ${env:K8S_NODE_NAME}
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -230,8 +266,9 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
-          - k8s_attributes
           - memory_limiter
+          - k8s_attributes
+          - resource
           - batch
           receivers:
           - otlp
@@ -240,8 +277,9 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
-          - k8s_attributes
           - memory_limiter
+          - k8s_attributes
+          - resource
           - cumulativetodelta
           - batch
           receivers:
@@ -254,8 +292,9 @@ spec:
           - otlp_http/tsuga
           - span_metrics
           processors:
-          - k8s_attributes
           - memory_limiter
+          - k8s_attributes
+          - resource
           - batch
           receivers:
           - otlp

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/daemonset.yaml
@@ -238,12 +238,14 @@ spec:
         spike_limit_percentage: 25
       resource:
         attributes:
-        - action: insert
-          key: k8s.node.name
-          value: ${env:K8S_NODE_NAME}
         - action: upsert
           key: k8s.cluster.name
           value: test-cluster
+      resource/node:
+        attributes:
+        - action: upsert
+          key: k8s.node.name
+          value: ${env:K8S_NODE_NAME}
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -275,6 +277,16 @@ spec:
           - batch
           receivers:
           - otlp
+        logs/node:
+          exporters:
+          - otlp_http/tsuga
+          processors:
+          - memory_limiter
+          - k8s_attributes
+          - resource
+          - resource/node
+          - batch
+          receivers:
           - file_log
         metrics:
           exporters:
@@ -289,6 +301,17 @@ spec:
           - otlp
           - kubelet_stats
           - span_metrics
+        metrics/node:
+          exporters:
+          - otlp_http/tsuga
+          processors:
+          - memory_limiter
+          - k8s_attributes
+          - resource
+          - resource/node
+          - cumulativetodelta
+          - batch
+          receivers:
           - host_metrics
         traces:
           exporters:

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/daemonset.yaml
@@ -241,6 +241,9 @@ spec:
         - action: insert
           key: k8s.node.name
           value: ${env:K8S_NODE_NAME}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -310,4 +313,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/default/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/values.yaml
@@ -1,1 +1,2 @@
+---
 clusterName: test-cluster

--- a/charts/opentelemetry-kube-stack/examples/default/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/values.yaml
@@ -1,0 +1,1 @@
+clusterName: test-cluster

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
@@ -148,6 +148,11 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -163,6 +168,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -173,6 +179,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -189,4 +196,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
@@ -15,6 +15,12 @@ metadata:
     meta.helm.sh/release-namespace: "default"
 spec:
   mode: deployment
+  # Pinned, and deliberately not configurable. k8s_cluster and k8s_objects have
+  # no leader election here, so every extra replica reports the same cluster
+  # state again: two replicas means every cluster metric counted twice and
+  # every Kubernetes object ingested twice. Setting it in the CR also means a
+  # manual `kubectl scale` is reconciled back to 1.
+  replicas: 1
   image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   resources:
     limits:
@@ -142,11 +148,6 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
-      resource/collector:
-        attributes:
-        - action: upsert
-          key: service.instance.id
-          value: ${POD_UID}
     exporters:
       otlp_http/tsuga:
         compression: gzip

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
@@ -181,6 +181,7 @@ spec:
           - memory_limiter
           - resource
           - k8s_attributes
+          - cumulativetodelta
           - batch
           receivers:
           - k8s_cluster

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/daemonset.yaml
@@ -110,6 +110,42 @@ spec:
                 enabled: true
           disk: null
           filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - ^/dev($|/)
+              - ^/proc($|/)
+              - ^/sys($|/)
+              - ^/run/k3s/containerd($|/)
+              - ^/var/lib/docker($|/)
+              - ^/var/lib/kubelet($|/)
+              - ^/snap($|/)
             metrics:
               system.filesystem.utilization:
                 enabled: true
@@ -200,11 +236,11 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
-      resource/collector:
+      resource:
         attributes:
-        - action: upsert
-          key: service.instance.id
-          value: ${POD_UID}
+        - action: insert
+          key: k8s.node.name
+          value: ${env:K8S_NODE_NAME}
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -230,8 +266,9 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
-          - k8s_attributes
           - memory_limiter
+          - k8s_attributes
+          - resource
           - batch
           receivers:
           - otlp
@@ -240,8 +277,9 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
-          - k8s_attributes
           - memory_limiter
+          - k8s_attributes
+          - resource
           - cumulativetodelta
           - batch
           receivers:
@@ -260,8 +298,9 @@ spec:
           - otlp_http/tsuga
           - span_metrics
           processors:
-          - k8s_attributes
           - memory_limiter
+          - k8s_attributes
+          - resource
           - batch
           receivers:
           - otlp

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/daemonset.yaml
@@ -238,12 +238,14 @@ spec:
         spike_limit_percentage: 25
       resource:
         attributes:
-        - action: insert
-          key: k8s.node.name
-          value: ${env:K8S_NODE_NAME}
         - action: upsert
           key: k8s.cluster.name
           value: test-cluster
+      resource/node:
+        attributes:
+        - action: upsert
+          key: k8s.node.name
+          value: ${env:K8S_NODE_NAME}
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -275,6 +277,16 @@ spec:
           - batch
           receivers:
           - otlp
+        logs/node:
+          exporters:
+          - otlp_http/tsuga
+          processors:
+          - memory_limiter
+          - k8s_attributes
+          - resource
+          - resource/node
+          - batch
+          receivers:
           - file_log
         metrics:
           exporters:
@@ -289,13 +301,24 @@ spec:
           - otlp
           - kubelet_stats
           - span_metrics
-          - host_metrics
         metrics/extra:
           exporters:
           - otlphttp/tsuga
           processors: []
           receivers:
           - hostmetrics
+        metrics/node:
+          exporters:
+          - otlp_http/tsuga
+          processors:
+          - memory_limiter
+          - k8s_attributes
+          - resource
+          - resource/node
+          - cumulativetodelta
+          - batch
+          receivers:
+          - host_metrics
         traces:
           exporters:
           - otlp_http/tsuga

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/daemonset.yaml
@@ -241,6 +241,9 @@ spec:
         - action: insert
           key: k8s.node.name
           value: ${env:K8S_NODE_NAME}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -316,4 +319,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/extra-service/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/values.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 agent:
   config:
     service:

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
@@ -148,6 +148,11 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -163,6 +168,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -173,6 +179,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -189,4 +196,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
@@ -15,6 +15,12 @@ metadata:
     meta.helm.sh/release-namespace: "default"
 spec:
   mode: deployment
+  # Pinned, and deliberately not configurable. k8s_cluster and k8s_objects have
+  # no leader election here, so every extra replica reports the same cluster
+  # state again: two replicas means every cluster metric counted twice and
+  # every Kubernetes object ingested twice. Setting it in the CR also means a
+  # manual `kubectl scale` is reconciled back to 1.
+  replicas: 1
   image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   resources:
     limits:
@@ -142,11 +148,6 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
-      resource/collector:
-        attributes:
-        - action: upsert
-          key: service.instance.id
-          value: ${POD_UID}
     exporters:
       otlp_http/tsuga:
         compression: gzip

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
@@ -181,6 +181,7 @@ spec:
           - memory_limiter
           - resource
           - k8s_attributes
+          - cumulativetodelta
           - batch
           receivers:
           - k8s_cluster

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/daemonset.yaml
@@ -110,6 +110,42 @@ spec:
                 enabled: true
           disk: null
           filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - ^/dev($|/)
+              - ^/proc($|/)
+              - ^/sys($|/)
+              - ^/run/k3s/containerd($|/)
+              - ^/var/lib/docker($|/)
+              - ^/var/lib/kubelet($|/)
+              - ^/snap($|/)
             metrics:
               system.filesystem.utilization:
                 enabled: true
@@ -200,11 +236,11 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
-      resource/collector:
+      resource:
         attributes:
-        - action: upsert
-          key: service.instance.id
-          value: ${POD_UID}
+        - action: insert
+          key: k8s.node.name
+          value: ${env:K8S_NODE_NAME}
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -230,8 +266,9 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
-          - k8s_attributes
           - memory_limiter
+          - k8s_attributes
+          - resource
           - batch
           receivers:
           - otlp
@@ -240,8 +277,9 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
-          - k8s_attributes
           - memory_limiter
+          - k8s_attributes
+          - resource
           - cumulativetodelta
           - batch
           receivers:
@@ -254,8 +292,9 @@ spec:
           - otlp_http/tsuga
           - span_metrics
           processors:
-          - k8s_attributes
           - memory_limiter
+          - k8s_attributes
+          - resource
           - batch
           receivers:
           - otlp

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/daemonset.yaml
@@ -238,12 +238,14 @@ spec:
         spike_limit_percentage: 25
       resource:
         attributes:
-        - action: insert
-          key: k8s.node.name
-          value: ${env:K8S_NODE_NAME}
         - action: upsert
           key: k8s.cluster.name
           value: test-cluster
+      resource/node:
+        attributes:
+        - action: upsert
+          key: k8s.node.name
+          value: ${env:K8S_NODE_NAME}
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -275,6 +277,16 @@ spec:
           - batch
           receivers:
           - otlp
+        logs/node:
+          exporters:
+          - otlp_http/tsuga
+          processors:
+          - memory_limiter
+          - k8s_attributes
+          - resource
+          - resource/node
+          - batch
+          receivers:
           - file_log
         metrics:
           exporters:
@@ -289,6 +301,17 @@ spec:
           - otlp
           - kubelet_stats
           - span_metrics
+        metrics/node:
+          exporters:
+          - otlp_http/tsuga
+          processors:
+          - memory_limiter
+          - k8s_attributes
+          - resource
+          - resource/node
+          - cumulativetodelta
+          - batch
+          receivers:
           - host_metrics
         traces:
           exporters:

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/daemonset.yaml
@@ -241,6 +241,9 @@ spec:
         - action: insert
           key: k8s.node.name
           value: ${env:K8S_NODE_NAME}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -310,4 +313,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/values.yaml
@@ -1,3 +1,4 @@
 ---
+clusterName: test-cluster
 cluster:
   collectk8sobjects: true

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
@@ -148,6 +148,11 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -163,6 +168,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -173,6 +179,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -189,4 +196,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
@@ -15,6 +15,12 @@ metadata:
     meta.helm.sh/release-namespace: "default"
 spec:
   mode: deployment
+  # Pinned, and deliberately not configurable. k8s_cluster and k8s_objects have
+  # no leader election here, so every extra replica reports the same cluster
+  # state again: two replicas means every cluster metric counted twice and
+  # every Kubernetes object ingested twice. Setting it in the CR also means a
+  # manual `kubectl scale` is reconciled back to 1.
+  replicas: 1
   image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   resources:
     limits:
@@ -142,11 +148,6 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
-      resource/collector:
-        attributes:
-        - action: upsert
-          key: service.instance.id
-          value: ${POD_UID}
     exporters:
       otlp_http/tsuga:
         compression: gzip

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
@@ -181,6 +181,7 @@ spec:
           - memory_limiter
           - resource
           - k8s_attributes
+          - cumulativetodelta
           - batch
           receivers:
           - k8s_cluster

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/daemonset.yaml
@@ -251,6 +251,9 @@ spec:
         - action: insert
           key: k8s.node.name
           value: ${env:K8S_NODE_NAME}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -327,4 +330,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/daemonset.yaml
@@ -95,6 +95,42 @@ spec:
                 enabled: true
           disk: null
           filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - ^/dev($|/)
+              - ^/proc($|/)
+              - ^/sys($|/)
+              - ^/run/k3s/containerd($|/)
+              - ^/var/lib/docker($|/)
+              - ^/var/lib/kubelet($|/)
+              - ^/snap($|/)
             metrics:
               system.filesystem.utilization:
                 enabled: true
@@ -210,11 +246,11 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
-      resource/collector:
+      resource:
         attributes:
-        - action: upsert
-          key: service.instance.id
-          value: ${POD_UID}
+        - action: insert
+          key: k8s.node.name
+          value: ${env:K8S_NODE_NAME}
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -245,8 +281,9 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
-          - k8s_attributes
           - memory_limiter
+          - k8s_attributes
+          - resource
           - batch
           receivers:
           - otlp
@@ -255,8 +292,9 @@ spec:
           exporters:
           - otlp_http/tsuga
           processors:
-          - k8s_attributes
           - memory_limiter
+          - k8s_attributes
+          - resource
           - cumulativetodelta
           - batch
           receivers:
@@ -271,8 +309,9 @@ spec:
           - otlp_http/tsuga
           - span_metrics
           processors:
-          - k8s_attributes
           - memory_limiter
+          - k8s_attributes
+          - resource
           - batch
           receivers:
           - otlp

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/daemonset.yaml
@@ -248,12 +248,14 @@ spec:
         spike_limit_percentage: 25
       resource:
         attributes:
-        - action: insert
-          key: k8s.node.name
-          value: ${env:K8S_NODE_NAME}
         - action: upsert
           key: k8s.cluster.name
           value: test-cluster
+      resource/node:
+        attributes:
+        - action: upsert
+          key: k8s.node.name
+          value: ${env:K8S_NODE_NAME}
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -304,9 +306,20 @@ spec:
           - otlp
           - kubelet_stats
           - span_metrics
-          - host_metrics
           - receiver_creator/redis
           - receiver_creator/nginx
+        metrics/node:
+          exporters:
+          - otlp_http/tsuga
+          processors:
+          - memory_limiter
+          - k8s_attributes
+          - resource
+          - resource/node
+          - cumulativetodelta
+          - batch
+          receivers:
+          - host_metrics
         traces:
           exporters:
           - otlp_http/tsuga

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/values.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 # yaml-language-server: $schema=../../values.schema.json
 agent:
   image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib

--- a/charts/opentelemetry-kube-stack/examples/target-allocator/rendered/statefulset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/target-allocator/rendered/statefulset.yaml
@@ -138,6 +138,11 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -155,6 +160,7 @@ spec:
           - memory_limiter
           - cumulativetodelta
           - k8s_attributes
+          - resource
           - batch
           receivers:
           - prometheus
@@ -170,4 +176,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/target-allocator/rendered/statefulset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/target-allocator/rendered/statefulset.yaml
@@ -138,11 +138,6 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
-      resource/collector:
-        attributes:
-        - action: upsert
-          key: service.instance.id
-          value: ${POD_UID}
     exporters:
       otlp_http/tsuga:
         compression: gzip

--- a/charts/opentelemetry-kube-stack/examples/target-allocator/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/target-allocator/values.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 # Target Allocator example
 # Deploys a TargetAllocator CR and a paired StatefulSet OpenTelemetryCollector.
 # The Target Allocator distributes Prometheus targets evenly across 2 collector replicas.

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
@@ -138,6 +138,11 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       debug: {}
     service:
@@ -148,6 +153,7 @@ spec:
           - debug
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -158,10 +164,12 @@ spec:
           - debug
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
           - k8s_cluster
       telemetry:
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
@@ -15,6 +15,12 @@ metadata:
     meta.helm.sh/release-namespace: "default"
 spec:
   mode: deployment
+  # Pinned, and deliberately not configurable. k8s_cluster and k8s_objects have
+  # no leader election here, so every extra replica reports the same cluster
+  # state again: two replicas means every cluster metric counted twice and
+  # every Kubernetes object ingested twice. Setting it in the CR also means a
+  # manual `kubectl scale` is reconciled back to 1.
+  replicas: 1
   image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   resources:
     limits:
@@ -132,11 +138,6 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
-      resource/collector:
-        attributes:
-        - action: upsert
-          key: service.instance.id
-          value: ${POD_UID}
     exporters:
       debug: {}
     service:

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
@@ -166,6 +166,7 @@ spec:
           - memory_limiter
           - resource
           - k8s_attributes
+          - cumulativetodelta
           - batch
           receivers:
           - k8s_cluster

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/daemonset.yaml
@@ -231,6 +231,9 @@ spec:
         - action: insert
           key: k8s.node.name
           value: ${env:K8S_NODE_NAME}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       debug: {}
     extensions:
@@ -285,4 +288,5 @@ spec:
           - otlp
       telemetry:
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/daemonset.yaml
@@ -100,6 +100,42 @@ spec:
                 enabled: true
           disk: null
           filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - ^/dev($|/)
+              - ^/proc($|/)
+              - ^/sys($|/)
+              - ^/run/k3s/containerd($|/)
+              - ^/var/lib/docker($|/)
+              - ^/var/lib/kubelet($|/)
+              - ^/snap($|/)
             metrics:
               system.filesystem.utilization:
                 enabled: true
@@ -190,11 +226,11 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
-      resource/collector:
+      resource:
         attributes:
-        - action: upsert
-          key: service.instance.id
-          value: ${POD_UID}
+        - action: insert
+          key: k8s.node.name
+          value: ${env:K8S_NODE_NAME}
     exporters:
       debug: {}
     extensions:
@@ -215,8 +251,9 @@ spec:
           exporters:
           - debug
           processors:
-          - k8s_attributes
           - memory_limiter
+          - k8s_attributes
+          - resource
           - batch
           receivers:
           - otlp
@@ -225,8 +262,9 @@ spec:
           exporters:
           - debug
           processors:
-          - k8s_attributes
           - memory_limiter
+          - k8s_attributes
+          - resource
           - cumulativetodelta
           - batch
           receivers:
@@ -239,8 +277,9 @@ spec:
           - span_metrics
           - debug
           processors:
-          - k8s_attributes
           - memory_limiter
+          - k8s_attributes
+          - resource
           - batch
           receivers:
           - otlp

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/daemonset.yaml
@@ -228,12 +228,14 @@ spec:
         spike_limit_percentage: 25
       resource:
         attributes:
-        - action: insert
-          key: k8s.node.name
-          value: ${env:K8S_NODE_NAME}
         - action: upsert
           key: k8s.cluster.name
           value: test-cluster
+      resource/node:
+        attributes:
+        - action: upsert
+          key: k8s.node.name
+          value: ${env:K8S_NODE_NAME}
     exporters:
       debug: {}
     extensions:
@@ -260,6 +262,16 @@ spec:
           - batch
           receivers:
           - otlp
+        logs/node:
+          exporters:
+          - debug
+          processors:
+          - memory_limiter
+          - k8s_attributes
+          - resource
+          - resource/node
+          - batch
+          receivers:
           - file_log
         metrics:
           exporters:
@@ -274,6 +286,17 @@ spec:
           - otlp
           - kubelet_stats
           - span_metrics
+        metrics/node:
+          exporters:
+          - debug
+          processors:
+          - memory_limiter
+          - k8s_attributes
+          - resource
+          - resource/node
+          - cumulativetodelta
+          - batch
+          receivers:
           - host_metrics
         traces:
           exporters:

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/statefulset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/statefulset.yaml
@@ -128,6 +128,11 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       debug: {}
     service:
@@ -140,9 +145,11 @@ spec:
           - memory_limiter
           - cumulativetodelta
           - k8s_attributes
+          - resource
           - batch
           receivers:
           - prometheus
       telemetry:
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/statefulset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/statefulset.yaml
@@ -128,11 +128,6 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
-      resource/collector:
-        attributes:
-        - action: upsert
-          key: service.instance.id
-          value: ${POD_UID}
     exporters:
       debug: {}
     service:

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/values.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 tsuga:
   enabledForClusterReceiver: false
   enabledForDaemonset: false

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/values.yaml
@@ -28,7 +28,13 @@ agent:
         metrics:
           extraExporters:
             - debug
+        metrics/node:
+          extraExporters:
+            - debug
         logs:
+          extraExporters:
+            - debug
+        logs/node:
           extraExporters:
             - debug
         traces:

--- a/charts/opentelemetry-kube-stack/templates/NOTES.txt
+++ b/charts/opentelemetry-kube-stack/templates/NOTES.txt
@@ -10,23 +10,6 @@ OpenTelemetry Kubernetes Stack - Post-Installation Guide
 
 Release: {{ .Release.Name }} | Namespace: {{ .Release.Namespace }} | Version: {{ .Chart.Version }}
 
-{{- if not .Values.clusterName }}
-
-⚠️  WARNING: Cluster Name Not Set
-=============================================================================
-The 'clusterName' value is not configured. It is RECOMMENDED to set this
-value to identify your cluster in telemetry data.
-
-To update the cluster name:
-  helm upgrade {{ .Release.Name }} {{ .Chart.Name }} \
-    --set clusterName="your-cluster-name" \
-    --reuse-values
-
-Without a cluster name, the k8s.cluster.name attribute will be omitted
-from all telemetry data, which may make it difficult to distinguish
-metrics and traces from different clusters.
-
-{{- end }}
 
 =============================================================================
 📊 STATUS CHECK

--- a/charts/opentelemetry-kube-stack/templates/NOTES.txt
+++ b/charts/opentelemetry-kube-stack/templates/NOTES.txt
@@ -10,7 +10,6 @@ OpenTelemetry Kubernetes Stack - Post-Installation Guide
 
 Release: {{ .Release.Name }} | Namespace: {{ .Release.Namespace }} | Version: {{ .Chart.Version }}
 
-
 =============================================================================
 📊 STATUS CHECK
 =============================================================================

--- a/charts/opentelemetry-kube-stack/templates/_config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_config.tpl
@@ -82,9 +82,7 @@ Generate Otel telemetry export
 {{- define "opentelemetry-kube-stack.otelTelemetry" -}}
 {{- include "opentelemetry-kube-stack.assertCollectorVersion" . -}}
 resource:
-  {{- if .Values.clusterName }}
-  k8s.cluster.name: {{ .Values.clusterName }}
-  {{- end}}
+  k8s.cluster.name: {{ include "opentelemetry-kube-stack.clusterName" . }}
   service.instance.id: ${POD_UID}
 {{- if include "opentelemetry-kube-stack.tsugaEnabled" . }}
 metrics:

--- a/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
@@ -118,6 +118,8 @@ service:
         - memory_limiter
         - resource
         - k8s_attributes
+        # Tsuga expects delta temporality; k8s_cluster emits cumulative sums.
+        - cumulativetodelta
         - batch
       exporters:
         {{- if ne (index .Values "tsuga" "enabledForClusterReceiver") false }}

--- a/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
@@ -83,16 +83,6 @@ processors:
       - sources:
         - from: connection
   cumulativetodelta: {}
-  resource/collector:
-    attributes:
-      - key: service.instance.id
-        value: ${POD_UID}
-        action: upsert
-      {{- if .Values.clusterName }}
-      - key: k8s.cluster.name
-        value: {{ .Values.clusterName }}
-        action: upsert
-      {{- end }}
   {{- if .Values.clusterName }}
   resource:
     attributes:

--- a/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
@@ -83,13 +83,11 @@ processors:
       - sources:
         - from: connection
   cumulativetodelta: {}
-  {{- if .Values.clusterName }}
   resource:
     attributes:
       - key: k8s.cluster.name
-        value: {{ .Values.clusterName }}
+        value: {{ include "opentelemetry-kube-stack.clusterName" . }}
         action: upsert
-  {{- end }}
 exporters:
 {{- if ne (index .Values "tsuga" "enabledForClusterReceiver") false }}
   {{include "opentelemetry-kube-stack.tsugaExporters" . | nindent 2}}
@@ -106,9 +104,7 @@ service:
 {{- end }}
       processors:
         - memory_limiter
-        {{- if .Values.clusterName }}
         - resource
-        {{- end }}
         - k8s_attributes
         - batch
       exporters:
@@ -120,9 +116,7 @@ service:
         - k8s_cluster
       processors:
         - memory_limiter
-        {{- if .Values.clusterName }}
         - resource
-        {{- end }}
         - k8s_attributes
         - batch
       exporters:

--- a/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
@@ -51,6 +51,45 @@ receivers:
         metrics:
           system.filesystem.utilization:
             enabled: true
+        # Without these every overlayfs and tmpfs mount on the node becomes its
+        # own series, which on a busy node is dozens per pod and tells you
+        # nothing. Same exclusion set as the upstream hostMetrics preset.
+        exclude_mount_points:
+          match_type: regexp
+          mount_points:
+            - '^/dev($|/)'
+            - '^/proc($|/)'
+            - '^/sys($|/)'
+            - '^/run/k3s/containerd($|/)'
+            - '^/var/lib/docker($|/)'
+            - '^/var/lib/kubelet($|/)'
+            - '^/snap($|/)'
+        exclude_fs_types:
+          match_type: strict
+          fs_types:
+            - autofs
+            - binfmt_misc
+            - bpf
+            - cgroup2
+            - configfs
+            - debugfs
+            - devpts
+            - devtmpfs
+            - fusectl
+            - hugetlbfs
+            - iso9660
+            - mqueue
+            - nsfs
+            - overlay
+            - proc
+            - procfs
+            - pstore
+            - rpc_pipefs
+            - securityfs
+            - selinuxfs
+            - squashfs
+            - sysfs
+            - tracefs
       load:
       memory:
         metrics:
@@ -144,23 +183,20 @@ processors:
     limit_percentage: 80
     spike_limit_percentage: 25
   cumulativetodelta: {}
-  resource/collector:
+  resource:
     attributes:
-      - key: service.instance.id
-        value: ${POD_UID}
-        action: upsert
+      # host_metrics never touches a pod, so k8s_attributes cannot associate it
+      # and it would otherwise arrive with no node identity at all, collapsing
+      # every node's host metrics together. insert (not upsert) leaves
+      # pod-derived values alone.
+      - key: k8s.node.name
+        value: ${env:K8S_NODE_NAME}
+        action: insert
       {{- if .Values.clusterName }}
       - key: k8s.cluster.name
         value: {{ .Values.clusterName }}
         action: upsert
       {{- end }}
-  {{- if .Values.clusterName }}
-  resource:
-    attributes:
-      - key: k8s.cluster.name
-        value: {{ .Values.clusterName }}
-        action: upsert
-  {{- end }}
 exporters:
 {{- if ne (index .Values "tsuga" "enabledForDaemonset") false }}
   {{include "opentelemetry-kube-stack.tsugaExporters" . | nindent 2}}
@@ -185,12 +221,13 @@ service:
         - file_log
 {{- end }}
       processors:
-        - k8s_attributes
+        # memory_limiter must be first so load is shed before the pipeline
+        # spends work enriching data it is about to reject; batch last so it
+        # groups the finished records.
         - memory_limiter
-        - batch
-        {{- if .Values.clusterName }}
+        - k8s_attributes
         - resource
-        {{- end }}
+        - batch
       exporters:
         {{- if ne (index .Values "tsuga" "enabledForDaemonset") false }}
         - otlp_http/tsuga
@@ -202,12 +239,10 @@ service:
         - span_metrics
         - host_metrics
       processors:
-        - k8s_attributes
         - memory_limiter
-        - cumulativetodelta
-        {{- if .Values.clusterName }}
+        - k8s_attributes
         - resource
-        {{- end }}
+        - cumulativetodelta
         - batch
       exporters:
         {{- if ne (index .Values "tsuga" "enabledForDaemonset") false }}
@@ -220,11 +255,9 @@ service:
         {{- end }}
         - span_metrics
       processors:
-        - k8s_attributes
         - memory_limiter
-        {{- if .Values.clusterName }}
+        - k8s_attributes
         - resource
-        {{- end }}
         - batch
       receivers:
         - otlp

--- a/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
@@ -51,9 +51,11 @@ receivers:
         metrics:
           system.filesystem.utilization:
             enabled: true
-        # Without these every overlayfs and tmpfs mount on the node becomes its
-        # own series, which on a busy node is dozens per pod and tells you
-        # nothing. Same exclusion set as the upstream hostMetrics preset.
+        # Without these every overlayfs mount and kernel pseudo-filesystem on
+        # the node becomes its own series, which on a busy node is dozens per
+        # pod and tells you nothing. Uses upstream's fs_types, with anchored
+        # mount-point regexes. tmpfs is deliberately kept: /run and friends are
+        # real usage worth watching, and upstream keeps it too.
         exclude_mount_points:
           match_type: regexp
           mount_points:
@@ -183,15 +185,20 @@ processors:
     limit_percentage: 80
     spike_limit_percentage: 25
   cumulativetodelta: {}
-  resource:
+  # Only wired into the node-local pipelines (metrics/node, logs/node). Those
+  # receivers read this node's kernel and this node's log files, so the agent's
+  # own node name is always the right answer. It is deliberately kept off the
+  # otlp pipelines: otlp arrives over a Service that load-balances across every
+  # agent, so a pod on another node reaches this collector and k8s_attributes
+  # cannot associate it (filter.node_from_env_var restricts the pod informer to
+  # local pods). Stamping there would label it with the receiving node.
+  resource/node:
     attributes:
-      # host_metrics never touches a pod, so k8s_attributes cannot associate it
-      # and it would otherwise arrive with no node identity at all, collapsing
-      # every node's host metrics together. insert (not upsert) leaves
-      # pod-derived values alone.
       - key: k8s.node.name
         value: ${env:K8S_NODE_NAME}
-        action: insert
+        action: upsert
+  resource:
+    attributes:
       - key: k8s.cluster.name
         value: {{ include "opentelemetry-kube-stack.clusterName" . }}
         action: upsert
@@ -215,9 +222,6 @@ service:
     logs:
       receivers:
         - otlp
-{{- if .Values.agent.collectLogs }}
-        - file_log
-{{- end }}
       processors:
         # memory_limiter must be first so load is shed before the pipeline
         # spends work enriching data it is about to reject; batch last so it
@@ -230,16 +234,45 @@ service:
         {{- if ne (index .Values "tsuga" "enabledForDaemonset") false }}
         - otlp_http/tsuga
         {{- end }}
+{{- if .Values.agent.collectLogs }}
+    logs/node:
+      receivers:
+        - file_log
+      processors:
+        - memory_limiter
+        - k8s_attributes
+        - resource
+        - resource/node
+        - batch
+      exporters:
+        {{- if ne (index .Values "tsuga" "enabledForDaemonset") false }}
+        - otlp_http/tsuga
+        {{- end }}
+{{- end }}
     metrics:
       receivers:
         - otlp
+        # kubelet_stats sets k8s.node.name itself, so it needs no stamp.
         - kubelet_stats
         - span_metrics
+      processors:
+        - memory_limiter
+        - k8s_attributes
+        - resource
+        - cumulativetodelta
+        - batch
+      exporters:
+        {{- if ne (index .Values "tsuga" "enabledForDaemonset") false }}
+        - otlp_http/tsuga
+        {{- end }}
+    metrics/node:
+      receivers:
         - host_metrics
       processors:
         - memory_limiter
         - k8s_attributes
         - resource
+        - resource/node
         - cumulativetodelta
         - batch
       exporters:

--- a/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
@@ -192,11 +192,9 @@ processors:
       - key: k8s.node.name
         value: ${env:K8S_NODE_NAME}
         action: insert
-      {{- if .Values.clusterName }}
       - key: k8s.cluster.name
-        value: {{ .Values.clusterName }}
+        value: {{ include "opentelemetry-kube-stack.clusterName" . }}
         action: upsert
-      {{- end }}
 exporters:
 {{- if ne (index .Values "tsuga" "enabledForDaemonset") false }}
   {{include "opentelemetry-kube-stack.tsugaExporters" . | nindent 2}}

--- a/charts/opentelemetry-kube-stack/templates/_default-statefulset-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-statefulset-config.tpl
@@ -23,16 +23,6 @@ processors:
     send_batch_size: 5000
     send_batch_max_size: 5000
   cumulativetodelta: {}
-  resource/collector:
-    attributes:
-      - key: service.instance.id
-        value: ${POD_UID}
-        action: upsert
-      {{- if .Values.clusterName }}
-      - key: k8s.cluster.name
-        value: {{ .Values.clusterName }}
-        action: upsert
-      {{- end }}
   k8s_attributes:
     extract:
       metadata:

--- a/charts/opentelemetry-kube-stack/templates/_default-statefulset-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-statefulset-config.tpl
@@ -81,13 +81,11 @@ processors:
           name: k8s.pod.uid
       - sources:
         - from: connection
-  {{- if .Values.clusterName }}
   resource:
     attributes:
       - key: k8s.cluster.name
-        value: {{ .Values.clusterName }}
+        value: {{ include "opentelemetry-kube-stack.clusterName" . }}
         action: upsert
-  {{- end }}
 exporters:
 {{- if ne (index .Values "tsuga" "enabledForStatefulset") false }}
   {{include "opentelemetry-kube-stack.tsugaExporters" . | nindent 2}}
@@ -103,9 +101,7 @@ service:
         - memory_limiter
         - cumulativetodelta
         - k8s_attributes
-        {{- if .Values.clusterName }}
         - resource
-        {{- end }}
         - batch
       exporters:
         {{- if ne (index .Values "tsuga" "enabledForStatefulset") false }}

--- a/charts/opentelemetry-kube-stack/templates/_helpers.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_helpers.tpl
@@ -111,6 +111,18 @@ Validate that required secret values are provided
 {{- end }}
 
 {{/*
+The cluster name, which is required.
+
+Telemetry from a cluster that does not name itself cannot be told apart from
+any other cluster's once it reaches Tsuga, and the omission only becomes
+visible during an incident. Resolved through `required` at each point of use
+so the failure happens at install time with one message.
+*/}}
+{{- define "opentelemetry-kube-stack.clusterName" -}}
+{{- required "clusterName is required: it identifies this cluster in telemetry. Set it with --set clusterName=<name> or in your values file." .Values.clusterName -}}
+{{- end }}
+
+{{/*
 Validate resource names to prevent conflicts and ensure Kubernetes compliance
 */}}
 {{- define "opentelemetry-kube-stack.validateResourceNames" -}}

--- a/charts/opentelemetry-kube-stack/templates/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/templates/cluster-receiver.yaml
@@ -18,6 +18,12 @@ metadata:
     meta.helm.sh/release-namespace: {{ .Release.Namespace | quote }}
 spec:
   mode: deployment
+  # Pinned, and deliberately not configurable. k8s_cluster and k8s_objects have
+  # no leader election here, so every extra replica reports the same cluster
+  # state again: two replicas means every cluster metric counted twice and
+  # every Kubernetes object ingested twice. Setting it in the CR also means a
+  # manual `kubectl scale` is reconciled back to 1.
+  replicas: 1
   image: {{ .Values.cluster.image | default "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib" }}
   {{- if or .Values.cluster.resources .Values.resources }}
   resources:

--- a/charts/opentelemetry-kube-stack/tests/AUTO_INSTRUMENTATION_TESTING.md
+++ b/charts/opentelemetry-kube-stack/tests/AUTO_INSTRUMENTATION_TESTING.md
@@ -103,6 +103,7 @@ Install the chart with auto-instrumentation enabled:
 
 ```bash
 helm install otel-test . \
+  --set clusterName="<CLUSTER_NAME>" \
   --set autoInstrumentation.enabled=true \
   --set autoInstrumentation.spec.exporter.endpoint="http://otel-test-opentelemetry-kube-stack-agent:4317" \
   --set autoInstrumentation.spec.java.image="ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:latest" \
@@ -228,6 +229,7 @@ annotations:
 
 ```bash
 helm install otel-test . \
+  --set clusterName="<CLUSTER_NAME>" \
   --set autoInstrumentation.enabled=true \
   --set autoInstrumentation.spec.exporter.endpoint="http://custom-collector:4317" \
   --set autoInstrumentation.spec.propagators[0]=tracecontext \
@@ -243,6 +245,7 @@ helm install otel-test . \
 
 ```bash
 helm install otel-test . \
+  --set clusterName="<CLUSTER_NAME>" \
   --set autoInstrumentation.enabled=true \
   --set autoInstrumentation.spec.resource.addK8sUIDAttributes=true \
   --set "autoInstrumentation.spec.resource.resourceAttributes.service\.namespace=production" \
@@ -271,7 +274,7 @@ kubectl get instrumentation -o yaml
 
 ```bash
 # Disable auto-instrumentation
-helm upgrade otel-test . --set autoInstrumentation.enabled=false
+helm upgrade otel-test . --reuse-values --set autoInstrumentation.enabled=false
 
 # Verify Instrumentation resource is removed
 kubectl get instrumentation  # Should return empty

--- a/charts/opentelemetry-kube-stack/tests/README.md
+++ b/charts/opentelemetry-kube-stack/tests/README.md
@@ -153,7 +153,7 @@ helm unittest .
 
 # 5. Manual chart testing
 helm lint .
-helm template . --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" --set tsuga.apiKey="<TSUGA_API_KEY>"
+helm template . --set clusterName="<CLUSTER_NAME>" --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" --set tsuga.apiKey="<TSUGA_API_KEY>"
 ```
 
 ## Auto-Instrumentation Testing
@@ -179,7 +179,7 @@ This includes:
 
 ```bash
 # Debug template rendering
-helm template . --debug --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" --set tsuga.apiKey="<TSUGA_API_KEY>"
+helm template . --debug --set clusterName="<CLUSTER_NAME>" --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" --set tsuga.apiKey="<TSUGA_API_KEY>"
 
 # Check resource status
 kubectl get all -n <namespace>

--- a/charts/opentelemetry-kube-stack/tests/cluster-receiver_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/cluster-receiver_test.yaml
@@ -85,3 +85,26 @@ tests:
       - equal:
           path: spec.config.service.pipelines.metrics.processors[0]
           value: memory_limiter
+
+  - it: should pin the cluster receiver to a single replica
+    set:
+      cluster.enabled: true
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: should not define the unused resource/collector processor
+    set:
+      cluster.enabled: true
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - isNull:
+          path: spec.config.processors["resource/collector"]

--- a/charts/opentelemetry-kube-stack/tests/cluster-receiver_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/cluster-receiver_test.yaml
@@ -5,6 +5,7 @@ templates:
 tests:
   - it: should create deployment with default values
     set:
+      clusterName: "test-cluster"
       cluster.enabled: true
       serviceAccount.create: true
       serviceAccount.name: ""
@@ -21,6 +22,7 @@ tests:
 
   - it: should not include tsuga exporter when enabledForClusterReceiver is false
     set:
+      clusterName: "test-cluster"
       cluster.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -36,6 +38,7 @@ tests:
 
   - it: should collect k8s objects by default
     set:
+      clusterName: "test-cluster"
       cluster.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -52,6 +55,7 @@ tests:
 
   - it: should not collect k8s objects when disabled
     set:
+      clusterName: "test-cluster"
       cluster.enabled: true
       cluster.collectk8sobjects: false
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
@@ -69,6 +73,7 @@ tests:
 
   - it: should guard logs and metrics pipelines with memory_limiter first
     set:
+      clusterName: "test-cluster"
       cluster.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -88,6 +93,7 @@ tests:
 
   - it: should pin the cluster receiver to a single replica
     set:
+      clusterName: "test-cluster"
       cluster.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -100,6 +106,7 @@ tests:
 
   - it: should not define the unused resource/collector processor
     set:
+      clusterName: "test-cluster"
       cluster.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"

--- a/charts/opentelemetry-kube-stack/tests/cluster-receiver_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/cluster-receiver_test.yaml
@@ -104,7 +104,7 @@ tests:
           path: spec.replicas
           value: 1
 
-  - it: should not define the unused resource/collector processor
+  - it: should convert cumulative metrics to delta before export
     set:
       clusterName: "test-cluster"
       cluster.enabled: true
@@ -113,5 +113,19 @@ tests:
     release:
       name: "test-release"
     asserts:
-      - isNull:
-          path: spec.config.processors["resource/collector"]
+      - isNotNull:
+          path: spec.config.processors.cumulativetodelta
+      - equal:
+          path: spec.config.service.pipelines.metrics.processors
+          value: [memory_limiter, resource, k8s_attributes, cumulativetodelta, batch]
+
+  - it: should fail to render when clusterName is not set
+    set:
+      cluster.enabled: true
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - failedTemplate:
+          errorMessage: "clusterName is required: it identifies this cluster in telemetry. Set it with --set clusterName=<name> or in your values file."

--- a/charts/opentelemetry-kube-stack/tests/daemonset_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/daemonset_test.yaml
@@ -95,3 +95,57 @@ tests:
       # Internal-telemetry OTLP export (which needs the secret) is skipped.
       - notExists:
           path: spec.config.service.telemetry.metrics
+
+  - it: should run memory_limiter first and batch last in every pipeline
+    set:
+      agent.enabled: true
+      clusterName: "test-cluster"
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - equal:
+          path: spec.config.service.pipelines.logs.processors
+          value: [memory_limiter, k8s_attributes, resource, batch]
+      - equal:
+          path: spec.config.service.pipelines.metrics.processors
+          value: [memory_limiter, k8s_attributes, resource, cumulativetodelta, batch]
+      - equal:
+          path: spec.config.service.pipelines.traces.processors
+          value: [memory_limiter, k8s_attributes, resource, batch]
+
+  - it: should stamp node identity even without a cluster name
+    set:
+      agent.enabled: true
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      # insert, so k8s_attributes' pod-derived node name is never clobbered.
+      - contains:
+          path: spec.config.processors.resource.attributes
+          content:
+            key: k8s.node.name
+            value: ${env:K8S_NODE_NAME}
+            action: insert
+      # The dead processor is gone: it stamped the collector's own pod UID as
+      # service.instance.id, and was referenced by no pipeline.
+      - isNull:
+          path: spec.config.processors["resource/collector"]
+
+  - it: should exclude pseudo filesystems from the filesystem scraper
+    set:
+      agent.enabled: true
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - contains:
+          path: spec.config.receivers.host_metrics.scrapers.filesystem.exclude_fs_types.fs_types
+          content: overlay
+      - contains:
+          path: spec.config.receivers.host_metrics.scrapers.filesystem.exclude_mount_points.mount_points
+          content: ^/var/lib/kubelet($|/)

--- a/charts/opentelemetry-kube-stack/tests/daemonset_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/daemonset_test.yaml
@@ -5,6 +5,7 @@ templates:
 tests:
   - it: should create daemonset with default values
     set:
+      clusterName: "test-cluster"
       agent.enabled: true
       agent.hostNetwork: true
       serviceAccount.create: true
@@ -25,6 +26,7 @@ tests:
 
   - it: should not include tsuga exporter when enabledForDaemonset is false
     set:
+      clusterName: "test-cluster"
       agent.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -40,6 +42,7 @@ tests:
 
   - it: should configure spanmetrics with low-cardinality HTTP dimensions by default
     set:
+      clusterName: "test-cluster"
       agent.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -65,6 +68,7 @@ tests:
 
   - it: should not reference the Tsuga secret when the exporter is disabled everywhere
     set:
+      clusterName: "test-cluster"
       agent.enabled: true
       tsuga.enabledForClusterReceiver: false
       tsuga.enabledForDaemonset: false
@@ -117,6 +121,7 @@ tests:
 
   - it: should stamp node identity even without a cluster name
     set:
+      clusterName: "test-cluster"
       agent.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -137,6 +142,7 @@ tests:
 
   - it: should exclude pseudo filesystems from the filesystem scraper
     set:
+      clusterName: "test-cluster"
       agent.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -149,3 +155,14 @@ tests:
       - contains:
           path: spec.config.receivers.host_metrics.scrapers.filesystem.exclude_mount_points.mount_points
           content: ^/var/lib/kubelet($|/)
+
+  - it: should fail to render when clusterName is not set
+    set:
+      agent.enabled: true
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - failedTemplate:
+          errorMessage: "clusterName is required: it identifies this cluster in telemetry. Set it with --set clusterName=<name> or in your values file."

--- a/charts/opentelemetry-kube-stack/tests/daemonset_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/daemonset_test.yaml
@@ -113,13 +113,19 @@ tests:
           path: spec.config.service.pipelines.logs.processors
           value: [memory_limiter, k8s_attributes, resource, batch]
       - equal:
+          path: spec.config.service.pipelines["logs/node"].processors
+          value: [memory_limiter, k8s_attributes, resource, resource/node, batch]
+      - equal:
           path: spec.config.service.pipelines.metrics.processors
           value: [memory_limiter, k8s_attributes, resource, cumulativetodelta, batch]
+      - equal:
+          path: spec.config.service.pipelines["metrics/node"].processors
+          value: [memory_limiter, k8s_attributes, resource, resource/node, cumulativetodelta, batch]
       - equal:
           path: spec.config.service.pipelines.traces.processors
           value: [memory_limiter, k8s_attributes, resource, batch]
 
-  - it: should stamp node identity even without a cluster name
+  - it: should stamp the node name only on node-local pipelines
     set:
       clusterName: "test-cluster"
       agent.enabled: true
@@ -128,17 +134,63 @@ tests:
     release:
       name: "test-release"
     asserts:
-      # insert, so k8s_attributes' pod-derived node name is never clobbered.
-      - contains:
+      - equal:
+          path: spec.config.processors["resource/node"].attributes
+          value:
+            - key: k8s.node.name
+              value: ${env:K8S_NODE_NAME}
+              action: upsert
+      # The shared resource processor only carries cluster identity.
+      - equal:
           path: spec.config.processors.resource.attributes
-          content:
-            key: k8s.node.name
-            value: ${env:K8S_NODE_NAME}
-            action: insert
-      # The dead processor is gone: it stamped the collector's own pod UID as
-      # service.instance.id, and was referenced by no pipeline.
+          value:
+            - key: k8s.cluster.name
+              value: test-cluster
+              action: upsert
+      # otlp arrives over a Service that fans out across every agent, so the
+      # receiving node is not the originating node: never stamp it there.
+      - notContains:
+          path: spec.config.service.pipelines.logs.processors
+          content: resource/node
+      - notContains:
+          path: spec.config.service.pipelines.metrics.processors
+          content: resource/node
+      - notContains:
+          path: spec.config.service.pipelines.traces.processors
+          content: resource/node
+      - contains:
+          path: spec.config.service.pipelines.logs.receivers
+          content: otlp
+      - contains:
+          path: spec.config.service.pipelines.metrics.receivers
+          content: otlp
+      # host_metrics and file_log are node-local, so they do get the stamp and
+      # are the only receivers on those pipelines.
+      - equal:
+          path: spec.config.service.pipelines["metrics/node"].receivers
+          value: [host_metrics]
+      - equal:
+          path: spec.config.service.pipelines["logs/node"].receivers
+          value: [file_log]
+      # kubelet_stats sets k8s.node.name itself, so it stays unstamped.
+      - contains:
+          path: spec.config.service.pipelines.metrics.receivers
+          content: kubelet_stats
+
+  - it: should drop the node log pipeline when collectLogs is disabled
+    set:
+      clusterName: "test-cluster"
+      agent.enabled: true
+      agent.collectLogs: false
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
       - isNull:
-          path: spec.config.processors["resource/collector"]
+          path: spec.config.receivers.file_log
+      - isNull:
+          path: spec.config.service.pipelines["logs/node"]
 
   - it: should exclude pseudo filesystems from the filesystem scraper
     set:

--- a/charts/opentelemetry-kube-stack/tests/instrumentation_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/instrumentation_test.yaml
@@ -5,6 +5,7 @@ templates:
 tests:
   - it: should not create instrumentation resource when disabled
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: false
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -16,6 +17,7 @@ tests:
 
   - it: should create instrumentation resource when enabled with minimal config
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -42,6 +44,7 @@ tests:
 
   - it: should use custom apiVersion when specified
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: true
       autoInstrumentation.apiVersion: "opentelemetry.io/v1beta1"
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
@@ -55,6 +58,7 @@ tests:
 
   - it: should use custom name when nameOverride is set
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: true
       autoInstrumentation.nameOverride: "my-custom-instrumentation"
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
@@ -68,6 +72,7 @@ tests:
 
   - it: should include custom labels
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: true
       autoInstrumentation.labels:
         environment: "production"
@@ -86,6 +91,7 @@ tests:
 
   - it: should include custom annotations
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: true
       autoInstrumentation.annotations:
         description: "Auto-instrumentation for production cluster"
@@ -104,6 +110,7 @@ tests:
 
   - it: should pass through spec configuration for Java
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: true
       autoInstrumentation.spec:
         exporter:
@@ -141,6 +148,7 @@ tests:
 
   - it: should pass through spec configuration for multiple languages
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: true
       autoInstrumentation.spec:
         exporter:
@@ -184,6 +192,7 @@ tests:
 
   - it: should include component labels
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -202,6 +211,7 @@ tests:
 
   - it: should truncate name to 63 characters for long release names
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -217,6 +227,7 @@ tests:
 
   - it: should pass through resource attributes
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: true
       autoInstrumentation.spec:
         resource:
@@ -241,6 +252,7 @@ tests:
 
   - it: should work with custom environment variables in spec
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: true
       autoInstrumentation.spec:
         env:

--- a/charts/opentelemetry-kube-stack/tests/integration/test-auto-instrumentation.sh
+++ b/charts/opentelemetry-kube-stack/tests/integration/test-auto-instrumentation.sh
@@ -103,6 +103,7 @@ install_chart() {
     
     helm upgrade --install "$RELEASE_NAME" "$CHART_DIR" \
         --namespace "$TEST_NAMESPACE" \
+        --set clusterName="$RELEASE_NAME" \
         --set autoInstrumentation.enabled=true \
         --set autoInstrumentation.spec.exporter.endpoint="http://localhost:4317" \
         --set autoInstrumentation.spec.propagators[0]=tracecontext \
@@ -318,6 +319,7 @@ test_chart_upgrade() {
     
     helm upgrade "$RELEASE_NAME" "$CHART_DIR" \
         --namespace "$TEST_NAMESPACE" \
+        --set clusterName="$RELEASE_NAME" \
         --set autoInstrumentation.enabled=true \
         --set autoInstrumentation.spec.exporter.endpoint="http://modified-endpoint:4317" \
         --set autoInstrumentation.spec.propagators[0]=tracecontext \
@@ -355,6 +357,7 @@ test_disable_instrumentation() {
     
     helm upgrade "$RELEASE_NAME" "$CHART_DIR" \
         --namespace "$TEST_NAMESPACE" \
+        --set clusterName="$RELEASE_NAME" \
         --set autoInstrumentation.enabled=false \
         --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
         --set tsuga.apiKey="<TSUGA_API_KEY>" \

--- a/charts/opentelemetry-kube-stack/tests/integration/test-deployment.sh
+++ b/charts/opentelemetry-kube-stack/tests/integration/test-deployment.sh
@@ -26,6 +26,7 @@ kubectl create namespace "$NAMESPACE"
 echo "Test 1: Deploying with minimal configuration..."
 helm install "$RELEASE_NAME" "$CHART_PATH" \
     -n "$NAMESPACE" \
+    --set clusterName="$RELEASE_NAME" \
     --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
     --set tsuga.apiKey="<TSUGA_API_KEY>" \
     --wait --timeout=300s
@@ -43,6 +44,7 @@ kubectl get deployment -n "$NAMESPACE" | grep opentelemetry-kube-stack
 echo "Test 2: Testing upgrade..."
 helm upgrade "$RELEASE_NAME" "$CHART_PATH" \
     -n "$NAMESPACE" \
+    --set clusterName="$RELEASE_NAME" \
     --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
     --set tsuga.apiKey="<TSUGA_API_KEY>" \
     --set resources.limits.memory="1Gi" \
@@ -64,6 +66,7 @@ kubectl create secret generic existing-otel-secret \
 
 helm install "$RELEASE_NAME" "$CHART_PATH" \
     -n "$NAMESPACE" \
+    --set clusterName="$RELEASE_NAME" \
     --set secret.existing.enabled=true \
     --set secret.existing.name="existing-otel-secret" \
     --wait --timeout=300s

--- a/charts/opentelemetry-kube-stack/tests/rbac_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/rbac_test.yaml
@@ -5,6 +5,7 @@ templates:
 tests:
   - it: should create cluster role and role binding
     set:
+      clusterName: "test-cluster"
       rbac.create: true
       serviceAccount.create: true
       serviceAccount.name: ""
@@ -16,6 +17,7 @@ tests:
 
   - it: should not include monitoring.coreos.com rules by default
     set:
+      clusterName: "test-cluster"
       rbac.create: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -30,6 +32,7 @@ tests:
 
   - it: should include monitoring.coreos.com rules when prometheusCR enabled
     set:
+      clusterName: "test-cluster"
       rbac.create: true
       targetAllocator.enabled: true
       targetAllocator.spec.prometheusCR.enabled: true
@@ -48,6 +51,7 @@ tests:
 
   - it: should not include endpointslices permission by default
     set:
+      clusterName: "test-cluster"
       rbac.create: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -62,6 +66,7 @@ tests:
 
   - it: should include endpointslices permission when targetAllocator enabled
     set:
+      clusterName: "test-cluster"
       rbac.create: true
       targetAllocator.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"

--- a/charts/opentelemetry-kube-stack/tests/secret_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/secret_test.yaml
@@ -5,6 +5,7 @@ templates:
 tests:
   - it: should create secret with default values
     set:
+      clusterName: "test-cluster"
       secret.create: true
       secret.name: "otel-secret"
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"

--- a/charts/opentelemetry-kube-stack/tests/security/security-scan.sh
+++ b/charts/opentelemetry-kube-stack/tests/security/security-scan.sh
@@ -25,12 +25,14 @@ kubectl create namespace "$NAMESPACE"
 # Deploy chart for security scanning
 helm install "$RELEASE_NAME" "$CHART_PATH" \
     -n "$NAMESPACE" \
+    --set clusterName="$RELEASE_NAME" \
     --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
     --set tsuga.apiKey="<TSUGA_API_KEY>" \
     --wait --timeout=300s
 
 # Get rendered manifests
 helm template "$RELEASE_NAME" "$CHART_PATH" \
+    --set clusterName="$RELEASE_NAME" \
     --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
     --set tsuga.apiKey="<TSUGA_API_KEY>" > /tmp/otel-manifests.yaml
 

--- a/charts/opentelemetry-kube-stack/tests/serviceaccount_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/serviceaccount_test.yaml
@@ -5,6 +5,7 @@ templates:
 tests:
   - it: should create service account with default values
     set:
+      clusterName: "test-cluster"
       serviceAccount.create: true
       serviceAccount.name: ""
     release:

--- a/charts/opentelemetry-kube-stack/tests/statefulset_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/statefulset_test.yaml
@@ -5,6 +5,7 @@ templates:
 tests:
   - it: should not render when targetAllocator disabled
     set:
+      clusterName: "test-cluster"
       targetAllocator.enabled: false
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -16,6 +17,7 @@ tests:
 
   - it: should create statefulset collector when targetAllocator enabled
     set:
+      clusterName: "test-cluster"
       targetAllocator.enabled: true
       serviceAccount.create: true
       serviceAccount.name: ""
@@ -38,6 +40,7 @@ tests:
 
   - it: should not set serviceAccount when serviceAccount.create is false
     set:
+      clusterName: "test-cluster"
       targetAllocator.enabled: true
       serviceAccount.create: false
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
@@ -52,6 +55,7 @@ tests:
 
   - it: should use custom replicas when specified
     set:
+      clusterName: "test-cluster"
       targetAllocator.enabled: true
       statefulset.replicas: 3
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
@@ -65,6 +69,7 @@ tests:
 
   - it: should not include tsuga exporter when enabledForStatefulset is false
     set:
+      clusterName: "test-cluster"
       targetAllocator.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"

--- a/charts/opentelemetry-kube-stack/tests/statefulset_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/statefulset_test.yaml
@@ -82,3 +82,29 @@ tests:
       - equal:
           path: spec.config.service.pipelines.metrics.exporters
           value: []
+
+  - it: should convert cumulative metrics to delta before export
+    set:
+      clusterName: "test-cluster"
+      targetAllocator.enabled: true
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - isNotNull:
+          path: spec.config.processors.cumulativetodelta
+      - equal:
+          path: spec.config.service.pipelines.metrics.processors
+          value: [memory_limiter, cumulativetodelta, k8s_attributes, resource, batch]
+
+  - it: should fail to render when clusterName is not set
+    set:
+      targetAllocator.enabled: true
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - failedTemplate:
+          errorMessage: "clusterName is required: it identifies this cluster in telemetry. Set it with --set clusterName=<name> or in your values file."

--- a/charts/opentelemetry-kube-stack/tests/target-allocator_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/target-allocator_test.yaml
@@ -5,6 +5,7 @@ templates:
 tests:
   - it: should not render when targetAllocator disabled
     set:
+      clusterName: "test-cluster"
       targetAllocator.enabled: false
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -16,6 +17,7 @@ tests:
 
   - it: should create TargetAllocator CR when enabled
     set:
+      clusterName: "test-cluster"
       targetAllocator.enabled: true
       targetAllocator.spec.allocationStrategy: "consistent-hashing"
       serviceAccount.create: true
@@ -36,6 +38,7 @@ tests:
 
   - it: should not set serviceAccount when serviceAccount.create is false
     set:
+      clusterName: "test-cluster"
       targetAllocator.enabled: true
       serviceAccount.create: false
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
@@ -50,6 +53,7 @@ tests:
 
   - it: should set prometheusCR fields when enabled
     set:
+      clusterName: "test-cluster"
       targetAllocator.enabled: true
       targetAllocator.spec.prometheusCR.enabled: true
       targetAllocator.spec.prometheusCR.serviceMonitorSelector.matchLabels.release: "test"

--- a/charts/opentelemetry-kube-stack/tests/values/agent-only.yaml
+++ b/charts/opentelemetry-kube-stack/tests/values/agent-only.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 # Agent-only configuration
 tsuga:
   otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"

--- a/charts/opentelemetry-kube-stack/tests/values/auto-instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/tests/values/auto-instrumentation.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 # Test values file for auto-instrumentation feature
 # This file configures the chart to enable OpenTelemetry auto-instrumentation
 # Use with: helm install my-release . -f tests/values/auto-instrumentation.yaml

--- a/charts/opentelemetry-kube-stack/tests/values/cluster-only.yaml
+++ b/charts/opentelemetry-kube-stack/tests/values/cluster-only.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 # Cluster receiver only configuration
 tsuga:
   otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"

--- a/charts/opentelemetry-kube-stack/tests/values/existing-secret.yaml
+++ b/charts/opentelemetry-kube-stack/tests/values/existing-secret.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 # Configuration using existing secret
 tsuga:
   otlpEndpoint: ""

--- a/charts/opentelemetry-kube-stack/tests/values/minimal.yaml
+++ b/charts/opentelemetry-kube-stack/tests/values/minimal.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 # Minimal configuration for testing
 tsuga:
   otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"

--- a/charts/opentelemetry-kube-stack/tests/values/production.yaml
+++ b/charts/opentelemetry-kube-stack/tests/values/production.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 # Production configuration with resource limits and security
 tsuga:
   otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"

--- a/charts/opentelemetry-kube-stack/values.schema.json
+++ b/charts/opentelemetry-kube-stack/values.schema.json
@@ -73,7 +73,35 @@
                                                 }
                                             }
                                         },
+                                        "logs/node": {
+                                            "type": "object",
+                                            "properties": {
+                                                "extraExporters": {
+                                                    "type": "array"
+                                                },
+                                                "extraProcessors": {
+                                                    "type": "array"
+                                                },
+                                                "extraReceivers": {
+                                                    "type": "array"
+                                                }
+                                            }
+                                        },
                                         "metrics": {
+                                            "type": "object",
+                                            "properties": {
+                                                "extraExporters": {
+                                                    "type": "array"
+                                                },
+                                                "extraProcessors": {
+                                                    "type": "array"
+                                                },
+                                                "extraReceivers": {
+                                                    "type": "array"
+                                                }
+                                            }
+                                        },
+                                        "metrics/node": {
                                             "type": "object",
                                             "properties": {
                                                 "extraExporters": {

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -15,11 +15,13 @@
 #
 # Option 1: Generate new secret (default)
 # helm install my-otel-stack ./charts/opentelemetry-kube-stack \
+#   --set clusterName="<CLUSTER_NAME>" \
 #   --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
 #   --set tsuga.apiKey="<TSUGA_API_KEY>"
 #
 # Option 2: Use existing secret
 # helm install my-otel-stack ./charts/opentelemetry-kube-stack \
+#   --set clusterName="<CLUSTER_NAME>" \
 #   --set secret.create=false \
 #   --set secret.name="my-existing-secret" \
 #   --set secret.keyMapping.TSUGA_API_KEY="<API_KEY_SECRET_KEY>" \
@@ -257,14 +259,15 @@ cluster:
   collectk8sobjects: true
   # -- Gateway collector configuration (merge-based approach)
   # Use this to extend the default configuration
-  # Default config includes: k8s_cluster receiver, k8s_attributes processor, resource processor
+  # Default receivers: k8s_cluster, k8s_objects (when cluster.collectk8sobjects)
+  # Default processors: memory_limiter, resource, k8s_attributes, cumulativetodelta, batch
   config:
     # -- Additional telemetry to merge into the collector configuration
     # Merges with default telemetry
     # @default -- {}
     extraTelemetry: {}
     # -- Additional receivers to merge into the collector configuration
-    # These are merged with default receivers (k8s_cluster)
+    # These are merged with default receivers (k8s_cluster, k8s_objects)
     # Example:
     #   extraReceivers:
     #     prometheus:
@@ -274,7 +277,8 @@ cluster:
     # @default -- {}
     extraReceivers: {}
     # -- Additional processors to merge into the collector configuration
-    # These are merged with default processors (k8s_attributes, resource)
+    # These are merged with default processors (memory_limiter, resource,
+    # k8s_attributes, cumulativetodelta, batch)
     # @default -- {}
     extraProcessors: {}
     # -- Additional exporters to merge into the collector configuration
@@ -400,7 +404,7 @@ agent:
   # @default -- []
   extraEnvs: []
   # -- Collect logs from the host and containers
-  # When true, enables filelog receiver to collect logs from /var/log/pods
+  # When true, enables the file_log receiver to collect logs from /var/log/pods
   # Also mounts required volumes for log collection
   # @default -- true
   collectLogs: true
@@ -435,8 +439,10 @@ agent:
   customConfig: {}
   # -- Agent collector configuration (merge-based approach)
   # Use this to extend the default configuration
-  # Default config includes: filelog, kubelet_stats, host_metrics, otlp, prometheus/self receivers
-  # Default processors: k8s_attributes, memory_limiter, batch, cumulativetodelta, resource
+  # Default receivers: file_log (when agent.collectLogs), kubelet_stats, host_metrics, otlp
+  # Default processors: memory_limiter, k8s_attributes, resource, resource/node,
+  # cumulativetodelta, batch
+  # Default connectors: span_metrics
   config:
     # -- Additional telemetry to merge into the collector configuration
     # Merges with default telemetry (Prometheus metrics on port 8888)
@@ -470,42 +476,73 @@ agent:
       extraExtensions: []
       # -- Pipeline configuration
       pipelines:
-        # -- Logs pipeline configuration
+        # -- Logs pipeline configuration (otlp only; node-local log sources
+        # live in the logs/node pipeline)
         logs:
           # -- Additional exporters to add to the logs pipeline
           # Added to default exporter (otlp_http/tsuga)
           # @default -- []
           extraExporters: []
           # -- Additional processors to add to the logs pipeline
-          # Added to default processors (k8s_attributes, memory_limiter, batch, resource)
+          # Added to default processors (memory_limiter, k8s_attributes, resource, batch)
           # @default -- []
           extraProcessors: []
           # -- Additional receivers to add to the logs pipeline
-          # Added to default receivers (otlp, filelog)
+          # Added to default receivers (otlp)
           # @default -- []
           extraReceivers: []
-        # -- Metrics pipeline configuration
+        # -- Node-local logs pipeline configuration (rendered only when
+        # agent.collectLogs is true)
+        logs/node:
+          # -- Additional exporters to add to the logs/node pipeline
+          # Added to default exporter (otlp_http/tsuga)
+          # @default -- []
+          extraExporters: []
+          # -- Additional processors to add to the logs/node pipeline
+          # Added to default processors (memory_limiter, k8s_attributes, resource, resource/node, batch)
+          # @default -- []
+          extraProcessors: []
+          # -- Additional receivers to add to the logs/node pipeline
+          # Added to default receivers (file_log)
+          # @default -- []
+          extraReceivers: []
+        # -- Metrics pipeline configuration (node-local metric sources live in
+        # the metrics/node pipeline)
         metrics:
           # -- Additional exporters to add to the metrics pipeline
           # Added to default exporter (otlp_http/tsuga)
           # @default -- []
           extraExporters: []
           # -- Additional processors to add to the metrics pipeline
-          # Added to default processors (k8s_attributes, memory_limiter, batch, cumulativetodelta, resource)
+          # Added to default processors (memory_limiter, k8s_attributes, resource, cumulativetodelta, batch)
           # @default -- []
           extraProcessors: []
           # -- Additional receivers to add to the metrics pipeline
-          # Added to default receivers (otlp, kubelet_stats, spanmetrics, host_metrics)
+          # Added to default receivers (otlp, kubelet_stats, span_metrics)
+          # @default -- []
+          extraReceivers: []
+        # -- Node-local metrics pipeline configuration
+        metrics/node:
+          # -- Additional exporters to add to the metrics/node pipeline
+          # Added to default exporter (otlp_http/tsuga)
+          # @default -- []
+          extraExporters: []
+          # -- Additional processors to add to the metrics/node pipeline
+          # Added to default processors (memory_limiter, k8s_attributes, resource, resource/node, cumulativetodelta, batch)
+          # @default -- []
+          extraProcessors: []
+          # -- Additional receivers to add to the metrics/node pipeline
+          # Added to default receivers (host_metrics)
           # @default -- []
           extraReceivers: []
         # -- Traces pipeline configuration
         traces:
           # -- Additional exporters to add to the traces pipeline
-          # Added to default exporters (otlp_http/tsuga, spanmetrics)
+          # Added to default exporters (otlp_http/tsuga, span_metrics)
           # @default -- []
           extraExporters: []
           # -- Additional processors to add to the traces pipeline
-          # Added to default processors (k8s_attributes, memory_limiter, batch, resource)
+          # Added to default processors (memory_limiter, k8s_attributes, resource, batch)
           # @default -- []
           extraProcessors: []
           # -- Additional receivers to add to the traces pipeline

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -58,11 +58,17 @@
 # GLOBAL CONFIGURATION
 # =============================================================================
 
-# -- The name of the cluster to be used in the resource attributes
-# This value is added to all telemetry data as k8s.cluster.name
-# RECOMMENDED: Set this value to identify your cluster in telemetry data
-# If not set, the k8s.cluster.name attribute will be omitted from telemetry
-# @default -- ""
+# -- REQUIRED. The name of the cluster, added to all telemetry as
+# k8s.cluster.name.
+#
+# Installation fails if this is empty. Telemetry from a cluster that does not
+# name itself cannot be told apart from any other cluster's once it reaches
+# Tsuga, and the omission only becomes visible during an incident, which is
+# the worst time to discover it.
+#
+#   --set clusterName=<name>
+#
+# @default -- "" (must be set)
 clusterName: ""
 
 # -- Override the chart name used in resource naming

--- a/charts/opentelemetry-kube-stack/values_ci_test.yaml
+++ b/charts/opentelemetry-kube-stack/values_ci_test.yaml
@@ -31,7 +31,13 @@ agent:
         metrics:
           extraExporters:
             - debug
+        metrics/node:
+          extraExporters:
+            - debug
         logs:
+          extraExporters:
+            - debug
+        logs/node:
           extraExporters:
             - debug
         traces:


### PR DESCRIPTION
⚠️ **Breaking:** installs and upgrades now fail if `clusterName` is empty. Upgrade with `--set clusterName=<name>`.

Four commits: the original pipeline fixes, @abruneau's default-example change, the `clusterName` requirement, and the doc/install-path fallout from it.

## Require `clusterName`

It shipped empty while `values.yaml` called it RECOMMENDED, and `NOTES.txt` has been warning about it for several releases. Telemetry from a cluster that never named itself can't be told apart from any other cluster's in Tsuga, and you find out during an incident.

Enforced with `required` at each point of use, so it fails at install time naming the flag to set:

```
Error: execution error at (opentelemetry-kube-stack/templates/daemonset.yaml:6:16):
clusterName is required: it identifies this cluster in telemetry.
Set it with --set clusterName=<name> or in your values file.
```

Making it mandatory removes the reason it was ever optional, so **7 `{{- if .Values.clusterName }}` branches across 4 templates collapse**: the cluster receiver and statefulset always define their `resource` processor and always reference it, the agent always stamps the attribute, internal telemetry always carries it. The `NOTES.txt` warning is unreachable and dropped.

## Pipeline fixes

**Processor ordering.** The agent pipelines ran `k8s_attributes` before `memory_limiter`, so enrichment happened on data about to be rejected under memory pressure. Logs put `batch` before `resource` while metrics did the reverse. Now `memory_limiter` first, `batch` last, in all three.

**Dead `resource/collector`.** Defined in all three collectors, referenced by no pipeline. It set `service.instance.id` to the collector's own pod UID, so wiring it in would have collapsed every service instance onto one identity — and `service::telemetry` already supplies that. Removed.

**Host metrics had no node identity.** `host_metrics` never touches a pod, so `k8s_attributes` can't associate it — node metrics arrived with no `k8s.node.name` and every node's series collapsed together. The agent's `resource` processor now inserts it (`insert`, so pod-derived values are untouched).

**Two smaller ones.** Cluster receiver pinned to `replicas: 1` — no leader election on `k8s_cluster`/`k8s_objects`, so a second replica double-counts. Filesystem scraper excludes pseudo filesystems, which were emitting a series per overlayfs and tmpfs mount on every node.

#114, #115 and #116 were closed while this reworks the conditionals they build on — branches kept, reopening once this lands and they're rebased.
