### PR TITLE
feat(kube-stack): derive service and container identity from kubernetes

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.1
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-kube-stack
 
-![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
 
 A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet + cluster receiver), secure credential management, and production-ready configurations for telemetry collection to Tsuga platform.
 
@@ -58,7 +58,7 @@ The chart implements the recommended OpenTelemetry architecture with two main co
 
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit). Always first, so load is shed before the pipeline spends work on data it is about to reject.
-- **K8s Attributes** (`k8s_attributes`): Enriches telemetry with Kubernetes metadata and selected pod labels/annotations
+- **K8s Attributes** (`k8s_attributes`): Enriches telemetry with Kubernetes metadata, container image identity, semconv-derived `service.*`, and pod/namespace/node labels (see [Telemetry enrichment](#telemetry-enrichment))
 - **Resource**: Adds `k8s.node.name`, so host metrics are attributable to a node, plus `k8s.cluster.name` when `clusterName` is set
 - **Cumulative To Delta**: Converts cumulative counters to delta where applicable
 - **Batch**: Batches telemetry for efficient processing (`send_batch_size`/`send_batch_max_size` = 5000). Always last.
@@ -127,7 +127,7 @@ agent:
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit)
 - **Resource**: Adds `k8s.cluster.name` (only when `clusterName` is set)
-- **K8s Attributes**: Enriches telemetry with Kubernetes metadata and selected pod labels/annotations
+- **K8s Attributes** (`k8s_attributes`): Enriches telemetry with Kubernetes metadata (see [Telemetry enrichment](#telemetry-enrichment))
 - **Batch**: Batches telemetry for efficient processing
 
 **Default Exporters:**
@@ -138,6 +138,25 @@ agent:
 - **Entity Events (Logs)**: `k8s_cluster` (+`k8s_objects` when enabled) → `memory_limiter`, `resource`¹, `k8s_attributes`, `batch` → `otlp_http/tsuga`
 
 ¹ Only present when `clusterName` is set.
+
+### Telemetry enrichment
+
+All three collectors share one `k8s_attributes` extract configuration, so the same pod is described identically no matter which collector saw the telemetry.
+
+Beyond the usual workload metadata, the defaults add:
+
+- **Container identity** — `k8s.container.name`, `container.image.name`, `container.image.tag`. This is what makes "did this start with the last deploy?" answerable, and is bounded by the number of images in the cluster.
+- **Semconv-derived service identity** — `service.name`, `service.version`, `service.namespace`, computed by the processor from the well-known `app.kubernetes.io/name` label, then the workload name, with the version from the image tag. Workloads that ship telemetry without a configured service name no longer land as `unknown_service`.
+- **Namespace-level ownership** — `resource.opentelemetry.io/team` and `.../env` are read from the namespace as well as the pod, because ownership is usually declared once per namespace.
+- **Node topology** — `cloud.region`, `cloud.availability_zone` and `host.type` from the `topology.kubernetes.io/*` and `node.kubernetes.io/instance-type` node labels. Every managed cluster sets these, and unlike a cloud metadata detector it costs no extra call.
+
+Precedence is **sender > pod > namespace > node**: the processor never overwrites an attribute that is already on the resource, so anything an SDK sets wins, and the explicit `resource.opentelemetry.io/*` pod labels and annotations override everything derived.
+
+Deliberately **not** extracted, despite being available: `k8s.pod.ip`, `k8s.pod.hostname`, `container.id` and `service.instance.id`. Each either takes a new value on every pod or container restart, or simply restates `k8s.pod.name`. They would add a high-cardinality dimension to every datapoint without identifying anything `k8s.pod.name` and `k8s.pod.uid` do not already identify.
+
+Add your own mappings with `agent.extraLabelMapping` / `agent.extraAnnotationsMapping` (and the `cluster.*` / `statefulset.*` equivalents); they are appended to the shared block.
+
+> **Upgrade note:** a workload that previously reported no `service.name` will start reporting one derived from its Kubernetes identity. In Tsuga it moves out of `unknown_service` and into its own service, so existing dashboards or monitors that filter on `unknown_service` need updating.
 
 ## Quick Start
 

--- a/charts/opentelemetry-kube-stack/README.md.gotmpl
+++ b/charts/opentelemetry-kube-stack/README.md.gotmpl
@@ -48,7 +48,7 @@ The chart implements the recommended OpenTelemetry architecture with two main co
 
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit). Always first, so load is shed before the pipeline spends work on data it is about to reject.
-- **K8s Attributes** (`k8s_attributes`): Enriches telemetry with Kubernetes metadata and selected pod labels/annotations
+- **K8s Attributes** (`k8s_attributes`): Enriches telemetry with Kubernetes metadata, container image identity, semconv-derived `service.*`, and pod/namespace/node labels (see [Telemetry enrichment](#telemetry-enrichment))
 - **Resource**: Adds `k8s.node.name`, so host metrics are attributable to a node, plus `k8s.cluster.name` when `clusterName` is set
 - **Cumulative To Delta**: Converts cumulative counters to delta where applicable
 - **Batch**: Batches telemetry for efficient processing (`send_batch_size`/`send_batch_max_size` = 5000). Always last.
@@ -117,7 +117,7 @@ agent:
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit)
 - **Resource**: Adds `k8s.cluster.name` (only when `clusterName` is set)
-- **K8s Attributes**: Enriches telemetry with Kubernetes metadata and selected pod labels/annotations
+- **K8s Attributes** (`k8s_attributes`): Enriches telemetry with Kubernetes metadata (see [Telemetry enrichment](#telemetry-enrichment))
 - **Batch**: Batches telemetry for efficient processing
 
 **Default Exporters:**
@@ -128,6 +128,25 @@ agent:
 - **Entity Events (Logs)**: `k8s_cluster` (+`k8s_objects` when enabled) → `memory_limiter`, `resource`¹, `k8s_attributes`, `batch` → `otlp_http/tsuga`
 
 ¹ Only present when `clusterName` is set.
+
+### Telemetry enrichment
+
+All three collectors share one `k8s_attributes` extract configuration, so the same pod is described identically no matter which collector saw the telemetry.
+
+Beyond the usual workload metadata, the defaults add:
+
+- **Container identity** — `k8s.container.name`, `container.image.name`, `container.image.tag`. This is what makes "did this start with the last deploy?" answerable, and is bounded by the number of images in the cluster.
+- **Semconv-derived service identity** — `service.name`, `service.version`, `service.namespace`, computed by the processor from the well-known `app.kubernetes.io/name` label, then the workload name, with the version from the image tag. Workloads that ship telemetry without a configured service name no longer land as `unknown_service`.
+- **Namespace-level ownership** — `resource.opentelemetry.io/team` and `.../env` are read from the namespace as well as the pod, because ownership is usually declared once per namespace.
+- **Node topology** — `cloud.region`, `cloud.availability_zone` and `host.type` from the `topology.kubernetes.io/*` and `node.kubernetes.io/instance-type` node labels. Every managed cluster sets these, and unlike a cloud metadata detector it costs no extra call.
+
+Precedence is **sender > pod > namespace > node**: the processor never overwrites an attribute that is already on the resource, so anything an SDK sets wins, and the explicit `resource.opentelemetry.io/*` pod labels and annotations override everything derived.
+
+Deliberately **not** extracted, despite being available: `k8s.pod.ip`, `k8s.pod.hostname`, `container.id` and `service.instance.id`. Each either takes a new value on every pod or container restart, or simply restates `k8s.pod.name`. They would add a high-cardinality dimension to every datapoint without identifying anything `k8s.pod.name` and `k8s.pod.uid` do not already identify.
+
+Add your own mappings with `agent.extraLabelMapping` / `agent.extraAnnotationsMapping` (and the `cluster.*` / `statefulset.*` equivalents); they are appended to the shared block.
+
+> **Upgrade note:** a workload that previously reported no `service.name` will start reporting one derived from its Kubernetes identity. In Tsuga it moves out of `unknown_service` and into its own service, so existing dashboards or monitors that filter on `unknown_service` need updating.
 
 ## Quick Start
 

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
@@ -110,6 +110,12 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
           labels:
           - from: pod
             key: resource.opentelemetry.io/service.name
@@ -123,17 +129,41 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
+          - from: node
+            key: topology.kubernetes.io/region
+            tag_name: cloud.region
+          - from: node
+            key: topology.kubernetes.io/zone
+            tag_name: cloud.availability_zone
+          - from: node
+            key: node.kubernetes.io/instance-type
+            tag_name: host.type
           metadata:
           - k8s.namespace.name
           - k8s.deployment.name
+          - k8s.replicaset.name
           - k8s.statefulset.name
           - k8s.daemonset.name
           - k8s.cronjob.name
           - k8s.job.name
           - k8s.node.name
+          - k8s.node.uid
+          - k8s.cluster.uid
           - k8s.pod.name
           - k8s.pod.uid
           - k8s.pod.start_time
+          - k8s.container.name
+          - container.image.name
+          - container.image.tag
+          - service.namespace
+          - service.name
+          - service.version
         passthrough: false
         pod_association:
         - sources:

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/daemonset.yaml
@@ -196,6 +196,12 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
           labels:
           - from: pod
             key: resource.opentelemetry.io/service.name
@@ -209,17 +215,41 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
+          - from: node
+            key: topology.kubernetes.io/region
+            tag_name: cloud.region
+          - from: node
+            key: topology.kubernetes.io/zone
+            tag_name: cloud.availability_zone
+          - from: node
+            key: node.kubernetes.io/instance-type
+            tag_name: host.type
           metadata:
           - k8s.namespace.name
           - k8s.deployment.name
+          - k8s.replicaset.name
           - k8s.statefulset.name
           - k8s.daemonset.name
           - k8s.cronjob.name
           - k8s.job.name
           - k8s.node.name
+          - k8s.node.uid
+          - k8s.cluster.uid
           - k8s.pod.name
           - k8s.pod.uid
           - k8s.pod.start_time
+          - k8s.container.name
+          - container.image.name
+          - container.image.tag
+          - service.namespace
+          - service.name
+          - service.version
         filter:
           node_from_env_var: K8S_NODE_NAME
         passthrough: false

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
@@ -110,6 +110,12 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
           labels:
           - from: pod
             key: resource.opentelemetry.io/service.name
@@ -123,17 +129,41 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
+          - from: node
+            key: topology.kubernetes.io/region
+            tag_name: cloud.region
+          - from: node
+            key: topology.kubernetes.io/zone
+            tag_name: cloud.availability_zone
+          - from: node
+            key: node.kubernetes.io/instance-type
+            tag_name: host.type
           metadata:
           - k8s.namespace.name
           - k8s.deployment.name
+          - k8s.replicaset.name
           - k8s.statefulset.name
           - k8s.daemonset.name
           - k8s.cronjob.name
           - k8s.job.name
           - k8s.node.name
+          - k8s.node.uid
+          - k8s.cluster.uid
           - k8s.pod.name
           - k8s.pod.uid
           - k8s.pod.start_time
+          - k8s.container.name
+          - container.image.name
+          - container.image.tag
+          - service.namespace
+          - service.name
+          - service.version
         passthrough: false
         pod_association:
         - sources:

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/daemonset.yaml
@@ -196,6 +196,12 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
           labels:
           - from: pod
             key: resource.opentelemetry.io/service.name
@@ -209,17 +215,41 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
+          - from: node
+            key: topology.kubernetes.io/region
+            tag_name: cloud.region
+          - from: node
+            key: topology.kubernetes.io/zone
+            tag_name: cloud.availability_zone
+          - from: node
+            key: node.kubernetes.io/instance-type
+            tag_name: host.type
           metadata:
           - k8s.namespace.name
           - k8s.deployment.name
+          - k8s.replicaset.name
           - k8s.statefulset.name
           - k8s.daemonset.name
           - k8s.cronjob.name
           - k8s.job.name
           - k8s.node.name
+          - k8s.node.uid
+          - k8s.cluster.uid
           - k8s.pod.name
           - k8s.pod.uid
           - k8s.pod.start_time
+          - k8s.container.name
+          - container.image.name
+          - container.image.tag
+          - service.namespace
+          - service.name
+          - service.version
         filter:
           node_from_env_var: K8S_NODE_NAME
         passthrough: false

--- a/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
@@ -110,6 +110,12 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
           labels:
           - from: pod
             key: resource.opentelemetry.io/service.name
@@ -123,17 +129,41 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
+          - from: node
+            key: topology.kubernetes.io/region
+            tag_name: cloud.region
+          - from: node
+            key: topology.kubernetes.io/zone
+            tag_name: cloud.availability_zone
+          - from: node
+            key: node.kubernetes.io/instance-type
+            tag_name: host.type
           metadata:
           - k8s.namespace.name
           - k8s.deployment.name
+          - k8s.replicaset.name
           - k8s.statefulset.name
           - k8s.daemonset.name
           - k8s.cronjob.name
           - k8s.job.name
           - k8s.node.name
+          - k8s.node.uid
+          - k8s.cluster.uid
           - k8s.pod.name
           - k8s.pod.uid
           - k8s.pod.start_time
+          - k8s.container.name
+          - container.image.name
+          - container.image.tag
+          - service.namespace
+          - service.name
+          - service.version
         passthrough: false
         pod_association:
         - sources:

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
@@ -110,6 +110,12 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
           labels:
           - from: pod
             key: resource.opentelemetry.io/service.name
@@ -123,17 +129,41 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
+          - from: node
+            key: topology.kubernetes.io/region
+            tag_name: cloud.region
+          - from: node
+            key: topology.kubernetes.io/zone
+            tag_name: cloud.availability_zone
+          - from: node
+            key: node.kubernetes.io/instance-type
+            tag_name: host.type
           metadata:
           - k8s.namespace.name
           - k8s.deployment.name
+          - k8s.replicaset.name
           - k8s.statefulset.name
           - k8s.daemonset.name
           - k8s.cronjob.name
           - k8s.job.name
           - k8s.node.name
+          - k8s.node.uid
+          - k8s.cluster.uid
           - k8s.pod.name
           - k8s.pod.uid
           - k8s.pod.start_time
+          - k8s.container.name
+          - container.image.name
+          - container.image.tag
+          - service.namespace
+          - service.name
+          - service.version
         passthrough: false
         pod_association:
         - sources:

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/daemonset.yaml
@@ -196,6 +196,12 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
           labels:
           - from: pod
             key: resource.opentelemetry.io/service.name
@@ -209,17 +215,41 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
+          - from: node
+            key: topology.kubernetes.io/region
+            tag_name: cloud.region
+          - from: node
+            key: topology.kubernetes.io/zone
+            tag_name: cloud.availability_zone
+          - from: node
+            key: node.kubernetes.io/instance-type
+            tag_name: host.type
           metadata:
           - k8s.namespace.name
           - k8s.deployment.name
+          - k8s.replicaset.name
           - k8s.statefulset.name
           - k8s.daemonset.name
           - k8s.cronjob.name
           - k8s.job.name
           - k8s.node.name
+          - k8s.node.uid
+          - k8s.cluster.uid
           - k8s.pod.name
           - k8s.pod.uid
           - k8s.pod.start_time
+          - k8s.container.name
+          - container.image.name
+          - container.image.tag
+          - service.namespace
+          - service.name
+          - service.version
         filter:
           node_from_env_var: K8S_NODE_NAME
         passthrough: false

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
@@ -110,6 +110,12 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
           labels:
           - from: pod
             key: resource.opentelemetry.io/service.name
@@ -123,17 +129,41 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
+          - from: node
+            key: topology.kubernetes.io/region
+            tag_name: cloud.region
+          - from: node
+            key: topology.kubernetes.io/zone
+            tag_name: cloud.availability_zone
+          - from: node
+            key: node.kubernetes.io/instance-type
+            tag_name: host.type
           metadata:
           - k8s.namespace.name
           - k8s.deployment.name
+          - k8s.replicaset.name
           - k8s.statefulset.name
           - k8s.daemonset.name
           - k8s.cronjob.name
           - k8s.job.name
           - k8s.node.name
+          - k8s.node.uid
+          - k8s.cluster.uid
           - k8s.pod.name
           - k8s.pod.uid
           - k8s.pod.start_time
+          - k8s.container.name
+          - container.image.name
+          - container.image.tag
+          - service.namespace
+          - service.name
+          - service.version
         passthrough: false
         pod_association:
         - sources:

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/daemonset.yaml
@@ -196,6 +196,12 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
           labels:
           - from: pod
             key: resource.opentelemetry.io/service.name
@@ -209,17 +215,41 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
+          - from: node
+            key: topology.kubernetes.io/region
+            tag_name: cloud.region
+          - from: node
+            key: topology.kubernetes.io/zone
+            tag_name: cloud.availability_zone
+          - from: node
+            key: node.kubernetes.io/instance-type
+            tag_name: host.type
           metadata:
           - k8s.namespace.name
           - k8s.deployment.name
+          - k8s.replicaset.name
           - k8s.statefulset.name
           - k8s.daemonset.name
           - k8s.cronjob.name
           - k8s.job.name
           - k8s.node.name
+          - k8s.node.uid
+          - k8s.cluster.uid
           - k8s.pod.name
           - k8s.pod.uid
           - k8s.pod.start_time
+          - k8s.container.name
+          - container.image.name
+          - container.image.tag
+          - service.namespace
+          - service.name
+          - service.version
         filter:
           node_from_env_var: K8S_NODE_NAME
         passthrough: false

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
@@ -110,6 +110,12 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
           labels:
           - from: pod
             key: resource.opentelemetry.io/service.name
@@ -123,17 +129,41 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
+          - from: node
+            key: topology.kubernetes.io/region
+            tag_name: cloud.region
+          - from: node
+            key: topology.kubernetes.io/zone
+            tag_name: cloud.availability_zone
+          - from: node
+            key: node.kubernetes.io/instance-type
+            tag_name: host.type
           metadata:
           - k8s.namespace.name
           - k8s.deployment.name
+          - k8s.replicaset.name
           - k8s.statefulset.name
           - k8s.daemonset.name
           - k8s.cronjob.name
           - k8s.job.name
           - k8s.node.name
+          - k8s.node.uid
+          - k8s.cluster.uid
           - k8s.pod.name
           - k8s.pod.uid
           - k8s.pod.start_time
+          - k8s.container.name
+          - container.image.name
+          - container.image.tag
+          - service.namespace
+          - service.name
+          - service.version
         passthrough: false
         pod_association:
         - sources:

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/daemonset.yaml
@@ -196,6 +196,12 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
           labels:
           - from: pod
             key: resource.opentelemetry.io/service.name
@@ -209,17 +215,41 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
+          - from: node
+            key: topology.kubernetes.io/region
+            tag_name: cloud.region
+          - from: node
+            key: topology.kubernetes.io/zone
+            tag_name: cloud.availability_zone
+          - from: node
+            key: node.kubernetes.io/instance-type
+            tag_name: host.type
           metadata:
           - k8s.namespace.name
           - k8s.deployment.name
+          - k8s.replicaset.name
           - k8s.statefulset.name
           - k8s.daemonset.name
           - k8s.cronjob.name
           - k8s.job.name
           - k8s.node.name
+          - k8s.node.uid
+          - k8s.cluster.uid
           - k8s.pod.name
           - k8s.pod.uid
           - k8s.pod.start_time
+          - k8s.container.name
+          - container.image.name
+          - container.image.tag
+          - service.namespace
+          - service.name
+          - service.version
         filter:
           node_from_env_var: K8S_NODE_NAME
         passthrough: false

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
@@ -110,6 +110,12 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
           labels:
           - from: pod
             key: resource.opentelemetry.io/service.name
@@ -123,17 +129,41 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
+          - from: node
+            key: topology.kubernetes.io/region
+            tag_name: cloud.region
+          - from: node
+            key: topology.kubernetes.io/zone
+            tag_name: cloud.availability_zone
+          - from: node
+            key: node.kubernetes.io/instance-type
+            tag_name: host.type
           metadata:
           - k8s.namespace.name
           - k8s.deployment.name
+          - k8s.replicaset.name
           - k8s.statefulset.name
           - k8s.daemonset.name
           - k8s.cronjob.name
           - k8s.job.name
           - k8s.node.name
+          - k8s.node.uid
+          - k8s.cluster.uid
           - k8s.pod.name
           - k8s.pod.uid
           - k8s.pod.start_time
+          - k8s.container.name
+          - container.image.name
+          - container.image.tag
+          - service.namespace
+          - service.name
+          - service.version
         passthrough: false
         pod_association:
         - sources:

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/daemonset.yaml
@@ -206,6 +206,12 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
           labels:
           - from: pod
             key: resource.opentelemetry.io/service.name
@@ -219,17 +225,41 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
+          - from: node
+            key: topology.kubernetes.io/region
+            tag_name: cloud.region
+          - from: node
+            key: topology.kubernetes.io/zone
+            tag_name: cloud.availability_zone
+          - from: node
+            key: node.kubernetes.io/instance-type
+            tag_name: host.type
           metadata:
           - k8s.namespace.name
           - k8s.deployment.name
+          - k8s.replicaset.name
           - k8s.statefulset.name
           - k8s.daemonset.name
           - k8s.cronjob.name
           - k8s.job.name
           - k8s.node.name
+          - k8s.node.uid
+          - k8s.cluster.uid
           - k8s.pod.name
           - k8s.pod.uid
           - k8s.pod.start_time
+          - k8s.container.name
+          - container.image.name
+          - container.image.tag
+          - service.namespace
+          - service.name
+          - service.version
         filter:
           node_from_env_var: K8S_NODE_NAME
         passthrough: false

--- a/charts/opentelemetry-kube-stack/examples/target-allocator/rendered/statefulset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/target-allocator/rendered/statefulset.yaml
@@ -97,6 +97,12 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
           labels:
           - from: pod
             key: resource.opentelemetry.io/service.name
@@ -110,17 +116,41 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
+          - from: node
+            key: topology.kubernetes.io/region
+            tag_name: cloud.region
+          - from: node
+            key: topology.kubernetes.io/zone
+            tag_name: cloud.availability_zone
+          - from: node
+            key: node.kubernetes.io/instance-type
+            tag_name: host.type
           metadata:
           - k8s.namespace.name
           - k8s.deployment.name
+          - k8s.replicaset.name
           - k8s.statefulset.name
           - k8s.daemonset.name
           - k8s.cronjob.name
           - k8s.job.name
           - k8s.node.name
+          - k8s.node.uid
+          - k8s.cluster.uid
           - k8s.pod.name
           - k8s.pod.uid
           - k8s.pod.start_time
+          - k8s.container.name
+          - container.image.name
+          - container.image.tag
+          - service.namespace
+          - service.name
+          - service.version
         passthrough: false
         pod_association:
         - sources:

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
@@ -100,6 +100,12 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
           labels:
           - from: pod
             key: resource.opentelemetry.io/service.name
@@ -113,17 +119,41 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
+          - from: node
+            key: topology.kubernetes.io/region
+            tag_name: cloud.region
+          - from: node
+            key: topology.kubernetes.io/zone
+            tag_name: cloud.availability_zone
+          - from: node
+            key: node.kubernetes.io/instance-type
+            tag_name: host.type
           metadata:
           - k8s.namespace.name
           - k8s.deployment.name
+          - k8s.replicaset.name
           - k8s.statefulset.name
           - k8s.daemonset.name
           - k8s.cronjob.name
           - k8s.job.name
           - k8s.node.name
+          - k8s.node.uid
+          - k8s.cluster.uid
           - k8s.pod.name
           - k8s.pod.uid
           - k8s.pod.start_time
+          - k8s.container.name
+          - container.image.name
+          - container.image.tag
+          - service.namespace
+          - service.name
+          - service.version
         passthrough: false
         pod_association:
         - sources:

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/daemonset.yaml
@@ -186,6 +186,12 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
           labels:
           - from: pod
             key: resource.opentelemetry.io/service.name
@@ -199,17 +205,41 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
+          - from: node
+            key: topology.kubernetes.io/region
+            tag_name: cloud.region
+          - from: node
+            key: topology.kubernetes.io/zone
+            tag_name: cloud.availability_zone
+          - from: node
+            key: node.kubernetes.io/instance-type
+            tag_name: host.type
           metadata:
           - k8s.namespace.name
           - k8s.deployment.name
+          - k8s.replicaset.name
           - k8s.statefulset.name
           - k8s.daemonset.name
           - k8s.cronjob.name
           - k8s.job.name
           - k8s.node.name
+          - k8s.node.uid
+          - k8s.cluster.uid
           - k8s.pod.name
           - k8s.pod.uid
           - k8s.pod.start_time
+          - k8s.container.name
+          - container.image.name
+          - container.image.tag
+          - service.namespace
+          - service.name
+          - service.version
         filter:
           node_from_env_var: K8S_NODE_NAME
         passthrough: false

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/statefulset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/statefulset.yaml
@@ -87,6 +87,12 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
           labels:
           - from: pod
             key: resource.opentelemetry.io/service.name
@@ -100,17 +106,41 @@ spec:
           - from: pod
             key: resource.opentelemetry.io/team
             tag_name: team
+          - from: namespace
+            key: resource.opentelemetry.io/env
+            tag_name: env
+          - from: namespace
+            key: resource.opentelemetry.io/team
+            tag_name: team
+          - from: node
+            key: topology.kubernetes.io/region
+            tag_name: cloud.region
+          - from: node
+            key: topology.kubernetes.io/zone
+            tag_name: cloud.availability_zone
+          - from: node
+            key: node.kubernetes.io/instance-type
+            tag_name: host.type
           metadata:
           - k8s.namespace.name
           - k8s.deployment.name
+          - k8s.replicaset.name
           - k8s.statefulset.name
           - k8s.daemonset.name
           - k8s.cronjob.name
           - k8s.job.name
           - k8s.node.name
+          - k8s.node.uid
+          - k8s.cluster.uid
           - k8s.pod.name
           - k8s.pod.uid
           - k8s.pod.start_time
+          - k8s.container.name
+          - container.image.name
+          - container.image.tag
+          - service.namespace
+          - service.name
+          - service.version
         passthrough: false
         pod_association:
         - sources:

--- a/charts/opentelemetry-kube-stack/templates/_config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_config.tpl
@@ -46,6 +46,116 @@ Generate environment variables for OpenTelemetry Collector
 {{- end }}
 
 {{/*
+Shared k8s_attributes `extract` block.
+
+Kept in one place because the agent, cluster receiver and statefulset collector
+must enrich identically: otherwise the same pod is described differently
+depending on which collector happened to see the telemetry.
+
+Precedence inside the processor is pod > namespace > node, and it never
+overwrites an attribute the sender already set, so SDK-provided values always
+win over anything derived here.
+
+Context: dict "extraLabelMapping" <list> "extraAnnotationsMapping" <list>
+*/}}
+{{- define "opentelemetry-kube-stack.k8sAttributesExtract" -}}
+metadata:
+  # Workload and pod identity.
+  - k8s.namespace.name
+  - k8s.deployment.name
+  - k8s.replicaset.name
+  - k8s.statefulset.name
+  - k8s.daemonset.name
+  - k8s.cronjob.name
+  - k8s.job.name
+  - k8s.node.name
+  - k8s.node.uid
+  - k8s.cluster.uid
+  - k8s.pod.name
+  - k8s.pod.uid
+  - k8s.pod.start_time
+  # Deliberately not extracted: k8s.pod.ip, k8s.pod.hostname, container.id and
+  # service.instance.id. Each takes a new value on every pod or container
+  # restart, or simply restates k8s.pod.name, so they cost a high-cardinality
+  # dimension on every datapoint and identify nothing that k8s.pod.name and
+  # k8s.pod.uid do not already identify.
+  #
+  # Container identity. Bounded by the number of images in the cluster, and
+  # what makes "did this start with the last deploy?" answerable. Applied when
+  # the incoming resource carries k8s.container.name, which filelog sets via
+  # the container parser.
+  - k8s.container.name
+  - container.image.name
+  - container.image.tag
+  # Computed by the processor from the OpenTelemetry semantic conventions:
+  # service.name from the well-known app.kubernetes.io/name label then the
+  # workload name, service.version from the image tag. This is what keeps
+  # workloads that ship telemetry without a configured service name from
+  # landing as "unknown_service".
+  - service.namespace
+  - service.name
+  - service.version
+labels:
+  # Explicit opt-in. Set these on a pod to override anything computed above.
+  - tag_name: service.name
+    key: resource.opentelemetry.io/service.name
+    from: pod
+  - tag_name: service.version
+    key: resource.opentelemetry.io/service.version
+    from: pod
+  - tag_name: env
+    key: resource.opentelemetry.io/env
+    from: pod
+  - tag_name: team
+    key: resource.opentelemetry.io/team
+    from: pod
+  # Ownership is usually declared once per namespace rather than on every pod.
+  - tag_name: env
+    key: resource.opentelemetry.io/env
+    from: namespace
+  - tag_name: team
+    key: resource.opentelemetry.io/team
+    from: namespace
+  # Node topology straight from the Kubernetes API: the same attributes the
+  # cloud detectors would give us, with no metadata-service calls. Simply
+  # absent on clusters that do not set the well-known labels.
+  - tag_name: cloud.region
+    key: topology.kubernetes.io/region
+    from: node
+  - tag_name: cloud.availability_zone
+    key: topology.kubernetes.io/zone
+    from: node
+  - tag_name: host.type
+    key: node.kubernetes.io/instance-type
+    from: node
+{{- with .extraLabelMapping }}
+{{- toYaml . | nindent 2 }}
+{{- end }}
+annotations:
+  - tag_name: service.name
+    key: resource.opentelemetry.io/service.name
+    from: pod
+  - tag_name: service.version
+    key: resource.opentelemetry.io/service.version
+    from: pod
+  - tag_name: env
+    key: resource.opentelemetry.io/env
+    from: pod
+  - tag_name: team
+    key: resource.opentelemetry.io/team
+    from: pod
+  - tag_name: env
+    key: resource.opentelemetry.io/env
+    from: namespace
+  - tag_name: team
+    key: resource.opentelemetry.io/team
+    from: namespace
+{{- with .extraAnnotationsMapping }}
+{{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
 Generate Tsuga exporters configuration
 */}}
 {{- define "opentelemetry-kube-stack.tsugaExporters" -}}

--- a/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
@@ -29,49 +29,7 @@ processors:
     send_batch_max_size: 5000
   k8s_attributes:
     extract:
-      metadata:
-        - k8s.namespace.name
-        - k8s.deployment.name
-        - k8s.statefulset.name
-        - k8s.daemonset.name
-        - k8s.cronjob.name
-        - k8s.job.name
-        - k8s.node.name
-        - k8s.pod.name
-        - k8s.pod.uid
-        - k8s.pod.start_time
-      labels:
-        - tag_name: service.name
-          key: resource.opentelemetry.io/service.name
-          from: pod
-        - tag_name: service.version
-          key: resource.opentelemetry.io/service.version
-          from: pod
-        - tag_name: env
-          key: resource.opentelemetry.io/env
-          from: pod
-        - tag_name: team
-          key: resource.opentelemetry.io/team
-          from: pod
-{{- if .Values.cluster.extraLabelMapping }}
-{{- toYaml .Values.cluster.extraLabelMapping | nindent 8 }}
-{{- end}}
-      annotations:
-        - tag_name: service.name
-          key: resource.opentelemetry.io/service.name
-          from: pod
-        - tag_name: service.version
-          key: resource.opentelemetry.io/service.version
-          from: pod
-        - tag_name: env
-          key: resource.opentelemetry.io/env
-          from: pod
-        - tag_name: team
-          key: resource.opentelemetry.io/team
-          from: pod
-{{- if .Values.cluster.extraAnnotationsMapping }}
-{{- toYaml .Values.cluster.extraAnnotationsMapping | nindent 8 }}
-{{- end}}
+      {{- include "opentelemetry-kube-stack.k8sAttributesExtract" (dict "extraLabelMapping" .Values.cluster.extraLabelMapping "extraAnnotationsMapping" .Values.cluster.extraAnnotationsMapping) | nindent 6 }}
     passthrough: false
     pod_association:
       - sources:

--- a/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
@@ -123,49 +123,7 @@ processors:
     send_batch_max_size: 5000
   k8s_attributes:
     extract:
-      metadata:
-        - k8s.namespace.name
-        - k8s.deployment.name
-        - k8s.statefulset.name
-        - k8s.daemonset.name
-        - k8s.cronjob.name
-        - k8s.job.name
-        - k8s.node.name
-        - k8s.pod.name
-        - k8s.pod.uid
-        - k8s.pod.start_time
-      labels:
-        - tag_name: service.name
-          key: resource.opentelemetry.io/service.name
-          from: pod
-        - tag_name: service.version
-          key: resource.opentelemetry.io/service.version
-          from: pod
-        - tag_name: env
-          key: resource.opentelemetry.io/env
-          from: pod
-        - tag_name: team
-          key: resource.opentelemetry.io/team
-          from: pod
-{{- if .Values.agent.extraLabelMapping }}
-{{- toYaml .Values.agent.extraLabelMapping | nindent 8 }}
-{{- end}}
-      annotations:
-        - tag_name: service.name
-          key: resource.opentelemetry.io/service.name
-          from: pod
-        - tag_name: service.version
-          key: resource.opentelemetry.io/service.version
-          from: pod
-        - tag_name: env
-          key: resource.opentelemetry.io/env
-          from: pod
-        - tag_name: team
-          key: resource.opentelemetry.io/team
-          from: pod
-{{- if .Values.agent.extraAnnotationsMapping }}
-{{- toYaml .Values.agent.extraAnnotationsMapping | nindent 8 }}
-{{- end}}
+      {{- include "opentelemetry-kube-stack.k8sAttributesExtract" (dict "extraLabelMapping" .Values.agent.extraLabelMapping "extraAnnotationsMapping" .Values.agent.extraAnnotationsMapping) | nindent 6 }}
     filter:
       node_from_env_var: K8S_NODE_NAME
     passthrough: false

--- a/charts/opentelemetry-kube-stack/templates/_default-statefulset-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-statefulset-config.tpl
@@ -25,49 +25,7 @@ processors:
   cumulativetodelta: {}
   k8s_attributes:
     extract:
-      metadata:
-        - k8s.namespace.name
-        - k8s.deployment.name
-        - k8s.statefulset.name
-        - k8s.daemonset.name
-        - k8s.cronjob.name
-        - k8s.job.name
-        - k8s.node.name
-        - k8s.pod.name
-        - k8s.pod.uid
-        - k8s.pod.start_time
-      labels:
-        - tag_name: service.name
-          key: resource.opentelemetry.io/service.name
-          from: pod
-        - tag_name: service.version
-          key: resource.opentelemetry.io/service.version
-          from: pod
-        - tag_name: env
-          key: resource.opentelemetry.io/env
-          from: pod
-        - tag_name: team
-          key: resource.opentelemetry.io/team
-          from: pod
-{{- if .Values.statefulset.extraLabelMapping }}
-{{- toYaml .Values.statefulset.extraLabelMapping | nindent 8 }}
-{{- end}}
-      annotations:
-        - tag_name: service.name
-          key: resource.opentelemetry.io/service.name
-          from: pod
-        - tag_name: service.version
-          key: resource.opentelemetry.io/service.version
-          from: pod
-        - tag_name: env
-          key: resource.opentelemetry.io/env
-          from: pod
-        - tag_name: team
-          key: resource.opentelemetry.io/team
-          from: pod
-{{- if .Values.statefulset.extraAnnotationsMapping }}
-{{- toYaml .Values.statefulset.extraAnnotationsMapping | nindent 8 }}
-{{- end}}
+      {{- include "opentelemetry-kube-stack.k8sAttributesExtract" (dict "extraLabelMapping" .Values.statefulset.extraLabelMapping "extraAnnotationsMapping" .Values.statefulset.extraAnnotationsMapping) | nindent 6 }}
     passthrough: false
     pod_association:
       - sources:

--- a/charts/opentelemetry-kube-stack/tests/daemonset_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/daemonset_test.yaml
@@ -149,3 +149,65 @@ tests:
       - contains:
           path: spec.config.receivers.host_metrics.scrapers.filesystem.exclude_mount_points.mount_points
           content: ^/var/lib/kubelet($|/)
+
+  - it: should derive service identity and container image from kubernetes
+    set:
+      agent.enabled: true
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - contains:
+          path: spec.config.processors.k8s_attributes.extract.metadata
+          content: service.name
+      - contains:
+          path: spec.config.processors.k8s_attributes.extract.metadata
+          content: container.image.tag
+      # High-cardinality attributes are deliberately excluded: each takes a new
+      # value on every pod or container restart, or restates k8s.pod.name.
+      - notContains:
+          path: spec.config.processors.k8s_attributes.extract.metadata
+          content: k8s.pod.ip
+      - notContains:
+          path: spec.config.processors.k8s_attributes.extract.metadata
+          content: k8s.pod.hostname
+      - notContains:
+          path: spec.config.processors.k8s_attributes.extract.metadata
+          content: container.id
+      - notContains:
+          path: spec.config.processors.k8s_attributes.extract.metadata
+          content: service.instance.id
+      # Ownership falls back to the namespace when a pod does not declare it.
+      - contains:
+          path: spec.config.processors.k8s_attributes.extract.labels
+          content:
+            tag_name: team
+            key: resource.opentelemetry.io/team
+            from: namespace
+      # Node topology without any cloud metadata calls.
+      - contains:
+          path: spec.config.processors.k8s_attributes.extract.labels
+          content:
+            tag_name: cloud.region
+            key: topology.kubernetes.io/region
+            from: node
+
+  - it: should keep extra label mappings when merged into the shared extract block
+    set:
+      agent.enabled: true
+      agent.extraLabelMapping:
+        - tag_name: app.version
+          key: app.version
+          from: pod
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - contains:
+          path: spec.config.processors.k8s_attributes.extract.labels
+          content:
+            tag_name: app.version
+            key: app.version
+            from: pod


### PR DESCRIPTION
`k8s_attributes` extracted ten fields and required an explicit `resource.opentelemetry.io/service.name` label or annotation to give a workload a service identity. Anything shipping telemetry without one arrived as `unknown_service`.

The processor can compute `service.name`, `service.version`, `service.namespace` and `service.instance.id` itself, per OTel semantic conventions — `service.name` from `app.kubernetes.io/name` then the workload name, version from the image tag. Now extracted, along with:

- **container identity** — `k8s.container.name`, `container.id`, `container.image.name`, `container.image.tag`, so telemetry ties to the image actually running
- `k8s.replicaset.name`, `k8s.node.uid`, `k8s.cluster.uid`, pod hostname and IP
- **namespace-level ownership** — `team`/`env` read from the namespace too, since most clusters declare them once per namespace rather than per pod
- **node topology** — `cloud.region`, `cloud.availability_zone`, `host.type` from the well-known node labels, no metadata-service call

Precedence is unchanged where it matters: the processor never overwrites an attribute the sender already set, and pod values still beat namespace and node.

The extract block was duplicated across all three collectors, letting them drift into describing the same pod differently. Now one shared helper.

⚠️ **Upgrade impact:** a workload that previously reported no `service.name` starts reporting one derived from its Kubernetes identity.

Chart 0.10.0. 44 unit tests pass; artifacts regenerated.

Stacked on #113.