### PR TITLE
feat(kube-stack): collect kubernetes events and node journald logs

### DIFF
--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.0
+version: 0.12.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-kube-stack
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
+![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
 
 A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet + cluster receiver), secure credential management, and production-ready configurations for telemetry collection to Tsuga platform.
 
@@ -55,12 +55,13 @@ The chart implements the recommended OpenTelemetry architecture with two main co
 - **Kubelet Stats** (`kubelet_stats`): Node and pod metrics via kubelet
 - **OTLP**: Receives traces, metrics, and logs over gRPC (`:4317`) and HTTP (`:4318`)
 - **File Logs** (`file_log`): Collects container logs from `/var/log/pods/*/*/*.log` (controlled by `agent.collectLogs`)
+- **Journald**: systemd unit logs from the node — kubelet, containerd (opt-in, see `agent.journald`)
 
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit). Always first, so load is shed before the pipeline spends work on data it is about to reject.
 - **Resource Detection** (`resource_detection`): Cloud identity — provider, account, region, instance id (see [Cloud resource detection](#cloud-resource-detection))
 - **K8s Attributes** (`k8s_attributes`): Enriches telemetry with Kubernetes metadata, container image identity, semconv-derived `service.*`, and pod/namespace/node labels (see [Telemetry enrichment](#telemetry-enrichment))
-- **Resource**: Adds `k8s.node.name`, so host metrics are attributable to a node, plus `k8s.cluster.name` when `clusterName` is set
+- **Resource**: Adds `k8s.node.name`, so host metrics and journald are attributable to a node, plus `k8s.cluster.name` when `clusterName` is set
 - **Cumulative To Delta**: Converts cumulative counters to delta where applicable
 - **Batch**: Batches telemetry for efficient processing (`send_batch_size`/`send_batch_max_size` = 5000). Always last.
 
@@ -71,7 +72,7 @@ The chart implements the recommended OpenTelemetry architecture with two main co
 - **otlp_http/tsuga**: Forwards all telemetry to the Tsuga endpoint with authentication (enabled unless `tsuga.enabledForDaemonset=false`)
 
 **Service Pipelines:**
-- **Logs**: `otlp` (+`file_log` when `agent.collectLogs`) → `memory_limiter`, `resource_detection`¹, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`
+- **Logs**: `otlp` (+`file_log` when `agent.collectLogs`, +`journald` when enabled) → `memory_limiter`, `resource_detection`¹, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`
 - **Metrics**: `otlp`, `kubelet_stats`, `span_metrics`, `host_metrics` → `memory_limiter`, `resource_detection`¹, `k8s_attributes`, `resource`, `cumulativetodelta`, `batch` → `otlp_http/tsuga`
 - **Traces**: `otlp` → `memory_limiter`, `resource_detection`¹, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`, `span_metrics`
 
@@ -121,11 +122,11 @@ agent:
 ### Cluster Receiver (Deployment)
 
 - Collects cluster metrics and events using the Kubernetes API server
-- **Pinned to a single replica.** `k8s_cluster` and `k8s_objects` do not use leader election here, so a second replica would report the same cluster state again: every cluster metric counted twice and every object ingested twice. The replica count is set in the `OpenTelemetryCollector` resource, so a manual `kubectl scale` is reconciled back to 1.
+- **Pinned to a single replica.** `k8s_cluster` and `k8s_objects` do not use leader election here, so a second replica would report the same cluster state again: every cluster metric counted twice and every Kubernetes event ingested twice. The replica count is set in the `OpenTelemetryCollector` resource, so a manual `kubectl scale` is reconciled back to 1.
 
 **Default Receivers:**
 - **Kubernetes Cluster** (`k8s_cluster`): Collects cluster-level metrics and entity events
-- **Kubernetes Objects** (`k8s_objects`): Watches pods (enabled by default, disable with `cluster.collectk8sobjects=false`)
+- **Kubernetes Objects** (`k8s_objects`): Watches pods (`cluster.collectk8sobjects`) and Kubernetes events (`cluster.collectk8sevents`), both enabled by default
 
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit)
@@ -207,6 +208,35 @@ serviceAccount:
 or with **EKS Pod Identity**, which needs no annotation at all — create a pod identity association pointing at the release namespace and the service account name (`<release>-opentelemetry-kube-stack` unless you set `serviceAccount.name`), then set `resourceDetection.detectEksClusterName=true`.
 
 The in-cluster RBAC the chart creates is already complete for everything the collectors do against the Kubernetes API.
+
+### Kubernetes events
+
+`cluster.collectk8sevents` (on by default) watches the `events.k8s.io` API and ships events as logs, filtered to `type=Warning`. Those are the only source for `FailedScheduling`, `BackOff`, `Evicted`, `ErrImagePull`, `FailedMount` and `Unhealthy` — no metric receiver reports them, and the RBAC for it was already granted. `Normal` events (Scheduled, Pulling, Pulled, Created, Started) are excluded: they are the bulk of the volume and restate what the watched pod objects already show.
+
+The receiver takes an initial snapshot on startup (`include_initial_state`, which the upstream receiver only supports receiver-wide, not per object). For events that means a collector restart replays whatever the API server still retains, one hour by default, so expect duplicates around restarts. Disable with `--set cluster.collectk8sevents=false`.
+
+### Node journald logs
+
+`agent.journald` (**off by default**) collects systemd unit logs from the node — kubelet, containerd — which are where node-level failures show up and are invisible in container stdout.
+
+It is off by default because it cannot work out of the box: the journald receiver shells out to `journalctl`, and the OpenTelemetry Collector images do not ship that binary. When enabled, the agent chroots into the host filesystem already mounted at `/hostfs` and runs the node's own `journalctl`, which means:
+
+- the node must actually have a binary at `agent.journald.journalctlPath` (default `/usr/bin/journalctl`)
+- the agent container runs as **root** with the `DAC_READ_SEARCH`, `SYS_PTRACE` and `SYS_CHROOT` capabilities, since journal files are root-owned and are read through a chroot
+
+Check a node before enabling it:
+
+```bash
+journalctl --header | grep "File path"
+```
+
+```yaml
+agent:
+  journald:
+    enabled: true
+    units: [kubelet, containerd]
+    priority: info
+```
 
 ## Quick Start
 
@@ -377,7 +407,7 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | agent.config.extraExporters | object | {} | Additional exporters to merge into the collector configuration These are merged with default exporters (otlp_http/tsuga) |
 | agent.config.extraExtensions | object | {} | Additional extensions to merge into the collector configuration These are merged with default extensions (health_check) |
 | agent.config.extraProcessors | object | {} | Additional processors to merge into the collector configuration These are merged with default processors |
-| agent.config.extraReceivers | object | {} | Additional receivers to merge into the collector configuration These are merged with default receivers |
+| agent.config.extraReceivers | object | {} | Additional receivers to merge into the collector configuration These are merged with default receivers. See the migration examples directly above this key in values.yaml for ready-to-paste blocks. |
 | agent.config.extraTelemetry | object | {} | Additional telemetry to merge into the collector configuration Merges with default telemetry (Prometheus metrics on port 8888) |
 | agent.config.service | object | `{"extraExtensions":[],"pipelines":{"extraPipelines":{},"logs":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"metrics":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"traces":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}}}` | Service configuration |
 | agent.config.service.extraExtensions | list | [] | Additional extensions to add to the service configuration Added to default extensions (health_check) |
@@ -401,6 +431,11 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | agent.extraLabelMapping | list | [] | Label mapping configuration for agent Maps Kubernetes pod labels to OpenTelemetry resource attributes These are appended to default label mappings Format: List of objects with tag_name, key, and from fields Example:   extraLabelMapping:     - tag_name: "app.version"       key: "app.version"       from: "pod" |
 | agent.hostNetwork | bool | true | Enable host network for agent (recommended for optimal performance) When true, agent uses host networking for better performance |
 | agent.image | string | "" | OpenTelemetry Collector image for agent Defaults to: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s |
+| agent.journald | object | `{"enabled":false,"journalctlPath":"/usr/bin/journalctl","priority":"info","units":["kubelet","containerd"]}` | Collect systemd/journald logs from the node (kubelet, containerd, ...) These are the logs for node-level failures - kubelet crashes, containerd errors, disk pressure - which are invisible in container stdout.  DISABLED BY DEFAULT because it cannot work out of the box: the journald receiver shells out to `journalctl`, and the OpenTelemetry Collector images do not ship it. When enabled, the agent chroots into the host filesystem already mounted at /hostfs and runs the node's own journalctl, so the node must actually have a binary at journalctlPath. Enabling this also makes the agent container run as root with DAC_READ_SEARCH/SYS_PTRACE/SYS_CHROOT. Verify on a node first: `journalctl --header | grep "File path"` |
+| agent.journald.enabled | bool | false | Enable the journald receiver on the agent |
+| agent.journald.journalctlPath | string | "/usr/bin/journalctl" | Absolute path to journalctl on the node (inside the /hostfs chroot) |
+| agent.journald.priority | string | "info" | Minimum message priority to keep. One of emerg, alert, crit, err, warning, notice, info, debug. |
+| agent.journald.units | list | ["kubelet", "containerd"] | systemd units to read. An empty list reads every unit, which is a lot. |
 | agent.nodeSelector | object | {} | Agent-specific node selector If not set, inherits from global nodeSelector configuration |
 | agent.resources | object | {} | Agent-specific resource limits and requests If not set, inherits from global resources configuration |
 | agent.tolerations | list | [] | Agent-specific tolerations If not set, inherits from global tolerations configuration |
@@ -411,7 +446,8 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | autoInstrumentation.nameOverride | string | "" | Override the name of the Instrumentation resource If empty, defaults to "<release-fullname>-instrumentation" |
 | autoInstrumentation.spec | object | {} | Instrumentation spec (full passthrough) This is passed directly to the Instrumentation Custom Resource spec. It can include (non-exhaustive): exporter, propagators, sampler, env, resource, and language blocks like java, nodejs, python, dotnet, go, apacheHttpd. Ref: https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#instrumentation |
 | cluster.affinity | object | {} | Cluster-specific affinity rules If not set, inherits from global affinity configuration |
-| cluster.collectk8sobjects | bool | `true` |  |
+| cluster.collectk8sevents | bool | true | Collect Kubernetes Warning events (FailedScheduling, BackOff, Evicted, ErrImagePull, FailedMount, Unhealthy, ...) as logs. Filtered to type=Warning: Normal events are the bulk of the volume and restate what the watched pod objects already show. Uses the RBAC rules already granted for events. Note that on collector restart the API server's retained event window (1h by default) is replayed, so a restart produces duplicates. |
+| cluster.collectk8sobjects | bool | true | Watch pod objects and ship them as logs This is used in the Kubernetes view to show pod configuration |
 | cluster.config | object | `{"extraConnectors":{},"extraExporters":{},"extraProcessors":{},"extraReceivers":{},"extraTelemetry":{},"service":{"extraExtensions":[],"pipelines":{"extraPipelines":{},"logs":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"metrics":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"traces":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}}}}` | Gateway collector configuration (merge-based approach) Use this to extend the default configuration Default config includes: k8s_cluster receiver, k8s_attributes processor, resource processor |
 | cluster.config.extraConnectors | object | {} | Additional connectors to merge into the collector configuration These are merged with default connectors |
 | cluster.config.extraExporters | object | {} | Additional exporters to merge into the collector configuration These are merged with default exporters (otlp_http/tsuga) |

--- a/charts/opentelemetry-kube-stack/README.md.gotmpl
+++ b/charts/opentelemetry-kube-stack/README.md.gotmpl
@@ -45,12 +45,13 @@ The chart implements the recommended OpenTelemetry architecture with two main co
 - **Kubelet Stats** (`kubelet_stats`): Node and pod metrics via kubelet
 - **OTLP**: Receives traces, metrics, and logs over gRPC (`:4317`) and HTTP (`:4318`)
 - **File Logs** (`file_log`): Collects container logs from `/var/log/pods/*/*/*.log` (controlled by `agent.collectLogs`)
+- **Journald**: systemd unit logs from the node — kubelet, containerd (opt-in, see `agent.journald`)
 
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit). Always first, so load is shed before the pipeline spends work on data it is about to reject.
 - **Resource Detection** (`resource_detection`): Cloud identity — provider, account, region, instance id (see [Cloud resource detection](#cloud-resource-detection))
 - **K8s Attributes** (`k8s_attributes`): Enriches telemetry with Kubernetes metadata, container image identity, semconv-derived `service.*`, and pod/namespace/node labels (see [Telemetry enrichment](#telemetry-enrichment))
-- **Resource**: Adds `k8s.node.name`, so host metrics are attributable to a node, plus `k8s.cluster.name` when `clusterName` is set
+- **Resource**: Adds `k8s.node.name`, so host metrics and journald are attributable to a node, plus `k8s.cluster.name` when `clusterName` is set
 - **Cumulative To Delta**: Converts cumulative counters to delta where applicable
 - **Batch**: Batches telemetry for efficient processing (`send_batch_size`/`send_batch_max_size` = 5000). Always last.
 
@@ -61,7 +62,7 @@ The chart implements the recommended OpenTelemetry architecture with two main co
 - **otlp_http/tsuga**: Forwards all telemetry to the Tsuga endpoint with authentication (enabled unless `tsuga.enabledForDaemonset=false`)
 
 **Service Pipelines:**
-- **Logs**: `otlp` (+`file_log` when `agent.collectLogs`) → `memory_limiter`, `resource_detection`¹, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`
+- **Logs**: `otlp` (+`file_log` when `agent.collectLogs`, +`journald` when enabled) → `memory_limiter`, `resource_detection`¹, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`
 - **Metrics**: `otlp`, `kubelet_stats`, `span_metrics`, `host_metrics` → `memory_limiter`, `resource_detection`¹, `k8s_attributes`, `resource`, `cumulativetodelta`, `batch` → `otlp_http/tsuga`
 - **Traces**: `otlp` → `memory_limiter`, `resource_detection`¹, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`, `span_metrics`
 
@@ -111,11 +112,11 @@ agent:
 ### Cluster Receiver (Deployment)
 
 - Collects cluster metrics and events using the Kubernetes API server
-- **Pinned to a single replica.** `k8s_cluster` and `k8s_objects` do not use leader election here, so a second replica would report the same cluster state again: every cluster metric counted twice and every object ingested twice. The replica count is set in the `OpenTelemetryCollector` resource, so a manual `kubectl scale` is reconciled back to 1.
+- **Pinned to a single replica.** `k8s_cluster` and `k8s_objects` do not use leader election here, so a second replica would report the same cluster state again: every cluster metric counted twice and every Kubernetes event ingested twice. The replica count is set in the `OpenTelemetryCollector` resource, so a manual `kubectl scale` is reconciled back to 1.
 
 **Default Receivers:**
 - **Kubernetes Cluster** (`k8s_cluster`): Collects cluster-level metrics and entity events
-- **Kubernetes Objects** (`k8s_objects`): Watches pods (enabled by default, disable with `cluster.collectk8sobjects=false`)
+- **Kubernetes Objects** (`k8s_objects`): Watches pods (`cluster.collectk8sobjects`) and Kubernetes events (`cluster.collectk8sevents`), both enabled by default
 
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit)
@@ -197,6 +198,35 @@ serviceAccount:
 or with **EKS Pod Identity**, which needs no annotation at all — create a pod identity association pointing at the release namespace and the service account name (`<release>-opentelemetry-kube-stack` unless you set `serviceAccount.name`), then set `resourceDetection.detectEksClusterName=true`.
 
 The in-cluster RBAC the chart creates is already complete for everything the collectors do against the Kubernetes API.
+
+### Kubernetes events
+
+`cluster.collectk8sevents` (on by default) watches the `events.k8s.io` API and ships events as logs, filtered to `type=Warning`. Those are the only source for `FailedScheduling`, `BackOff`, `Evicted`, `ErrImagePull`, `FailedMount` and `Unhealthy` — no metric receiver reports them, and the RBAC for it was already granted. `Normal` events (Scheduled, Pulling, Pulled, Created, Started) are excluded: they are the bulk of the volume and restate what the watched pod objects already show.
+
+The receiver takes an initial snapshot on startup (`include_initial_state`, which the upstream receiver only supports receiver-wide, not per object). For events that means a collector restart replays whatever the API server still retains, one hour by default, so expect duplicates around restarts. Disable with `--set cluster.collectk8sevents=false`.
+
+### Node journald logs
+
+`agent.journald` (**off by default**) collects systemd unit logs from the node — kubelet, containerd — which are where node-level failures show up and are invisible in container stdout.
+
+It is off by default because it cannot work out of the box: the journald receiver shells out to `journalctl`, and the OpenTelemetry Collector images do not ship that binary. When enabled, the agent chroots into the host filesystem already mounted at `/hostfs` and runs the node's own `journalctl`, which means:
+
+- the node must actually have a binary at `agent.journald.journalctlPath` (default `/usr/bin/journalctl`)
+- the agent container runs as **root** with the `DAC_READ_SEARCH`, `SYS_PTRACE` and `SYS_CHROOT` capabilities, since journal files are root-owned and are read through a chroot
+
+Check a node before enabling it:
+
+```bash
+journalctl --header | grep "File path"
+```
+
+```yaml
+agent:
+  journald:
+    enabled: true
+    units: [kubelet, containerd]
+    priority: info
+```
 
 ## Quick Start
 

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
@@ -18,8 +18,8 @@ spec:
   # Pinned, and deliberately not configurable. k8s_cluster and k8s_objects have
   # no leader election here, so every extra replica reports the same cluster
   # state again: two replicas means every cluster metric counted twice and
-  # every Kubernetes object ingested twice. Setting it in the CR also means a
-  # manual `kubectl scale` is reconciled back to 1.
+  # every Kubernetes event ingested twice. Setting it in the CR also means a
+  # manual `kubectl scale` is reconciled back to 1 by the operator.
   replicas: 1
   image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   resources:
@@ -90,6 +90,10 @@ spec:
         - group: ""
           mode: watch
           name: pods
+        - field_selector: type=Warning
+          group: events.k8s.io
+          mode: watch
+          name: events
     processors:
       batch:
         send_batch_max_size: 5000

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
@@ -18,8 +18,8 @@ spec:
   # Pinned, and deliberately not configurable. k8s_cluster and k8s_objects have
   # no leader election here, so every extra replica reports the same cluster
   # state again: two replicas means every cluster metric counted twice and
-  # every Kubernetes object ingested twice. Setting it in the CR also means a
-  # manual `kubectl scale` is reconciled back to 1.
+  # every Kubernetes event ingested twice. Setting it in the CR also means a
+  # manual `kubectl scale` is reconciled back to 1 by the operator.
   replicas: 1
   image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   resources:
@@ -90,6 +90,10 @@ spec:
         - group: ""
           mode: watch
           name: pods
+        - field_selector: type=Warning
+          group: events.k8s.io
+          mode: watch
+          name: events
     processors:
       batch:
         send_batch_max_size: 5000

--- a/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
@@ -18,8 +18,8 @@ spec:
   # Pinned, and deliberately not configurable. k8s_cluster and k8s_objects have
   # no leader election here, so every extra replica reports the same cluster
   # state again: two replicas means every cluster metric counted twice and
-  # every Kubernetes object ingested twice. Setting it in the CR also means a
-  # manual `kubectl scale` is reconciled back to 1.
+  # every Kubernetes event ingested twice. Setting it in the CR also means a
+  # manual `kubectl scale` is reconciled back to 1 by the operator.
   replicas: 1
   image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   resources:
@@ -90,6 +90,10 @@ spec:
         - group: ""
           mode: watch
           name: pods
+        - field_selector: type=Warning
+          group: events.k8s.io
+          mode: watch
+          name: events
     processors:
       batch:
         send_batch_max_size: 5000

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
@@ -18,8 +18,8 @@ spec:
   # Pinned, and deliberately not configurable. k8s_cluster and k8s_objects have
   # no leader election here, so every extra replica reports the same cluster
   # state again: two replicas means every cluster metric counted twice and
-  # every Kubernetes object ingested twice. Setting it in the CR also means a
-  # manual `kubectl scale` is reconciled back to 1.
+  # every Kubernetes event ingested twice. Setting it in the CR also means a
+  # manual `kubectl scale` is reconciled back to 1 by the operator.
   replicas: 1
   image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   resources:
@@ -90,6 +90,10 @@ spec:
         - group: ""
           mode: watch
           name: pods
+        - field_selector: type=Warning
+          group: events.k8s.io
+          mode: watch
+          name: events
     processors:
       batch:
         send_batch_max_size: 5000

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
@@ -18,8 +18,8 @@ spec:
   # Pinned, and deliberately not configurable. k8s_cluster and k8s_objects have
   # no leader election here, so every extra replica reports the same cluster
   # state again: two replicas means every cluster metric counted twice and
-  # every Kubernetes object ingested twice. Setting it in the CR also means a
-  # manual `kubectl scale` is reconciled back to 1.
+  # every Kubernetes event ingested twice. Setting it in the CR also means a
+  # manual `kubectl scale` is reconciled back to 1 by the operator.
   replicas: 1
   image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   resources:
@@ -90,6 +90,10 @@ spec:
         - group: ""
           mode: watch
           name: pods
+        - field_selector: type=Warning
+          group: events.k8s.io
+          mode: watch
+          name: events
     processors:
       batch:
         send_batch_max_size: 5000

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
@@ -18,8 +18,8 @@ spec:
   # Pinned, and deliberately not configurable. k8s_cluster and k8s_objects have
   # no leader election here, so every extra replica reports the same cluster
   # state again: two replicas means every cluster metric counted twice and
-  # every Kubernetes object ingested twice. Setting it in the CR also means a
-  # manual `kubectl scale` is reconciled back to 1.
+  # every Kubernetes event ingested twice. Setting it in the CR also means a
+  # manual `kubectl scale` is reconciled back to 1 by the operator.
   replicas: 1
   image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   resources:
@@ -90,6 +90,10 @@ spec:
         - group: ""
           mode: watch
           name: pods
+        - field_selector: type=Warning
+          group: events.k8s.io
+          mode: watch
+          name: events
     processors:
       batch:
         send_batch_max_size: 5000

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
@@ -18,8 +18,8 @@ spec:
   # Pinned, and deliberately not configurable. k8s_cluster and k8s_objects have
   # no leader election here, so every extra replica reports the same cluster
   # state again: two replicas means every cluster metric counted twice and
-  # every Kubernetes object ingested twice. Setting it in the CR also means a
-  # manual `kubectl scale` is reconciled back to 1.
+  # every Kubernetes event ingested twice. Setting it in the CR also means a
+  # manual `kubectl scale` is reconciled back to 1 by the operator.
   replicas: 1
   image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   resources:
@@ -90,6 +90,10 @@ spec:
         - group: ""
           mode: watch
           name: pods
+        - field_selector: type=Warning
+          group: events.k8s.io
+          mode: watch
+          name: events
     processors:
       batch:
         send_batch_max_size: 5000

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
@@ -18,8 +18,8 @@ spec:
   # Pinned, and deliberately not configurable. k8s_cluster and k8s_objects have
   # no leader election here, so every extra replica reports the same cluster
   # state again: two replicas means every cluster metric counted twice and
-  # every Kubernetes object ingested twice. Setting it in the CR also means a
-  # manual `kubectl scale` is reconciled back to 1.
+  # every Kubernetes event ingested twice. Setting it in the CR also means a
+  # manual `kubectl scale` is reconciled back to 1 by the operator.
   replicas: 1
   image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
   resources:
@@ -80,6 +80,10 @@ spec:
         - group: ""
           mode: watch
           name: pods
+        - field_selector: type=Warning
+          group: events.k8s.io
+          mode: watch
+          name: events
     processors:
       batch:
         send_batch_max_size: 5000

--- a/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
@@ -7,14 +7,29 @@ receivers:
     metrics:
       k8s.pod.status_reason:
         enabled: true
-{{- if .Values.cluster.collectk8sobjects }}
+{{- if or .Values.cluster.collectk8sobjects .Values.cluster.collectk8sevents }}
   k8s_objects:
     auth_type: serviceAccount
+    # Receiver-wide (the field does not exist per-object): on start, snapshot
+    # current objects before watching. For events that means the API server's
+    # retained window (1h by default) is replayed after a collector restart.
     include_initial_state: true
     objects:
+    {{- if .Values.cluster.collectk8sobjects }}
       - group: ""
         name: pods
         mode: watch
+    {{- end }}
+    {{- if .Values.cluster.collectk8sevents }}
+      # Warning only. Normal events (Scheduled, Pulling, Pulled, Created,
+      # Started) are the bulk of the volume and restate what the pod objects
+      # above already show; the diagnostic value - FailedScheduling, BackOff,
+      # Evicted, ErrImagePull, FailedMount, Unhealthy - is all type=Warning.
+      - group: events.k8s.io
+        name: events
+        mode: watch
+        field_selector: type=Warning
+    {{- end }}
 {{- end }}
 processors:
   memory_limiter:
@@ -62,7 +77,7 @@ service:
     logs:
       receivers:
         - k8s_cluster
-{{- if .Values.cluster.collectk8sobjects }}
+{{- if or .Values.cluster.collectk8sobjects .Values.cluster.collectk8sevents }}
         - k8s_objects
 {{- end }}
       processors:

--- a/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
@@ -24,6 +24,20 @@ receivers:
       enabled: true
     start_at: end
   {{- end }}
+{{- if .Values.agent.journald.enabled }}
+  journald:
+    # The collector images do not ship journalctl, and the binary must match
+    # the systemd that wrote the journal. So chroot into the mounted host root
+    # (already available at /hostfs for host_metrics) and run the node's own.
+    root_path: /hostfs
+    journalctl_path: {{ .Values.agent.journald.journalctlPath }}
+    priority: {{ .Values.agent.journald.priority }}
+    start_at: end
+    {{- with .Values.agent.journald.units }}
+    units:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- end }}
   kubelet_stats:
     auth_type: serviceAccount
     collection_interval: 20s
@@ -146,10 +160,9 @@ processors:
   cumulativetodelta: {}
   resource:
     attributes:
-      # host_metrics never touches a pod, so k8s_attributes cannot associate it
-      # and it would otherwise arrive with no node identity at all, collapsing
-      # every node's host metrics together. insert (not upsert) leaves
-      # pod-derived values alone.
+      # host_metrics and journald never touch a pod, so k8s_attributes cannot
+      # associate them and they would otherwise arrive with no node identity at
+      # all. insert (not upsert) leaves pod-derived values alone.
       - key: k8s.node.name
         value: ${env:K8S_NODE_NAME}
         action: insert
@@ -180,6 +193,9 @@ service:
         - otlp
 {{- if .Values.agent.collectLogs }}
         - file_log
+{{- end }}
+{{- if .Values.agent.journald.enabled }}
+        - journald
 {{- end }}
       processors:
         # memory_limiter must be first so load is shed before the pipeline

--- a/charts/opentelemetry-kube-stack/templates/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/templates/cluster-receiver.yaml
@@ -21,8 +21,8 @@ spec:
   # Pinned, and deliberately not configurable. k8s_cluster and k8s_objects have
   # no leader election here, so every extra replica reports the same cluster
   # state again: two replicas means every cluster metric counted twice and
-  # every Kubernetes object ingested twice. Setting it in the CR also means a
-  # manual `kubectl scale` is reconciled back to 1.
+  # every Kubernetes event ingested twice. Setting it in the CR also means a
+  # manual `kubectl scale` is reconciled back to 1 by the operator.
   replicas: 1
   image: {{ .Values.cluster.image | default "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib" }}
   {{- if or .Values.cluster.resources .Values.resources }}

--- a/charts/opentelemetry-kube-stack/templates/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/templates/daemonset.yaml
@@ -79,6 +79,19 @@ spec:
   {{- if .Values.serviceAccount.create }}
   serviceAccount: {{ .Values.serviceAccount.name | default (include "opentelemetry-kube-stack.serviceAccountName" .) }}
   {{- end }}
+  {{- if .Values.agent.journald.enabled }}
+  # journalctl reads root-owned journal files and is executed through a chroot
+  # into the mounted host root, so the container needs root plus the file-read
+  # and chroot capabilities. Only applied when journald collection is on.
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    capabilities:
+      add:
+        - DAC_READ_SEARCH
+        - SYS_PTRACE
+        - SYS_CHROOT
+  {{- end }}
   env:
     {{- include "opentelemetry-kube-stack.collectorEnv" . | nindent 4 }}
     {{- if .Values.agent.extraEnvs }}

--- a/charts/opentelemetry-kube-stack/tests/cluster-receiver_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/cluster-receiver_test.yaml
@@ -50,23 +50,6 @@ tests:
           path: spec.config.service.pipelines.logs.receivers
           content: k8s_objects
 
-  - it: should not collect k8s objects when disabled
-    set:
-      cluster.enabled: true
-      cluster.collectk8sobjects: false
-      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
-      tsuga.apiKey: "<TSUGA_API_KEY>"
-    release:
-      name: "test-release"
-    asserts:
-      - isKind:
-          of: OpenTelemetryCollector
-      - isNull:
-          path: spec.config.receivers.k8s_objects
-      - notContains:
-          path: spec.config.service.pipelines.logs.receivers
-          content: k8s_objects
-
   - it: should guard logs and metrics pipelines with memory_limiter first
     set:
       cluster.enabled: true
@@ -108,3 +91,54 @@ tests:
     asserts:
       - isNull:
           path: spec.config.processors["resource/collector"]
+
+  - it: should collect k8s events by default
+    set:
+      cluster.enabled: true
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - contains:
+          path: spec.config.receivers.k8s_objects.objects
+          content:
+            group: events.k8s.io
+            name: events
+            mode: watch
+            field_selector: type=Warning
+
+  - it: should keep the k8s_objects receiver for events when pod objects are disabled
+    set:
+      cluster.enabled: true
+      cluster.collectk8sobjects: false
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - notContains:
+          path: spec.config.receivers.k8s_objects.objects
+          content:
+            group: ""
+            name: pods
+            mode: watch
+      - contains:
+          path: spec.config.service.pipelines.logs.receivers
+          content: k8s_objects
+
+  - it: should not collect k8s objects when both objects and events are disabled
+    set:
+      cluster.enabled: true
+      cluster.collectk8sobjects: false
+      cluster.collectk8sevents: false
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - isNull:
+          path: spec.config.receivers.k8s_objects
+      - notContains:
+          path: spec.config.service.pipelines.logs.receivers
+          content: k8s_objects

--- a/charts/opentelemetry-kube-stack/tests/daemonset_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/daemonset_test.yaml
@@ -273,3 +273,45 @@ tests:
       - equal:
           path: spec.config.processors.resource_detection.timeout
           value: 5s
+
+  - it: should not collect journald by default
+    set:
+      agent.enabled: true
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - isNull:
+          path: spec.config.receivers.journald
+      - notContains:
+          path: spec.config.service.pipelines.logs.receivers
+          content: journald
+      # No root/capabilities escalation unless journald is explicitly enabled.
+      - isNull:
+          path: spec.securityContext
+
+  - it: should collect journald through the host journalctl when enabled
+    set:
+      agent.enabled: true
+      agent.journald.enabled: true
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - equal:
+          path: spec.config.receivers.journald.root_path
+          value: /hostfs
+      - equal:
+          path: spec.config.receivers.journald.journalctl_path
+          value: /usr/bin/journalctl
+      - contains:
+          path: spec.config.service.pipelines.logs.receivers
+          content: journald
+      - equal:
+          path: spec.securityContext.runAsUser
+          value: 0
+      - contains:
+          path: spec.securityContext.capabilities.add
+          content: SYS_CHROOT

--- a/charts/opentelemetry-kube-stack/values.schema.json
+++ b/charts/opentelemetry-kube-stack/values.schema.json
@@ -128,6 +128,26 @@
                 "image": {
                     "type": "string"
                 },
+                "journald": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "journalctlPath": {
+                            "type": "string"
+                        },
+                        "priority": {
+                            "type": "string"
+                        },
+                        "units": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
                 "nodeSelector": {
                     "type": "object"
                 },
@@ -167,6 +187,9 @@
             "properties": {
                 "affinity": {
                     "type": "object"
+                },
+                "collectk8sevents": {
+                    "type": "boolean"
                 },
                 "collectk8sobjects": {
                     "type": "boolean"

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -303,8 +303,19 @@ cluster:
   #           exporters: [otlp_http/tsuga]
   # @default -- {}
   customConfig: {}
+  # -- Watch pod objects and ship them as logs
   # This is used in the Kubernetes view to show pod configuration
+  # @default -- true
   collectk8sobjects: true
+  # -- Collect Kubernetes Warning events (FailedScheduling, BackOff, Evicted,
+  # ErrImagePull, FailedMount, Unhealthy, ...) as logs.
+  # Filtered to type=Warning: Normal events are the bulk of the volume and
+  # restate what the watched pod objects already show. Uses the RBAC rules
+  # already granted for events. Note that on collector restart the API
+  # server's retained event window (1h by default) is replayed, so a restart
+  # produces duplicates.
+  # @default -- true
+  collectk8sevents: true
   # -- Gateway collector configuration (merge-based approach)
   # Use this to extend the default configuration
   # Default config includes: k8s_cluster receiver, k8s_attributes processor, resource processor
@@ -477,6 +488,34 @@ agent:
   # @default -- false
   collectProcesses: false
 
+  # -- Collect systemd/journald logs from the node (kubelet, containerd, ...)
+  # These are the logs for node-level failures - kubelet crashes, containerd
+  # errors, disk pressure - which are invisible in container stdout.
+  #
+  # DISABLED BY DEFAULT because it cannot work out of the box: the journald
+  # receiver shells out to `journalctl`, and the OpenTelemetry Collector images
+  # do not ship it. When enabled, the agent chroots into the host filesystem
+  # already mounted at /hostfs and runs the node's own journalctl, so the node
+  # must actually have a binary at journalctlPath. Enabling this also makes the
+  # agent container run as root with DAC_READ_SEARCH/SYS_PTRACE/SYS_CHROOT.
+  # Verify on a node first: `journalctl --header | grep "File path"`
+  journald:
+    # -- Enable the journald receiver on the agent
+    # @default -- false
+    enabled: false
+    # -- Absolute path to journalctl on the node (inside the /hostfs chroot)
+    # @default -- "/usr/bin/journalctl"
+    journalctlPath: /usr/bin/journalctl
+    # -- systemd units to read. An empty list reads every unit, which is a lot.
+    # @default -- ["kubelet", "containerd"]
+    units:
+      - kubelet
+      - containerd
+    # -- Minimum message priority to keep. One of emerg, alert, crit, err,
+    # warning, notice, info, debug.
+    # @default -- "info"
+    priority: info
+
   # -- Replace default config with complete custom configuration
   # When set, this completely replaces the default collector configuration
   # Use this for full control over the OpenTelemetry Collector config
@@ -492,8 +531,44 @@ agent:
     # Merges with default telemetry (Prometheus metrics on port 8888)
     # @default -- {}
     extraTelemetry: {}
+    # MIGRATING FROM AN EXISTING AGENT
+    # ---------------------------------------------------------------------
+    # The agent can accept the wire formats your current tooling already
+    # emits, so applications keep their existing SDK and just point at this
+    # DaemonSet. Add the receiver below and list it under the matching
+    # pipeline's extraReceivers. All of these ship in the
+    # opentelemetry-collector-contrib image, which is the agent default. If
+    # you pin agent.image to opentelemetry-collector-k8s instead, note that
+    # it carries zipkin, jaeger and fluentforward but not statsd or
+    # prometheusremotewrite.
+    #
+    #   config:
+    #     extraReceivers:
+    #       zipkin: {}                                  # -> traces
+    #       jaeger:                                     # -> traces
+    #         protocols:
+    #           grpc:
+    #             endpoint: ${env:MY_POD_IP}:14250
+    #           thrift_http:
+    #             endpoint: ${env:MY_POD_IP}:14268
+    #       statsd:                                     # -> metrics
+    #         endpoint: ${env:MY_POD_IP}:8125
+    #       prometheusremotewrite:                      # -> metrics
+    #         endpoint: ${env:MY_POD_IP}:9090
+    #       fluentforward:                              # -> logs
+    #         endpoint: ${env:MY_POD_IP}:8006
+    #     service:
+    #       pipelines:
+    #         traces:
+    #           extraReceivers: [zipkin, jaeger]
+    #         metrics:
+    #           extraReceivers: [statsd, prometheusremotewrite]
+    #         logs:
+    #           extraReceivers: [fluentforward]
+    # ---------------------------------------------------------------------
     # -- Additional receivers to merge into the collector configuration
-    # These are merged with default receivers
+    # These are merged with default receivers. See the migration examples
+    # directly above this key in values.yaml for ready-to-paste blocks.
     # @default -- {}
     extraReceivers: {}
     # -- Additional processors to merge into the collector configuration


### PR DESCRIPTION
**Kubernetes events** were not collected at all. They are the only source for `OOMKilled`, `FailedScheduling`, `BackOff`, `Evicted`, `ErrImagePull`, `FailedMount` and `Unhealthy` — no metric receiver reports them — and the RBAC was already granted. `k8s_objects` now watches `events.k8s.io` alongside pods, on by default via `cluster.collectk8sevents`.

Note: `include_initial_state` is receiver-wide, not per object, so a collector restart replays the API server's retained event window (1h by default) and produces duplicates.

**Node journald logs**, off by default. Kubelet crashes, containerd errors and disk pressure are invisible in container stdout. Off by default because it can't work out of the box: the receiver shells out to `journalctl` and the collector images don't ship it. When enabled the agent chroots into the host root already mounted at `/hostfs` and runs the node's own binary, which requires the container to run as **root** with `DAC_READ_SEARCH`, `SYS_PTRACE` and `SYS_CHROOT`. That securityContext is only applied when the flag is on.

**Migration receivers**, documented only. `zipkin`, `jaeger`, `statsd`, `prometheusremotewrite` and `fluentforward` via the existing `extraReceivers` merge, with the matching pipeline wiring — apps migrating from another agent keep their SDK and point at this DaemonSet. No new flags; `extraReceivers` already does this.

Chart 0.12.0. 51 unit tests pass; artifacts regenerated.

Stacked on #115.