### PR TITLE
feat(kube-stack): detect cloud resource attributes

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: 0.11.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-kube-stack
 
-![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
 
 A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet + cluster receiver), secure credential management, and production-ready configurations for telemetry collection to Tsuga platform.
 
@@ -58,6 +58,7 @@ The chart implements the recommended OpenTelemetry architecture with two main co
 
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit). Always first, so load is shed before the pipeline spends work on data it is about to reject.
+- **Resource Detection** (`resource_detection`): Cloud identity — provider, account, region, instance id (see [Cloud resource detection](#cloud-resource-detection))
 - **K8s Attributes** (`k8s_attributes`): Enriches telemetry with Kubernetes metadata, container image identity, semconv-derived `service.*`, and pod/namespace/node labels (see [Telemetry enrichment](#telemetry-enrichment))
 - **Resource**: Adds `k8s.node.name`, so host metrics are attributable to a node, plus `k8s.cluster.name` when `clusterName` is set
 - **Cumulative To Delta**: Converts cumulative counters to delta where applicable
@@ -70,11 +71,13 @@ The chart implements the recommended OpenTelemetry architecture with two main co
 - **otlp_http/tsuga**: Forwards all telemetry to the Tsuga endpoint with authentication (enabled unless `tsuga.enabledForDaemonset=false`)
 
 **Service Pipelines:**
-- **Logs**: `otlp` (+`file_log` when `agent.collectLogs`) → `memory_limiter`, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`
-- **Metrics**: `otlp`, `kubelet_stats`, `span_metrics`, `host_metrics` → `memory_limiter`, `k8s_attributes`, `resource`, `cumulativetodelta`, `batch` → `otlp_http/tsuga`
-- **Traces**: `otlp` → `memory_limiter`, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`, `span_metrics`
+- **Logs**: `otlp` (+`file_log` when `agent.collectLogs`) → `memory_limiter`, `resource_detection`¹, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`
+- **Metrics**: `otlp`, `kubelet_stats`, `span_metrics`, `host_metrics` → `memory_limiter`, `resource_detection`¹, `k8s_attributes`, `resource`, `cumulativetodelta`, `batch` → `otlp_http/tsuga`
+- **Traces**: `otlp` → `memory_limiter`, `resource_detection`¹, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`, `span_metrics`
 
 Collector self-telemetry is exported through `service::telemetry`, not a pipeline.
+
+¹ Only present when `resourceDetection.enabled` is true (the default).
 
 **Default Spanmetrics Dimensions:**
 - `http.request.method`
@@ -126,6 +129,7 @@ agent:
 
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit)
+- **Resource Detection** (`resource_detection`): Cloud identity (see [Cloud resource detection](#cloud-resource-detection))
 - **Resource**: Adds `k8s.cluster.name` (only when `clusterName` is set)
 - **K8s Attributes** (`k8s_attributes`): Enriches telemetry with Kubernetes metadata (see [Telemetry enrichment](#telemetry-enrichment))
 - **Batch**: Batches telemetry for efficient processing
@@ -134,10 +138,11 @@ agent:
 - **otlp_http/tsuga**: Forwards to the Tsuga endpoint (enabled unless `tsuga.enabledForClusterReceiver=false`)
 
 **Service Pipelines:**
-- **Metrics**: `k8s_cluster` → `memory_limiter`, `resource`¹, `k8s_attributes`, `batch` → `otlp_http/tsuga`
-- **Entity Events (Logs)**: `k8s_cluster` (+`k8s_objects` when enabled) → `memory_limiter`, `resource`¹, `k8s_attributes`, `batch` → `otlp_http/tsuga`
+- **Metrics**: `k8s_cluster` → `memory_limiter`, `resource_detection`¹, `resource`², `k8s_attributes`, `batch` → `otlp_http/tsuga`
+- **Entity Events (Logs)**: `k8s_cluster` (+`k8s_objects` when enabled) → `memory_limiter`, `resource_detection`¹, `resource`², `k8s_attributes`, `batch` → `otlp_http/tsuga`
 
-¹ Only present when `clusterName` is set.
+¹ Only present when `resourceDetection.enabled` is true (the default).
+² Only present when `clusterName` is set.
 
 ### Telemetry enrichment
 
@@ -157,6 +162,51 @@ Deliberately **not** extracted, despite being available: `k8s.pod.ip`, `k8s.pod.
 Add your own mappings with `agent.extraLabelMapping` / `agent.extraAnnotationsMapping` (and the `cluster.*` / `statefulset.*` equivalents); they are appended to the shared block.
 
 > **Upgrade note:** a workload that previously reported no `service.name` will start reporting one derived from its Kubernetes identity. In Tsuga it moves out of `unknown_service` and into its own service, so existing dashboards or monitors that filter on `unknown_service` need updating.
+
+### Cloud resource detection
+
+`resourceDetection` (on by default) runs the `resource_detection` processor on every collector, adding `cloud.provider`, `cloud.platform`, `cloud.account.id`, `cloud.region` and `host.id` — the actual instance id, which is what lets you pivot from telemetry to the cloud console.
+
+Detected values never override attributes the sender already set (`override: false`), and detection runs before `k8s_attributes`, so an explicit `clusterName` always wins over anything detected.
+
+**On local and bare-metal clusters, turn this off:**
+
+```bash
+helm install ... --set resourceDetection.enabled=false
+```
+
+The cloud detectors probe the link-local metadata service at `169.254.169.254`. On kind, minikube, k3s, Docker Desktop or on-prem nothing answers that address: collectors still start and telemetry still flows, but each one waits out `resourceDetection.timeout` on startup and logs a detector error. On a real cloud it is also worth trimming `resourceDetection.detectors` to just your provider, which skips the other providers' probes entirely.
+
+#### EKS cluster name detection and IAM
+
+Every EKS attribute is served by the instance metadata service for free — except `k8s.cluster.name`, which costs an `ec2:DescribeInstances` API call. It is therefore **opt-in** via `resourceDetection.detectEksClusterName`; left on, it would log an error on every EKS cluster whose collector role lacks the permission. For most users, setting `clusterName` is simpler and costs nothing.
+
+This permission cannot be granted by this chart. `ec2:DescribeInstances` is an **AWS IAM** permission, a different authorization system from the Kubernetes RBAC that the chart's `ClusterRole` manages — a `ClusterRole` grants access to the Kubernetes API only, never to an AWS API. Creating the IAM role itself is an AWS account-level change made outside the cluster. The chart's part is the service account annotation hook; the rest is yours.
+
+To enable it, attach this policy to an IAM role:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    { "Effect": "Allow", "Action": "ec2:DescribeInstances", "Resource": "*" }
+  ]
+}
+```
+
+Then bind the role to the collector's service account, either with **IRSA**:
+
+```yaml
+resourceDetection:
+  detectEksClusterName: true
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>
+```
+
+or with **EKS Pod Identity**, which needs no annotation at all — create a pod identity association pointing at the release namespace and the service account name (`<release>-opentelemetry-kube-stack` unless you set `serviceAccount.name`), then set `resourceDetection.detectEksClusterName=true`.
+
+The in-cluster RBAC the chart creates is already complete for everything the collectors do against the Kubernetes API.
 
 ## Quick Start
 
@@ -404,6 +454,10 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | opentelemetry-operator.manager.collectorImage.repository | string | `"otel/opentelemetry-collector-k8s"` |  |
 | rbac | object | `{"create":true}` | RBAC configuration |
 | rbac.create | bool | true | Create RBAC resources (ClusterRole and ClusterRoleBinding) Required for collecting Kubernetes cluster metrics and metadata |
+| resourceDetection.detectEksClusterName | bool | false | Let the EKS detector resolve k8s.cluster.name (AWS only)  Every other EKS attribute comes from the instance metadata service for free. This one does not: it costs an ec2:DescribeInstances API call, so leaving it on would log an error on every EKS cluster whose collector role lacks that permission. Most users should simply set `clusterName` instead.  This is an AWS IAM permission, not Kubernetes RBAC, so the chart cannot grant it. Attach a role with the policy below via IRSA or EKS Pod Identity, then point the service account at it:    {"Version": "2012-10-17", "Statement": [{     "Effect": "Allow", "Action": "ec2:DescribeInstances", "Resource": "*"}]}    serviceAccount:     annotations:       eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/<ROLE>  |
+| resourceDetection.detectors | list | ["env", "eks", "aks", "gcp", "ec2", "azure"] | Detectors to run, in order. Earlier detectors win on conflict. `env` reads OTEL_RESOURCE_ATTRIBUTES and costs nothing on any cluster. Detected values never override attributes the sender already set. |
+| resourceDetection.enabled | bool | true | Run the resource_detection processor on all collectors |
+| resourceDetection.timeout | string | "2s" | How long each detector may take before it gives up. |
 | resources.limits | object | `{"cpu":"500m","memory":"512Mi"}` | Resource limits |
 | resources.limits.cpu | string | "500m" | CPU limit |
 | resources.limits.memory | string | "512Mi" | Memory limit |

--- a/charts/opentelemetry-kube-stack/README.md.gotmpl
+++ b/charts/opentelemetry-kube-stack/README.md.gotmpl
@@ -48,6 +48,7 @@ The chart implements the recommended OpenTelemetry architecture with two main co
 
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit). Always first, so load is shed before the pipeline spends work on data it is about to reject.
+- **Resource Detection** (`resource_detection`): Cloud identity — provider, account, region, instance id (see [Cloud resource detection](#cloud-resource-detection))
 - **K8s Attributes** (`k8s_attributes`): Enriches telemetry with Kubernetes metadata, container image identity, semconv-derived `service.*`, and pod/namespace/node labels (see [Telemetry enrichment](#telemetry-enrichment))
 - **Resource**: Adds `k8s.node.name`, so host metrics are attributable to a node, plus `k8s.cluster.name` when `clusterName` is set
 - **Cumulative To Delta**: Converts cumulative counters to delta where applicable
@@ -60,11 +61,13 @@ The chart implements the recommended OpenTelemetry architecture with two main co
 - **otlp_http/tsuga**: Forwards all telemetry to the Tsuga endpoint with authentication (enabled unless `tsuga.enabledForDaemonset=false`)
 
 **Service Pipelines:**
-- **Logs**: `otlp` (+`file_log` when `agent.collectLogs`) → `memory_limiter`, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`
-- **Metrics**: `otlp`, `kubelet_stats`, `span_metrics`, `host_metrics` → `memory_limiter`, `k8s_attributes`, `resource`, `cumulativetodelta`, `batch` → `otlp_http/tsuga`
-- **Traces**: `otlp` → `memory_limiter`, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`, `span_metrics`
+- **Logs**: `otlp` (+`file_log` when `agent.collectLogs`) → `memory_limiter`, `resource_detection`¹, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`
+- **Metrics**: `otlp`, `kubelet_stats`, `span_metrics`, `host_metrics` → `memory_limiter`, `resource_detection`¹, `k8s_attributes`, `resource`, `cumulativetodelta`, `batch` → `otlp_http/tsuga`
+- **Traces**: `otlp` → `memory_limiter`, `resource_detection`¹, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`, `span_metrics`
 
 Collector self-telemetry is exported through `service::telemetry`, not a pipeline.
+
+¹ Only present when `resourceDetection.enabled` is true (the default).
 
 **Default Spanmetrics Dimensions:**
 - `http.request.method`
@@ -116,6 +119,7 @@ agent:
 
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit)
+- **Resource Detection** (`resource_detection`): Cloud identity (see [Cloud resource detection](#cloud-resource-detection))
 - **Resource**: Adds `k8s.cluster.name` (only when `clusterName` is set)
 - **K8s Attributes** (`k8s_attributes`): Enriches telemetry with Kubernetes metadata (see [Telemetry enrichment](#telemetry-enrichment))
 - **Batch**: Batches telemetry for efficient processing
@@ -124,10 +128,11 @@ agent:
 - **otlp_http/tsuga**: Forwards to the Tsuga endpoint (enabled unless `tsuga.enabledForClusterReceiver=false`)
 
 **Service Pipelines:**
-- **Metrics**: `k8s_cluster` → `memory_limiter`, `resource`¹, `k8s_attributes`, `batch` → `otlp_http/tsuga`
-- **Entity Events (Logs)**: `k8s_cluster` (+`k8s_objects` when enabled) → `memory_limiter`, `resource`¹, `k8s_attributes`, `batch` → `otlp_http/tsuga`
+- **Metrics**: `k8s_cluster` → `memory_limiter`, `resource_detection`¹, `resource`², `k8s_attributes`, `batch` → `otlp_http/tsuga`
+- **Entity Events (Logs)**: `k8s_cluster` (+`k8s_objects` when enabled) → `memory_limiter`, `resource_detection`¹, `resource`², `k8s_attributes`, `batch` → `otlp_http/tsuga`
 
-¹ Only present when `clusterName` is set.
+¹ Only present when `resourceDetection.enabled` is true (the default).
+² Only present when `clusterName` is set.
 
 ### Telemetry enrichment
 
@@ -147,6 +152,51 @@ Deliberately **not** extracted, despite being available: `k8s.pod.ip`, `k8s.pod.
 Add your own mappings with `agent.extraLabelMapping` / `agent.extraAnnotationsMapping` (and the `cluster.*` / `statefulset.*` equivalents); they are appended to the shared block.
 
 > **Upgrade note:** a workload that previously reported no `service.name` will start reporting one derived from its Kubernetes identity. In Tsuga it moves out of `unknown_service` and into its own service, so existing dashboards or monitors that filter on `unknown_service` need updating.
+
+### Cloud resource detection
+
+`resourceDetection` (on by default) runs the `resource_detection` processor on every collector, adding `cloud.provider`, `cloud.platform`, `cloud.account.id`, `cloud.region` and `host.id` — the actual instance id, which is what lets you pivot from telemetry to the cloud console.
+
+Detected values never override attributes the sender already set (`override: false`), and detection runs before `k8s_attributes`, so an explicit `clusterName` always wins over anything detected.
+
+**On local and bare-metal clusters, turn this off:**
+
+```bash
+helm install ... --set resourceDetection.enabled=false
+```
+
+The cloud detectors probe the link-local metadata service at `169.254.169.254`. On kind, minikube, k3s, Docker Desktop or on-prem nothing answers that address: collectors still start and telemetry still flows, but each one waits out `resourceDetection.timeout` on startup and logs a detector error. On a real cloud it is also worth trimming `resourceDetection.detectors` to just your provider, which skips the other providers' probes entirely.
+
+#### EKS cluster name detection and IAM
+
+Every EKS attribute is served by the instance metadata service for free — except `k8s.cluster.name`, which costs an `ec2:DescribeInstances` API call. It is therefore **opt-in** via `resourceDetection.detectEksClusterName`; left on, it would log an error on every EKS cluster whose collector role lacks the permission. For most users, setting `clusterName` is simpler and costs nothing.
+
+This permission cannot be granted by this chart. `ec2:DescribeInstances` is an **AWS IAM** permission, a different authorization system from the Kubernetes RBAC that the chart's `ClusterRole` manages — a `ClusterRole` grants access to the Kubernetes API only, never to an AWS API. Creating the IAM role itself is an AWS account-level change made outside the cluster. The chart's part is the service account annotation hook; the rest is yours.
+
+To enable it, attach this policy to an IAM role:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    { "Effect": "Allow", "Action": "ec2:DescribeInstances", "Resource": "*" }
+  ]
+}
+```
+
+Then bind the role to the collector's service account, either with **IRSA**:
+
+```yaml
+resourceDetection:
+  detectEksClusterName: true
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/<ROLE_NAME>
+```
+
+or with **EKS Pod Identity**, which needs no annotation at all — create a pod identity association pointing at the release namespace and the service account name (`<release>-opentelemetry-kube-stack` unless you set `serviceAccount.name`), then set `resourceDetection.detectEksClusterName=true`.
+
+The in-cluster RBAC the chart creates is already complete for everything the collectors do against the Kubernetes API.
 
 ## Quick Start
 

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
@@ -178,6 +178,24 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource_detection:
+        aks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        detectors:
+        - env
+        - eks
+        - aks
+        - gcp
+        - ec2
+        - azure
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: false
+        override: false
+        timeout: 2s
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -193,6 +211,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - batch
           receivers:
@@ -203,6 +222,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - batch
           receivers:

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/daemonset.yaml
@@ -271,6 +271,24 @@ spec:
         - action: insert
           key: k8s.node.name
           value: ${env:K8S_NODE_NAME}
+      resource_detection:
+        aks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        detectors:
+        - env
+        - eks
+        - aks
+        - gcp
+        - ec2
+        - azure
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: false
+        override: false
+        timeout: 2s
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -297,6 +315,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - resource
           - batch
@@ -308,6 +327,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - resource
           - cumulativetodelta
@@ -323,6 +343,7 @@ spec:
           - span_metrics
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - resource
           - batch

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
@@ -178,6 +178,24 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource_detection:
+        aks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        detectors:
+        - env
+        - eks
+        - aks
+        - gcp
+        - ec2
+        - azure
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: false
+        override: false
+        timeout: 2s
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -193,6 +211,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - batch
           receivers:
@@ -203,6 +222,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - batch
           receivers:

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/daemonset.yaml
@@ -271,6 +271,24 @@ spec:
         - action: insert
           key: k8s.node.name
           value: ${env:K8S_NODE_NAME}
+      resource_detection:
+        aks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        detectors:
+        - env
+        - eks
+        - aks
+        - gcp
+        - ec2
+        - azure
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: false
+        override: false
+        timeout: 2s
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -297,6 +315,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - resource
           - batch
@@ -308,6 +327,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - resource
           - cumulativetodelta
@@ -323,6 +343,7 @@ spec:
           - span_metrics
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - resource
           - batch

--- a/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
@@ -178,6 +178,24 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource_detection:
+        aks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        detectors:
+        - env
+        - eks
+        - aks
+        - gcp
+        - ec2
+        - azure
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: false
+        override: false
+        timeout: 2s
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -193,6 +211,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - batch
           receivers:
@@ -203,6 +222,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - batch
           receivers:

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
@@ -178,6 +178,24 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource_detection:
+        aks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        detectors:
+        - env
+        - eks
+        - aks
+        - gcp
+        - ec2
+        - azure
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: false
+        override: false
+        timeout: 2s
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -193,6 +211,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - batch
           receivers:
@@ -203,6 +222,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - batch
           receivers:

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/daemonset.yaml
@@ -271,6 +271,24 @@ spec:
         - action: insert
           key: k8s.node.name
           value: ${env:K8S_NODE_NAME}
+      resource_detection:
+        aks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        detectors:
+        - env
+        - eks
+        - aks
+        - gcp
+        - ec2
+        - azure
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: false
+        override: false
+        timeout: 2s
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -297,6 +315,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - resource
           - batch
@@ -308,6 +327,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - resource
           - cumulativetodelta
@@ -323,6 +343,7 @@ spec:
           - span_metrics
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - resource
           - batch

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
@@ -178,6 +178,24 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource_detection:
+        aks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        detectors:
+        - env
+        - eks
+        - aks
+        - gcp
+        - ec2
+        - azure
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: false
+        override: false
+        timeout: 2s
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -193,6 +211,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - batch
           receivers:
@@ -203,6 +222,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - batch
           receivers:

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/daemonset.yaml
@@ -271,6 +271,24 @@ spec:
         - action: insert
           key: k8s.node.name
           value: ${env:K8S_NODE_NAME}
+      resource_detection:
+        aks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        detectors:
+        - env
+        - eks
+        - aks
+        - gcp
+        - ec2
+        - azure
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: false
+        override: false
+        timeout: 2s
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -297,6 +315,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - resource
           - batch
@@ -308,6 +327,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - resource
           - cumulativetodelta
@@ -329,6 +349,7 @@ spec:
           - span_metrics
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - resource
           - batch

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
@@ -178,6 +178,24 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource_detection:
+        aks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        detectors:
+        - env
+        - eks
+        - aks
+        - gcp
+        - ec2
+        - azure
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: false
+        override: false
+        timeout: 2s
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -193,6 +211,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - batch
           receivers:
@@ -203,6 +222,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - batch
           receivers:

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/daemonset.yaml
@@ -271,6 +271,24 @@ spec:
         - action: insert
           key: k8s.node.name
           value: ${env:K8S_NODE_NAME}
+      resource_detection:
+        aks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        detectors:
+        - env
+        - eks
+        - aks
+        - gcp
+        - ec2
+        - azure
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: false
+        override: false
+        timeout: 2s
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -297,6 +315,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - resource
           - batch
@@ -308,6 +327,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - resource
           - cumulativetodelta
@@ -323,6 +343,7 @@ spec:
           - span_metrics
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - resource
           - batch

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
@@ -178,6 +178,24 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource_detection:
+        aks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        detectors:
+        - env
+        - eks
+        - aks
+        - gcp
+        - ec2
+        - azure
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: false
+        override: false
+        timeout: 2s
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -193,6 +211,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - batch
           receivers:
@@ -203,6 +222,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - batch
           receivers:

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/daemonset.yaml
@@ -281,6 +281,24 @@ spec:
         - action: insert
           key: k8s.node.name
           value: ${env:K8S_NODE_NAME}
+      resource_detection:
+        aks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        detectors:
+        - env
+        - eks
+        - aks
+        - gcp
+        - ec2
+        - azure
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: false
+        override: false
+        timeout: 2s
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -312,6 +330,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - resource
           - batch
@@ -323,6 +342,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - resource
           - cumulativetodelta
@@ -340,6 +360,7 @@ spec:
           - span_metrics
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - resource
           - batch

--- a/charts/opentelemetry-kube-stack/examples/target-allocator/rendered/statefulset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/target-allocator/rendered/statefulset.yaml
@@ -168,6 +168,24 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource_detection:
+        aks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        detectors:
+        - env
+        - eks
+        - aks
+        - gcp
+        - ec2
+        - azure
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: false
+        override: false
+        timeout: 2s
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -183,6 +201,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource_detection
           - cumulativetodelta
           - k8s_attributes
           - batch

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
@@ -168,6 +168,24 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource_detection:
+        aks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        detectors:
+        - env
+        - eks
+        - aks
+        - gcp
+        - ec2
+        - azure
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: false
+        override: false
+        timeout: 2s
     exporters:
       debug: {}
     service:
@@ -178,6 +196,7 @@ spec:
           - debug
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - batch
           receivers:
@@ -188,6 +207,7 @@ spec:
           - debug
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - batch
           receivers:

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/daemonset.yaml
@@ -261,6 +261,24 @@ spec:
         - action: insert
           key: k8s.node.name
           value: ${env:K8S_NODE_NAME}
+      resource_detection:
+        aks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        detectors:
+        - env
+        - eks
+        - aks
+        - gcp
+        - ec2
+        - azure
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: false
+        override: false
+        timeout: 2s
     exporters:
       debug: {}
     extensions:
@@ -282,6 +300,7 @@ spec:
           - debug
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - resource
           - batch
@@ -293,6 +312,7 @@ spec:
           - debug
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - resource
           - cumulativetodelta
@@ -308,6 +328,7 @@ spec:
           - debug
           processors:
           - memory_limiter
+          - resource_detection
           - k8s_attributes
           - resource
           - batch

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/statefulset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/statefulset.yaml
@@ -158,6 +158,24 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource_detection:
+        aks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: true
+        detectors:
+        - env
+        - eks
+        - aks
+        - gcp
+        - ec2
+        - azure
+        eks:
+          resource_attributes:
+            k8s.cluster.name:
+              enabled: false
+        override: false
+        timeout: 2s
     exporters:
       debug: {}
     service:
@@ -168,6 +186,7 @@ spec:
           - debug
           processors:
           - memory_limiter
+          - resource_detection
           - cumulativetodelta
           - k8s_attributes
           - batch

--- a/charts/opentelemetry-kube-stack/templates/_config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_config.tpl
@@ -46,6 +46,36 @@ Generate environment variables for OpenTelemetry Collector
 {{- end }}
 
 {{/*
+Shared resource_detection processor.
+
+Runs before k8s_attributes in every pipeline, with override disabled, so the
+order of precedence ends up: attributes the sender already set > cloud
+metadata > Kubernetes API. Where both can answer (cloud.region, from IMDS here
+or from the topology.kubernetes.io/region node label in k8s_attributes) the
+cloud answer wins on cloud and the node label covers everything else.
+*/}}
+{{- define "opentelemetry-kube-stack.resourceDetection" -}}
+resource_detection:
+  detectors:
+    {{- toYaml .Values.resourceDetection.detectors | nindent 4 }}
+  timeout: {{ .Values.resourceDetection.timeout }}
+  override: false
+  eks:
+    resource_attributes:
+      k8s.cluster.name:
+        # Opt-in: unlike every other EKS attribute this one is not served by
+        # IMDS, it costs an EC2:DescribeInstances call. Left on by default it
+        # would log an error on every EKS cluster that has not granted it.
+        enabled: {{ .Values.resourceDetection.detectEksClusterName }}
+  aks:
+    resource_attributes:
+      k8s.cluster.name:
+        # Free by comparison: derived from the Azure IMDS response, no
+        # additional permission and no extra API call.
+        enabled: true
+{{- end }}
+
+{{/*
 Shared k8s_attributes `extract` block.
 
 Kept in one place because the agent, cluster receiver and statefulset collector

--- a/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
@@ -27,6 +27,9 @@ processors:
     # Enforce a hard limit of 5000 items per batch. This prevents the
     # timeout from creating a massive batch that would be rejected.
     send_batch_max_size: 5000
+  {{- if .Values.resourceDetection.enabled }}
+  {{- include "opentelemetry-kube-stack.resourceDetection" . | nindent 2 }}
+  {{- end }}
   k8s_attributes:
     extract:
       {{- include "opentelemetry-kube-stack.k8sAttributesExtract" (dict "extraLabelMapping" .Values.cluster.extraLabelMapping "extraAnnotationsMapping" .Values.cluster.extraAnnotationsMapping) | nindent 6 }}
@@ -64,6 +67,9 @@ service:
 {{- end }}
       processors:
         - memory_limiter
+        {{- if .Values.resourceDetection.enabled }}
+        - resource_detection
+        {{- end }}
         {{- if .Values.clusterName }}
         - resource
         {{- end }}
@@ -78,6 +84,9 @@ service:
         - k8s_cluster
       processors:
         - memory_limiter
+        {{- if .Values.resourceDetection.enabled }}
+        - resource_detection
+        {{- end }}
         {{- if .Values.clusterName }}
         - resource
         {{- end }}

--- a/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
@@ -121,6 +121,9 @@ processors:
     # Enforce a hard limit of 5000 items per batch. This prevents the
     # timeout from creating a massive batch that would be rejected.
     send_batch_max_size: 5000
+  {{- if .Values.resourceDetection.enabled }}
+  {{- include "opentelemetry-kube-stack.resourceDetection" . | nindent 2 }}
+  {{- end }}
   k8s_attributes:
     extract:
       {{- include "opentelemetry-kube-stack.k8sAttributesExtract" (dict "extraLabelMapping" .Values.agent.extraLabelMapping "extraAnnotationsMapping" .Values.agent.extraAnnotationsMapping) | nindent 6 }}
@@ -183,6 +186,9 @@ service:
         # spends work enriching data it is about to reject; batch last so it
         # groups the finished records.
         - memory_limiter
+        {{- if .Values.resourceDetection.enabled }}
+        - resource_detection
+        {{- end }}
         - k8s_attributes
         - resource
         - batch
@@ -198,6 +204,9 @@ service:
         - host_metrics
       processors:
         - memory_limiter
+        {{- if .Values.resourceDetection.enabled }}
+        - resource_detection
+        {{- end }}
         - k8s_attributes
         - resource
         - cumulativetodelta
@@ -214,6 +223,9 @@ service:
         - span_metrics
       processors:
         - memory_limiter
+        {{- if .Values.resourceDetection.enabled }}
+        - resource_detection
+        {{- end }}
         - k8s_attributes
         - resource
         - batch

--- a/charts/opentelemetry-kube-stack/templates/_default-statefulset-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-statefulset-config.tpl
@@ -23,6 +23,9 @@ processors:
     send_batch_size: 5000
     send_batch_max_size: 5000
   cumulativetodelta: {}
+  {{- if .Values.resourceDetection.enabled }}
+  {{- include "opentelemetry-kube-stack.resourceDetection" . | nindent 2 }}
+  {{- end }}
   k8s_attributes:
     extract:
       {{- include "opentelemetry-kube-stack.k8sAttributesExtract" (dict "extraLabelMapping" .Values.statefulset.extraLabelMapping "extraAnnotationsMapping" .Values.statefulset.extraAnnotationsMapping) | nindent 6 }}
@@ -59,6 +62,9 @@ service:
         - prometheus
       processors:
         - memory_limiter
+        {{- if .Values.resourceDetection.enabled }}
+        - resource_detection
+        {{- end }}
         - cumulativetodelta
         - k8s_attributes
         {{- if .Values.clusterName }}

--- a/charts/opentelemetry-kube-stack/tests/daemonset_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/daemonset_test.yaml
@@ -107,13 +107,13 @@ tests:
     asserts:
       - equal:
           path: spec.config.service.pipelines.logs.processors
-          value: [memory_limiter, k8s_attributes, resource, batch]
+          value: [memory_limiter, resource_detection, k8s_attributes, resource, batch]
       - equal:
           path: spec.config.service.pipelines.metrics.processors
-          value: [memory_limiter, k8s_attributes, resource, cumulativetodelta, batch]
+          value: [memory_limiter, resource_detection, k8s_attributes, resource, cumulativetodelta, batch]
       - equal:
           path: spec.config.service.pipelines.traces.processors
-          value: [memory_limiter, k8s_attributes, resource, batch]
+          value: [memory_limiter, resource_detection, k8s_attributes, resource, batch]
 
   - it: should stamp node identity even without a cluster name
     set:
@@ -211,3 +211,65 @@ tests:
             tag_name: app.version
             key: app.version
             from: pod
+
+  - it: should detect cloud resources before enriching from kubernetes
+    set:
+      agent.enabled: true
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      # Detection must never clobber what the sender already declared.
+      - equal:
+          path: spec.config.processors.resource_detection.override
+          value: false
+      # EKS cluster-name detection costs an IAM permission, so it must stay
+      # opt-in; AKS gets it from IMDS for free and stays on.
+      - equal:
+          path: spec.config.processors.resource_detection.eks.resource_attributes["k8s.cluster.name"].enabled
+          value: false
+      - equal:
+          path: spec.config.processors.resource_detection.aks.resource_attributes["k8s.cluster.name"].enabled
+          value: true
+      - equal:
+          path: spec.config.service.pipelines.traces.processors
+          value: [memory_limiter, resource_detection, k8s_attributes, resource, batch]
+
+  - it: should drop resource detection entirely when disabled for local clusters
+    set:
+      agent.enabled: true
+      resourceDetection.enabled: false
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - isNull:
+          path: spec.config.processors.resource_detection
+      - notContains:
+          path: spec.config.service.pipelines.metrics.processors
+          content: resource_detection
+      - notContains:
+          path: spec.config.service.pipelines.logs.processors
+          content: resource_detection
+      - notContains:
+          path: spec.config.service.pipelines.traces.processors
+          content: resource_detection
+
+  - it: should honour a trimmed detector list
+    set:
+      agent.enabled: true
+      resourceDetection.detectors: [env, ec2]
+      resourceDetection.timeout: 5s
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - equal:
+          path: spec.config.processors.resource_detection.detectors
+          value: [env, ec2]
+      - equal:
+          path: spec.config.processors.resource_detection.timeout
+          value: 5s

--- a/charts/opentelemetry-kube-stack/values.schema.json
+++ b/charts/opentelemetry-kube-stack/values.schema.json
@@ -338,6 +338,26 @@
                 }
             }
         },
+        "resourceDetection": {
+            "type": "object",
+            "properties": {
+                "detectEksClusterName": {
+                    "type": "boolean"
+                },
+                "detectors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "timeout": {
+                    "type": "string"
+                }
+            }
+        },
         "resources": {
             "type": "object",
             "properties": {

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -65,6 +65,62 @@
 # @default -- ""
 clusterName: ""
 
+# =============================================================================
+# CLOUD RESOURCE DETECTION
+# =============================================================================
+# Adds cloud identity to every signal from every collector: cloud.provider,
+# cloud.platform, cloud.account.id, cloud.region and host.id (the instance id,
+# which is what lets you pivot from telemetry to the cloud console).
+#
+# DISABLE THIS ON LOCAL AND BARE-METAL CLUSTERS (kind, minikube, k3s, Docker
+# Desktop, on-prem). The cloud detectors probe the link-local metadata service
+# at 169.254.169.254, and nothing answers that address off-cloud. Collectors
+# still start and telemetry still flows, but each one waits out `timeout` on
+# startup and logs a detector error, which is a confusing first impression:
+#
+#   --set resourceDetection.enabled=false
+#
+# On cloud, trimming `detectors` to just your provider is also worth doing: it
+# skips the other providers' probes entirely.
+resourceDetection:
+  # -- Run the resource_detection processor on all collectors
+  # @default -- true
+  enabled: true
+  # -- Detectors to run, in order. Earlier detectors win on conflict.
+  # `env` reads OTEL_RESOURCE_ATTRIBUTES and costs nothing on any cluster.
+  # Detected values never override attributes the sender already set.
+  # @default -- ["env", "eks", "aks", "gcp", "ec2", "azure"]
+  detectors:
+    - env
+    - eks
+    - aks
+    - gcp
+    - ec2
+    - azure
+  # -- Let the EKS detector resolve k8s.cluster.name (AWS only)
+  #
+  # Every other EKS attribute comes from the instance metadata service for
+  # free. This one does not: it costs an ec2:DescribeInstances API call, so
+  # leaving it on would log an error on every EKS cluster whose collector role
+  # lacks that permission. Most users should simply set `clusterName` instead.
+  #
+  # This is an AWS IAM permission, not Kubernetes RBAC, so the chart cannot
+  # grant it. Attach a role with the policy below via IRSA or EKS Pod Identity,
+  # then point the service account at it:
+  #
+  #   {"Version": "2012-10-17", "Statement": [{
+  #     "Effect": "Allow", "Action": "ec2:DescribeInstances", "Resource": "*"}]}
+  #
+  #   serviceAccount:
+  #     annotations:
+  #       eks.amazonaws.com/role-arn: arn:aws:iam::<ACCOUNT_ID>:role/<ROLE>
+  #
+  # @default -- false
+  detectEksClusterName: false
+  # -- How long each detector may take before it gives up.
+  # @default -- "2s"
+  timeout: 2s
+
 # -- Override the chart name used in resource naming
 # @default -- ""
 nameOverride: ""


### PR DESCRIPTION
Telemetry carried no cloud identity — no `cloud.provider`, `cloud.region`, `cloud.account.id` or `host.id` on any signal, so nothing to pivot on when moving from Tsuga to a cloud console, and multi-region/multi-account customers had only the manually set `clusterName` to tell workloads apart.

Adds `resource_detection` to all three collectors, before `k8s_attributes` with `override: false`. Precedence: what the sender set > cloud metadata > Kubernetes API. Where both can answer (`cloud.region` from IMDS or from the `topology.kubernetes.io/region` node label added in #114) the cloud answer wins on cloud and the node label covers everything else.

⚠️ **Must be disabled on local and bare-metal clusters.** The cloud detectors probe `169.254.169.254`, which nothing answers off-cloud, so every collector waits out the timeout and logs a detector error at startup:

```
--set resourceDetection.enabled=false
```

On cloud, `resourceDetection.detectors` can be trimmed to a single provider to skip the other probes.

**EKS cluster name is separately opt-in** (`detectEksClusterName`, default false). Every other EKS attribute comes from IMDS free; that one costs an `ec2:DescribeInstances` call, so enabling it by default would log an error on every EKS cluster whose collector role lacks the permission. Setting `clusterName` is simpler for most users. IAM is not something a Helm chart can grant — the README documents the policy plus both the IRSA and Pod Identity wiring.

Chart 0.11.0. 47 unit tests pass; artifacts regenerated.

Stacked on #114.