### PR TITLE
feat(kube-stack)!: require clusterName

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releas
 **Option B: Install with this chart** by setting `opentelemetry-operator.enabled=true` in your `values.yaml` file or on the command line when installing:
 ```bash
 helm install my-opentelemetry-kube-stack tsuga-charts/opentelemetry-kube-stack \
+  --set clusterName="<CLUSTER_NAME>" \
   --set opentelemetry-operator.enabled=true
 ```
 
@@ -68,6 +69,7 @@ It is recommended to create a secret for the Tsuga API key and use it in the `va
 
 ```bash
 helm install my-otel-stack ./charts/opentelemetry-kube-stack \
+  --set clusterName="<CLUSTER_NAME>" \
   --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
   --set tsuga.apiKey="<TSUGA_API_KEY>"
 ```
@@ -75,6 +77,7 @@ helm install my-otel-stack ./charts/opentelemetry-kube-stack \
 **Option B: Use existing secret**
 ```bash
 helm install my-otel-stack ./charts/opentelemetry-kube-stack \
+  --set clusterName="<CLUSTER_NAME>" \
   --set secret.create=false \
   --set secret.name="my-existing-secret" \
   --set secret.keyMapping.TSUGA_API_KEY="<API_KEY_SECRET_KEY>" \
@@ -86,7 +89,8 @@ helm install my-otel-stack ./charts/opentelemetry-kube-stack \
 To install the opentelemetry-kube-stack chart:
 
 ```bash
-helm install my-opentelemetry-kube-stack tsuga-charts/opentelemetry-kube-stack
+helm install my-opentelemetry-kube-stack tsuga-charts/opentelemetry-kube-stack \
+  --set clusterName="<CLUSTER_NAME>"
 ```
 
 To uninstall the chart:

--- a/charts/opentelemetry-kube-stack/CHANGELOG.md
+++ b/charts/opentelemetry-kube-stack/CHANGELOG.md
@@ -5,18 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [opentelemetry-kube-stack-0.10.0] - 2026-07-27
+
+### Breaking Changes
+- **BREAKING** Require clusterName by @gus-tsuga
+  Installs and upgrades now fail if clusterName is empty. Pass --set clusterName=<name>; --reuse-values does not supply it, because the stored value is the empty string.
+
+### Added
+- Pass clusterName in every documented install path by @gus-tsuga
+
+### Changed
+- Group breaking changes in generated release notes by @gus-tsuga
+
+## [opentelemetry-kube-stack-0.9.0] - 2026-07-16
+
+### Added
+- Enable cluster.collectk8sobjects by default by @gus-tsuga
+
+### Fixed
+- Guard cluster receiver pipelines with memory_limiter by @gus-tsuga
+
+## [opentelemetry-kube-stack-0.7.4] - 2026-07-13
+
+### Fixed
+- Render service.telemetry.resource as a map (#111) by @abruneau in [#111](https://github.com/tsuga-dev/helm-charts/pull/111)
+
+### Changed
+- Making placeholders explicits by @gus-tsuga
+
 ## [opentelemetry-kube-stack-0.7.3] - 2026-07-01
 
 ### Added
 - Align demo and kube-stack with OTel naming conventions (#95) by @abruneau in [#95](https://github.com/tsuga-dev/helm-charts/pull/95)
 
+### Fixed
+- List-form telemetry headers + collector version guard (#107) by @abruneau in [#107](https://github.com/tsuga-dev/helm-charts/pull/107)
+
 ### Changed
 - Fix Old otel conventions (#98) by @abruneau in [#98](https://github.com/tsuga-dev/helm-charts/pull/98)
 - Docs/readme charts update (#104) by @abruneau in [#104](https://github.com/tsuga-dev/helm-charts/pull/104)
 - Remove payment log pod annotation and default to contrib image (#106) by @abruneau in [#106](https://github.com/tsuga-dev/helm-charts/pull/106)
-
-### Fixed
-- List-form telemetry headers + collector version guard (#107) by @abruneau in [#107](https://github.com/tsuga-dev/helm-charts/pull/107)
 
 ## [opentelemetry-kube-stack-0.7.2] - 2026-06-11
 
@@ -91,10 +119,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add schema for targetAllocator and statefulset values by @abruneau
 - Add target-allocator example by @abruneau
 
-### Changed
-- Add statefulset collector-TA link tests by @abruneau
-- Bump version by @abruneau
-
 ### Fixed
 - Make replicas conditional, document TA coupling by @abruneau
 - Guard TargetAllocator serviceAccount on serviceAccount.create by @abruneau
@@ -108,6 +132,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add net.host.name and cumulativetodelta to statefulset collector by @abruneau
 - Fix tolerations type for agent and cluster by @abruneau
 
+### Changed
+- Add statefulset collector-TA link tests by @abruneau
+- Bump version by @abruneau
+
 ## [opentelemetry-kube-stack-0.4.0] - 2026-02-17
 
 ### Added
@@ -115,13 +143,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make clusterName optional with warning by @abruneau
 - Document operator and cert-manager requirements by @abruneau
 
+### Fixed
+- Update gitignore and operator condition by @abruneau
+
 ### Changed
 - Add auto-instrumentation examples and testing framework by @abruneau
 - Remove unused otel-crds dependency by @abruneau
 - Bump version by @abruneau
-
-### Fixed
-- Update gitignore and operator condition by @abruneau
 
 ## [opentelemetry-kube-stack-0.3.0] - 2026-02-02
 
@@ -145,12 +173,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [opentelemetry-kube-stack-0.2.14] - 2026-01-12
 
+### Fixed
+- Fix custom config not being taken in count by @abruneau
+
 ### Changed
 - Enhance OpenTelemetry configuration by adding k8s_observer extension for improved Kubernetes resource observation. Update daemonset and service templates to include new logging receiver and adjust extraExtensions handling. by @abruneau
 - Bump version by @abruneau
-
-### Fixed
-- Fix custom config not being taken in count by @abruneau
 
 ## [opentelemetry-kube-stack-0.2.13] - 2026-01-12
 
@@ -242,6 +270,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - First commit by @abruneau
 - Add Makefile for example generation and validation; update Helm chart configurations by @abruneau
+[opentelemetry-kube-stack-0.10.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.9.0...opentelemetry-kube-stack-0.10.0
+
+[opentelemetry-kube-stack-0.9.0]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.7.4...opentelemetry-kube-stack-0.9.0
+
+[opentelemetry-kube-stack-0.7.4]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.7.3...opentelemetry-kube-stack-0.7.4
+
 [opentelemetry-kube-stack-0.7.3]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.7.2...opentelemetry-kube-stack-0.7.3
 
 [opentelemetry-kube-stack-0.7.2]: https://github.com/tsuga-dev/helm-charts/compare/opentelemetry-kube-stack-0.7.1...opentelemetry-kube-stack-0.7.2

--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-kube-stack/Makefile
+++ b/charts/opentelemetry-kube-stack/Makefile
@@ -71,6 +71,7 @@ clean:
 install:
 	@echo "Installing chart with test values..."
 	helm install otel-test . \
+		--set clusterName="test-cluster" \
 		--set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
 		--set tsuga.apiKey="<TSUGA_API_KEY>" \
 		--wait --timeout=300s
@@ -84,6 +85,7 @@ uninstall:
 template:
 	@echo "Templating chart..."
 	helm template otel-test . \
+		--set clusterName="test-cluster" \
 		--set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
 		--set tsuga.apiKey="<TSUGA_API_KEY>"
 
@@ -91,6 +93,7 @@ template:
 dry-run:
 	@echo "Dry run installation..."
 	helm install otel-test . \
+		--set clusterName="test-cluster" \
 		--set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
 		--set tsuga.apiKey="<TSUGA_API_KEY>" \
 		--dry-run --debug

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-kube-stack
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
 
 A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet + cluster receiver), secure credential management, and production-ready configurations for telemetry collection to Tsuga platform.
 
@@ -377,7 +377,7 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | cluster.nodeSelector | object | {} | Cluster-specific node selector If not set, inherits from global nodeSelector configuration |
 | cluster.resources | object | {} | Cluster-specific resource limits and requests If not set, inherits from global resources configuration |
 | cluster.tolerations | list | [] | Cluster-specific tolerations If not set, inherits from global tolerations configuration |
-| clusterName | string | "" | The name of the cluster to be used in the resource attributes This value is added to all telemetry data as k8s.cluster.name RECOMMENDED: Set this value to identify your cluster in telemetry data If not set, the k8s.cluster.name attribute will be omitted from telemetry |
+| clusterName | string | "" (must be set) | REQUIRED. The name of the cluster, added to all telemetry as k8s.cluster.name.  Installation fails if this is empty. Telemetry from a cluster that does not name itself cannot be told apart from any other cluster's once it reaches Tsuga, and the omission only becomes visible during an incident, which is the worst time to discover it.    --set clusterName=<name>  |
 | fullnameOverride | string | "" | Override the full name used in resource naming |
 | image | string | "" | Default OpenTelemetry Collector image Used as fallback when cluster.image or agent.image are not set Format: registry/repository:tag |
 | nameOverride | string | "" | Override the chart name used in resource naming |

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -183,6 +183,7 @@ opentelemetry-operator:
 Or via command line:
 ```bash
 helm install my-otel-stack tsuga-charts/opentelemetry-kube-stack \
+  --set clusterName="<CLUSTER_NAME>" \
   --set opentelemetry-operator.enabled=true
 ```
 
@@ -200,6 +201,9 @@ kubectl wait --for=condition=Ready pods -l app.kubernetes.io/name=opentelemetry-
 ```
 
 ## Installation
+
+`clusterName` is required on every install: it is what distinguishes this cluster's
+telemetry from every other cluster's in Tsuga.
 
 ## Auto-instrumentation (APM)
 
@@ -262,6 +266,7 @@ helm repo update
 
 # Install with Tsuga configuration
 helm install my-otel-stack tsuga-charts/opentelemetry-kube-stack \
+  --set clusterName="<CLUSTER_NAME>" \
   --set secret.create=true \
   --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
   --set tsuga.apiKey="<TSUGA_API_KEY>"
@@ -272,6 +277,7 @@ helm install my-otel-stack tsuga-charts/opentelemetry-kube-stack \
 ```bash
 # Install directly from the chart directory
 helm install my-otel-stack ./opentelemetry-kube-stack \
+  --set clusterName="<CLUSTER_NAME>" \
   --set secret.create=true \
   --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
   --set tsuga.apiKey="<TSUGA_API_KEY>"
@@ -282,6 +288,7 @@ helm install my-otel-stack ./opentelemetry-kube-stack \
 ```bash
 # Create a values file
 cat > my-values.yaml << EOF
+clusterName: "<CLUSTER_NAME>"
 tsuga:
   otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
   apiKey: "<TSUGA_API_KEY>"
@@ -513,7 +520,7 @@ helm lint .
 # Test rendering
 make template
 # or
-helm template test . --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" --set tsuga.apiKey="<TSUGA_API_KEY>"
+helm template test . --set clusterName="<CLUSTER_NAME>" --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" --set tsuga.apiKey="<TSUGA_API_KEY>"
 ```
 
 ### Documentation

--- a/charts/opentelemetry-kube-stack/README.md.gotmpl
+++ b/charts/opentelemetry-kube-stack/README.md.gotmpl
@@ -173,6 +173,7 @@ opentelemetry-operator:
 Or via command line:
 ```bash
 helm install my-otel-stack tsuga-charts/opentelemetry-kube-stack \
+  --set clusterName="<CLUSTER_NAME>" \
   --set opentelemetry-operator.enabled=true
 ```
 
@@ -190,6 +191,9 @@ kubectl wait --for=condition=Ready pods -l app.kubernetes.io/name=opentelemetry-
 ```
 
 ## Installation
+
+`clusterName` is required on every install: it is what distinguishes this cluster's
+telemetry from every other cluster's in Tsuga.
 
 ## Auto-instrumentation (APM)
 
@@ -241,6 +245,7 @@ Supported annotation keys depend on language (examples):
 - `instrumentation.opentelemetry.io/inject-nodejs`
 - `instrumentation.opentelemetry.io/inject-dotnet`
 
+
 ### Install the Chart
 
 #### Option 1: Using Chart Repository (Recommended)
@@ -252,6 +257,7 @@ helm repo update
 
 # Install with Tsuga configuration
 helm install my-otel-stack tsuga-charts/opentelemetry-kube-stack \
+  --set clusterName="<CLUSTER_NAME>" \
   --set secret.create=true \
   --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
   --set tsuga.apiKey="<TSUGA_API_KEY>"
@@ -262,6 +268,7 @@ helm install my-otel-stack tsuga-charts/opentelemetry-kube-stack \
 ```bash
 # Install directly from the chart directory
 helm install my-otel-stack ./opentelemetry-kube-stack \
+  --set clusterName="<CLUSTER_NAME>" \
   --set secret.create=true \
   --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
   --set tsuga.apiKey="<TSUGA_API_KEY>"
@@ -272,6 +279,7 @@ helm install my-otel-stack ./opentelemetry-kube-stack \
 ```bash
 # Create a values file
 cat > my-values.yaml << EOF
+clusterName: "<CLUSTER_NAME>"
 tsuga:
   otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
   apiKey: "<TSUGA_API_KEY>"
@@ -352,7 +360,7 @@ helm lint .
 # Test rendering
 make template
 # or
-helm template test . --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" --set tsuga.apiKey="<TSUGA_API_KEY>"
+helm template test . --set clusterName="<CLUSTER_NAME>" --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" --set tsuga.apiKey="<TSUGA_API_KEY>"
 ```
 
 ### Documentation

--- a/charts/opentelemetry-kube-stack/cliff.toml
+++ b/charts/opentelemetry-kube-stack/cliff.toml
@@ -24,9 +24,12 @@ https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
 ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {%- for group, commits in grouped_commits %}
 
-### {{ group | upper_first }}
+### {{ group | striptags | trim | upper_first }}
 {%- for commit in commits %}
-- {{ commit.message | split(pat="\n") | first | upper_first | trim }}{% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}{% if commit.remote.pr_number %} in [#{{ commit.remote.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.remote.pr_number }}){% endif %}
+- {% if commit.breaking %}**BREAKING** {% endif %}{{ commit.message | split(pat="\n") | first | upper_first | trim }}{% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}{% if commit.remote.pr_number %} in [#{{ commit.remote.pr_number }}]({{ self::remote_url() }}/pull/{{ commit.remote.pr_number }}){% endif %}
+{%- if commit.breaking and commit.breaking_description and commit.breaking_description != commit.message %}
+  {{ commit.breaking_description | split(pat="\n") | first | upper_first | trim }}
+{%- endif %}
 {%- endfor %}
 {%- endfor %}
 {%- if first_time_contributors | length != 0 %}
@@ -63,16 +66,20 @@ exclude_paths = ["charts/opentelemetry-kube-stack/CHANGELOG.md", "charts/opentel
 # Tags created by helm chart-releaser for this chart (e.g. opentelemetry-kube-stack-0.6.1)
 tag_pattern = "opentelemetry-kube-stack-[0-9].*"
 commit_parsers = [
-  { message = "^feat", group = "Added" },
-  { message = "^fix", group = "Fixed" },
-  { message = "^docs", group = "Added" },
-  { message = "^perf", group = "Changed" },
-  { message = "^refactor", group = "Changed" },
-  { message = "^style", group = "Changed" },
-  { message = "^test", group = "Changed" },
-  { message = "^chore", group = "Changed" },
-  { message = "^ci", group = "Changed" },
-  { message = "^.*", group = "Changed" },
+  # Breaking changes get their own group, whether flagged with `type!:` or a
+  # `BREAKING CHANGE:` footer. Must come first: parsing stops at the first match.
+  { message = "^[a-zA-Z]+(\\(.*\\))?!:", group = "<!-- 0 -->Breaking Changes" },
+  { footer = "^BREAKING[ -]CHANGE:", group = "<!-- 0 -->Breaking Changes" },
+  { message = "^feat", group = "<!-- 1 -->Added" },
+  { message = "^fix", group = "<!-- 2 -->Fixed" },
+  { message = "^docs", group = "<!-- 1 -->Added" },
+  { message = "^perf", group = "<!-- 3 -->Changed" },
+  { message = "^refactor", group = "<!-- 3 -->Changed" },
+  { message = "^style", group = "<!-- 3 -->Changed" },
+  { message = "^test", group = "<!-- 3 -->Changed" },
+  { message = "^chore", group = "<!-- 3 -->Changed" },
+  { message = "^ci", group = "<!-- 3 -->Changed" },
+  { message = "^.*", group = "<!-- 3 -->Changed" },
 ]
 filter_commits = false
 topo_order = false

--- a/charts/opentelemetry-kube-stack/deploy.sh
+++ b/charts/opentelemetry-kube-stack/deploy.sh
@@ -537,7 +537,7 @@ show_next_steps() {
     
     echo -e "\n${CYAN}Useful Commands:${NC}"
     echo -e "• Uninstall: ${BLUE}helm uninstall $RELEASE_NAME -n $NAMESPACE${NC}"
-    echo -e "• Upgrade: ${BLUE}helm upgrade $RELEASE_NAME . -n $NAMESPACE${NC}"
+    echo -e "• Upgrade: ${BLUE}helm upgrade $RELEASE_NAME . -n $NAMESPACE --reuse-values${NC}"
     echo -e "• Status: ${BLUE}helm status $RELEASE_NAME -n $NAMESPACE${NC}"
 }
 

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
@@ -142,11 +142,19 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
       resource/collector:
         attributes:
         - action: upsert
           key: service.instance.id
           value: ${POD_UID}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -162,6 +170,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -172,6 +181,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -188,4 +198,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/daemonset.yaml
@@ -200,11 +200,19 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
       resource/collector:
         attributes:
         - action: upsert
           key: service.instance.id
           value: ${POD_UID}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -233,6 +241,7 @@ spec:
           - k8s_attributes
           - memory_limiter
           - batch
+          - resource
           receivers:
           - otlp
           - file_log
@@ -243,6 +252,7 @@ spec:
           - k8s_attributes
           - memory_limiter
           - cumulativetodelta
+          - resource
           - batch
           receivers:
           - otlp
@@ -256,6 +266,7 @@ spec:
           processors:
           - k8s_attributes
           - memory_limiter
+          - resource
           - batch
           receivers:
           - otlp
@@ -271,4 +282,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/values.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 # yaml-language-server: $schema=../../values.schema.json
 tsuga:
   otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
@@ -142,11 +142,19 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
       resource/collector:
         attributes:
         - action: upsert
           key: service.instance.id
           value: ${POD_UID}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -162,6 +170,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -172,6 +181,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -188,4 +198,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/daemonset.yaml
@@ -200,11 +200,19 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
       resource/collector:
         attributes:
         - action: upsert
           key: service.instance.id
           value: ${POD_UID}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -233,6 +241,7 @@ spec:
           - k8s_attributes
           - memory_limiter
           - batch
+          - resource
           receivers:
           - otlp
           - file_log
@@ -243,6 +252,7 @@ spec:
           - k8s_attributes
           - memory_limiter
           - cumulativetodelta
+          - resource
           - batch
           receivers:
           - otlp
@@ -256,6 +266,7 @@ spec:
           processors:
           - k8s_attributes
           - memory_limiter
+          - resource
           - batch
           receivers:
           - otlp
@@ -271,4 +282,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/create-secret/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/values.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 tsuga:
   otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
   apiKey: "<TSUGA_API_KEY>"

--- a/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
@@ -142,11 +142,19 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
       resource/collector:
         attributes:
         - action: upsert
           key: service.instance.id
           value: ${POD_UID}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -162,6 +170,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -172,6 +181,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -188,4 +198,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/custom-config/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/custom-config/values.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 # yaml-language-server: $schema=../../values.schema.json
 agent:
   image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
@@ -142,11 +142,19 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
       resource/collector:
         attributes:
         - action: upsert
           key: service.instance.id
           value: ${POD_UID}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -162,6 +170,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -172,6 +181,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -188,4 +198,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/daemonset.yaml
@@ -200,11 +200,19 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
       resource/collector:
         attributes:
         - action: upsert
           key: service.instance.id
           value: ${POD_UID}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -233,6 +241,7 @@ spec:
           - k8s_attributes
           - memory_limiter
           - batch
+          - resource
           receivers:
           - otlp
           - file_log
@@ -243,6 +252,7 @@ spec:
           - k8s_attributes
           - memory_limiter
           - cumulativetodelta
+          - resource
           - batch
           receivers:
           - otlp
@@ -256,6 +266,7 @@ spec:
           processors:
           - k8s_attributes
           - memory_limiter
+          - resource
           - batch
           receivers:
           - otlp
@@ -271,4 +282,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/default/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/values.yaml
@@ -1,0 +1,2 @@
+---
+clusterName: test-cluster

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
@@ -142,11 +142,19 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
       resource/collector:
         attributes:
         - action: upsert
           key: service.instance.id
           value: ${POD_UID}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -162,6 +170,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -172,6 +181,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -188,4 +198,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/daemonset.yaml
@@ -200,11 +200,19 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
       resource/collector:
         attributes:
         - action: upsert
           key: service.instance.id
           value: ${POD_UID}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -233,6 +241,7 @@ spec:
           - k8s_attributes
           - memory_limiter
           - batch
+          - resource
           receivers:
           - otlp
           - file_log
@@ -243,6 +252,7 @@ spec:
           - k8s_attributes
           - memory_limiter
           - cumulativetodelta
+          - resource
           - batch
           receivers:
           - otlp
@@ -262,6 +272,7 @@ spec:
           processors:
           - k8s_attributes
           - memory_limiter
+          - resource
           - batch
           receivers:
           - otlp
@@ -277,4 +288,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/extra-service/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/values.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 agent:
   config:
     service:

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
@@ -142,11 +142,19 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
       resource/collector:
         attributes:
         - action: upsert
           key: service.instance.id
           value: ${POD_UID}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -162,6 +170,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -172,6 +181,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -188,4 +198,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/daemonset.yaml
@@ -200,11 +200,19 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
       resource/collector:
         attributes:
         - action: upsert
           key: service.instance.id
           value: ${POD_UID}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -233,6 +241,7 @@ spec:
           - k8s_attributes
           - memory_limiter
           - batch
+          - resource
           receivers:
           - otlp
           - file_log
@@ -243,6 +252,7 @@ spec:
           - k8s_attributes
           - memory_limiter
           - cumulativetodelta
+          - resource
           - batch
           receivers:
           - otlp
@@ -256,6 +266,7 @@ spec:
           processors:
           - k8s_attributes
           - memory_limiter
+          - resource
           - batch
           receivers:
           - otlp
@@ -271,4 +282,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/values.yaml
@@ -1,3 +1,4 @@
 ---
+clusterName: test-cluster
 cluster:
   collectk8sobjects: true

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
@@ -142,11 +142,19 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
       resource/collector:
         attributes:
         - action: upsert
           key: service.instance.id
           value: ${POD_UID}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -162,6 +170,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -172,6 +181,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -188,4 +198,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/daemonset.yaml
@@ -210,11 +210,19 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
       resource/collector:
         attributes:
         - action: upsert
           key: service.instance.id
           value: ${POD_UID}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -248,6 +256,7 @@ spec:
           - k8s_attributes
           - memory_limiter
           - batch
+          - resource
           receivers:
           - otlp
           - receiver_creator/logs
@@ -258,6 +267,7 @@ spec:
           - k8s_attributes
           - memory_limiter
           - cumulativetodelta
+          - resource
           - batch
           receivers:
           - otlp
@@ -273,6 +283,7 @@ spec:
           processors:
           - k8s_attributes
           - memory_limiter
+          - resource
           - batch
           receivers:
           - otlp
@@ -288,4 +299,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/values.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 # yaml-language-server: $schema=../../values.schema.json
 agent:
   image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib

--- a/charts/opentelemetry-kube-stack/examples/target-allocator/rendered/statefulset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/target-allocator/rendered/statefulset.yaml
@@ -138,11 +138,19 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
       resource/collector:
         attributes:
         - action: upsert
           key: service.instance.id
           value: ${POD_UID}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       otlp_http/tsuga:
         compression: gzip
@@ -160,6 +168,7 @@ spec:
           - memory_limiter
           - cumulativetodelta
           - k8s_attributes
+          - resource
           - batch
           receivers:
           - prometheus
@@ -175,4 +184,5 @@ spec:
                     value: Bearer ${TSUGA_API_KEY}
                   protocol: http/protobuf
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/target-allocator/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/target-allocator/values.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 # Target Allocator example
 # Deploys a TargetAllocator CR and a paired StatefulSet OpenTelemetryCollector.
 # The Target Allocator distributes Prometheus targets evenly across 2 collector replicas.

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
@@ -132,11 +132,19 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
       resource/collector:
         attributes:
         - action: upsert
           key: service.instance.id
           value: ${POD_UID}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       debug: {}
     service:
@@ -147,6 +155,7 @@ spec:
           - debug
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
@@ -157,10 +166,12 @@ spec:
           - debug
           processors:
           - memory_limiter
+          - resource
           - k8s_attributes
           - batch
           receivers:
           - k8s_cluster
       telemetry:
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/daemonset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/daemonset.yaml
@@ -190,11 +190,19 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
       resource/collector:
         attributes:
         - action: upsert
           key: service.instance.id
           value: ${POD_UID}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       debug: {}
     extensions:
@@ -218,6 +226,7 @@ spec:
           - k8s_attributes
           - memory_limiter
           - batch
+          - resource
           receivers:
           - otlp
           - file_log
@@ -228,6 +237,7 @@ spec:
           - k8s_attributes
           - memory_limiter
           - cumulativetodelta
+          - resource
           - batch
           receivers:
           - otlp
@@ -241,9 +251,11 @@ spec:
           processors:
           - k8s_attributes
           - memory_limiter
+          - resource
           - batch
           receivers:
           - otlp
       telemetry:
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/statefulset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/statefulset.yaml
@@ -128,11 +128,19 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      resource:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
       resource/collector:
         attributes:
         - action: upsert
           key: service.instance.id
           value: ${POD_UID}
+        - action: upsert
+          key: k8s.cluster.name
+          value: test-cluster
     exporters:
       debug: {}
     service:
@@ -145,9 +153,11 @@ spec:
           - memory_limiter
           - cumulativetodelta
           - k8s_attributes
+          - resource
           - batch
           receivers:
           - prometheus
       telemetry:
         resource:
+          k8s.cluster.name: test-cluster
           service.instance.id: ${POD_UID}

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/values.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/values.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 tsuga:
   enabledForClusterReceiver: false
   enabledForDaemonset: false

--- a/charts/opentelemetry-kube-stack/templates/NOTES.txt
+++ b/charts/opentelemetry-kube-stack/templates/NOTES.txt
@@ -10,24 +10,6 @@ OpenTelemetry Kubernetes Stack - Post-Installation Guide
 
 Release: {{ .Release.Name }} | Namespace: {{ .Release.Namespace }} | Version: {{ .Chart.Version }}
 
-{{- if not .Values.clusterName }}
-
-⚠️  WARNING: Cluster Name Not Set
-=============================================================================
-The 'clusterName' value is not configured. It is RECOMMENDED to set this
-value to identify your cluster in telemetry data.
-
-To update the cluster name:
-  helm upgrade {{ .Release.Name }} {{ .Chart.Name }} \
-    --set clusterName="your-cluster-name" \
-    --reuse-values
-
-Without a cluster name, the k8s.cluster.name attribute will be omitted
-from all telemetry data, which may make it difficult to distinguish
-metrics and traces from different clusters.
-
-{{- end }}
-
 =============================================================================
 📊 STATUS CHECK
 =============================================================================

--- a/charts/opentelemetry-kube-stack/templates/_config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_config.tpl
@@ -82,9 +82,7 @@ Generate Otel telemetry export
 {{- define "opentelemetry-kube-stack.otelTelemetry" -}}
 {{- include "opentelemetry-kube-stack.assertCollectorVersion" . -}}
 resource:
-  {{- if .Values.clusterName }}
-  k8s.cluster.name: {{ .Values.clusterName }}
-  {{- end}}
+  k8s.cluster.name: {{ include "opentelemetry-kube-stack.clusterName" . }}
   service.instance.id: ${POD_UID}
 {{- if include "opentelemetry-kube-stack.tsugaEnabled" . }}
 metrics:

--- a/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
@@ -88,18 +88,14 @@ processors:
       - key: service.instance.id
         value: ${POD_UID}
         action: upsert
-      {{- if .Values.clusterName }}
       - key: k8s.cluster.name
-        value: {{ .Values.clusterName }}
+        value: {{ include "opentelemetry-kube-stack.clusterName" . }}
         action: upsert
-      {{- end }}
-  {{- if .Values.clusterName }}
   resource:
     attributes:
       - key: k8s.cluster.name
-        value: {{ .Values.clusterName }}
+        value: {{ include "opentelemetry-kube-stack.clusterName" . }}
         action: upsert
-  {{- end }}
 exporters:
 {{- if ne (index .Values "tsuga" "enabledForClusterReceiver") false }}
   {{include "opentelemetry-kube-stack.tsugaExporters" . | nindent 2}}
@@ -116,9 +112,7 @@ service:
 {{- end }}
       processors:
         - memory_limiter
-        {{- if .Values.clusterName }}
         - resource
-        {{- end }}
         - k8s_attributes
         - batch
       exporters:
@@ -130,9 +124,7 @@ service:
         - k8s_cluster
       processors:
         - memory_limiter
-        {{- if .Values.clusterName }}
         - resource
-        {{- end }}
         - k8s_attributes
         - batch
       exporters:

--- a/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
@@ -149,18 +149,14 @@ processors:
       - key: service.instance.id
         value: ${POD_UID}
         action: upsert
-      {{- if .Values.clusterName }}
       - key: k8s.cluster.name
-        value: {{ .Values.clusterName }}
+        value: {{ include "opentelemetry-kube-stack.clusterName" . }}
         action: upsert
-      {{- end }}
-  {{- if .Values.clusterName }}
   resource:
     attributes:
       - key: k8s.cluster.name
-        value: {{ .Values.clusterName }}
+        value: {{ include "opentelemetry-kube-stack.clusterName" . }}
         action: upsert
-  {{- end }}
 exporters:
 {{- if ne (index .Values "tsuga" "enabledForDaemonset") false }}
   {{include "opentelemetry-kube-stack.tsugaExporters" . | nindent 2}}
@@ -188,9 +184,7 @@ service:
         - k8s_attributes
         - memory_limiter
         - batch
-        {{- if .Values.clusterName }}
         - resource
-        {{- end }}
       exporters:
         {{- if ne (index .Values "tsuga" "enabledForDaemonset") false }}
         - otlp_http/tsuga
@@ -205,9 +199,7 @@ service:
         - k8s_attributes
         - memory_limiter
         - cumulativetodelta
-        {{- if .Values.clusterName }}
         - resource
-        {{- end }}
         - batch
       exporters:
         {{- if ne (index .Values "tsuga" "enabledForDaemonset") false }}
@@ -222,9 +214,7 @@ service:
       processors:
         - k8s_attributes
         - memory_limiter
-        {{- if .Values.clusterName }}
         - resource
-        {{- end }}
         - batch
       receivers:
         - otlp

--- a/charts/opentelemetry-kube-stack/templates/_default-statefulset-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-statefulset-config.tpl
@@ -28,11 +28,9 @@ processors:
       - key: service.instance.id
         value: ${POD_UID}
         action: upsert
-      {{- if .Values.clusterName }}
       - key: k8s.cluster.name
-        value: {{ .Values.clusterName }}
+        value: {{ include "opentelemetry-kube-stack.clusterName" . }}
         action: upsert
-      {{- end }}
   k8s_attributes:
     extract:
       metadata:
@@ -91,13 +89,11 @@ processors:
           name: k8s.pod.uid
       - sources:
         - from: connection
-  {{- if .Values.clusterName }}
   resource:
     attributes:
       - key: k8s.cluster.name
-        value: {{ .Values.clusterName }}
+        value: {{ include "opentelemetry-kube-stack.clusterName" . }}
         action: upsert
-  {{- end }}
 exporters:
 {{- if ne (index .Values "tsuga" "enabledForStatefulset") false }}
   {{include "opentelemetry-kube-stack.tsugaExporters" . | nindent 2}}
@@ -113,9 +109,7 @@ service:
         - memory_limiter
         - cumulativetodelta
         - k8s_attributes
-        {{- if .Values.clusterName }}
         - resource
-        {{- end }}
         - batch
       exporters:
         {{- if ne (index .Values "tsuga" "enabledForStatefulset") false }}

--- a/charts/opentelemetry-kube-stack/templates/_helpers.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_helpers.tpl
@@ -111,6 +111,18 @@ Validate that required secret values are provided
 {{- end }}
 
 {{/*
+The cluster name, which is required.
+
+Telemetry from a cluster that does not name itself cannot be told apart from
+any other cluster's once it reaches Tsuga, and the omission only becomes
+visible during an incident. Resolved through `required` at each point of use
+so the failure happens at install time with one message.
+*/}}
+{{- define "opentelemetry-kube-stack.clusterName" -}}
+{{- required "clusterName is required: it identifies this cluster in telemetry. Set it with --set clusterName=<name> or in your values file." .Values.clusterName -}}
+{{- end }}
+
+{{/*
 Validate resource names to prevent conflicts and ensure Kubernetes compliance
 */}}
 {{- define "opentelemetry-kube-stack.validateResourceNames" -}}

--- a/charts/opentelemetry-kube-stack/tests/AUTO_INSTRUMENTATION_TESTING.md
+++ b/charts/opentelemetry-kube-stack/tests/AUTO_INSTRUMENTATION_TESTING.md
@@ -103,6 +103,7 @@ Install the chart with auto-instrumentation enabled:
 
 ```bash
 helm install otel-test . \
+  --set clusterName="<CLUSTER_NAME>" \
   --set autoInstrumentation.enabled=true \
   --set autoInstrumentation.spec.exporter.endpoint="http://otel-test-opentelemetry-kube-stack-agent:4317" \
   --set autoInstrumentation.spec.java.image="ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:latest" \
@@ -228,6 +229,7 @@ annotations:
 
 ```bash
 helm install otel-test . \
+  --set clusterName="<CLUSTER_NAME>" \
   --set autoInstrumentation.enabled=true \
   --set autoInstrumentation.spec.exporter.endpoint="http://custom-collector:4317" \
   --set autoInstrumentation.spec.propagators[0]=tracecontext \
@@ -243,6 +245,7 @@ helm install otel-test . \
 
 ```bash
 helm install otel-test . \
+  --set clusterName="<CLUSTER_NAME>" \
   --set autoInstrumentation.enabled=true \
   --set autoInstrumentation.spec.resource.addK8sUIDAttributes=true \
   --set "autoInstrumentation.spec.resource.resourceAttributes.service\.namespace=production" \
@@ -271,7 +274,7 @@ kubectl get instrumentation -o yaml
 
 ```bash
 # Disable auto-instrumentation
-helm upgrade otel-test . --set autoInstrumentation.enabled=false
+helm upgrade otel-test . --reuse-values --set autoInstrumentation.enabled=false
 
 # Verify Instrumentation resource is removed
 kubectl get instrumentation  # Should return empty

--- a/charts/opentelemetry-kube-stack/tests/README.md
+++ b/charts/opentelemetry-kube-stack/tests/README.md
@@ -153,7 +153,7 @@ helm unittest .
 
 # 5. Manual chart testing
 helm lint .
-helm template . --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" --set tsuga.apiKey="<TSUGA_API_KEY>"
+helm template . --set clusterName="<CLUSTER_NAME>" --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" --set tsuga.apiKey="<TSUGA_API_KEY>"
 ```
 
 ## Auto-Instrumentation Testing
@@ -179,7 +179,7 @@ This includes:
 
 ```bash
 # Debug template rendering
-helm template . --debug --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" --set tsuga.apiKey="<TSUGA_API_KEY>"
+helm template . --debug --set clusterName="<CLUSTER_NAME>" --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" --set tsuga.apiKey="<TSUGA_API_KEY>"
 
 # Check resource status
 kubectl get all -n <namespace>

--- a/charts/opentelemetry-kube-stack/tests/cluster-receiver_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/cluster-receiver_test.yaml
@@ -5,6 +5,7 @@ templates:
 tests:
   - it: should create deployment with default values
     set:
+      clusterName: "test-cluster"
       cluster.enabled: true
       serviceAccount.create: true
       serviceAccount.name: ""
@@ -21,6 +22,7 @@ tests:
 
   - it: should not include tsuga exporter when enabledForClusterReceiver is false
     set:
+      clusterName: "test-cluster"
       cluster.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -36,6 +38,7 @@ tests:
 
   - it: should collect k8s objects by default
     set:
+      clusterName: "test-cluster"
       cluster.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -52,6 +55,7 @@ tests:
 
   - it: should not collect k8s objects when disabled
     set:
+      clusterName: "test-cluster"
       cluster.enabled: true
       cluster.collectk8sobjects: false
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
@@ -69,6 +73,7 @@ tests:
 
   - it: should guard logs and metrics pipelines with memory_limiter first
     set:
+      clusterName: "test-cluster"
       cluster.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -85,3 +90,14 @@ tests:
       - equal:
           path: spec.config.service.pipelines.metrics.processors[0]
           value: memory_limiter
+
+  - it: should fail to render when clusterName is not set
+    set:
+      cluster.enabled: true
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - failedTemplate:
+          errorMessage: "clusterName is required: it identifies this cluster in telemetry. Set it with --set clusterName=<name> or in your values file."

--- a/charts/opentelemetry-kube-stack/tests/daemonset_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/daemonset_test.yaml
@@ -5,6 +5,7 @@ templates:
 tests:
   - it: should create daemonset with default values
     set:
+      clusterName: "test-cluster"
       agent.enabled: true
       agent.hostNetwork: true
       serviceAccount.create: true
@@ -25,6 +26,7 @@ tests:
 
   - it: should not include tsuga exporter when enabledForDaemonset is false
     set:
+      clusterName: "test-cluster"
       agent.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -40,6 +42,7 @@ tests:
 
   - it: should configure spanmetrics with low-cardinality HTTP dimensions by default
     set:
+      clusterName: "test-cluster"
       agent.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -65,6 +68,7 @@ tests:
 
   - it: should not reference the Tsuga secret when the exporter is disabled everywhere
     set:
+      clusterName: "test-cluster"
       agent.enabled: true
       tsuga.enabledForClusterReceiver: false
       tsuga.enabledForDaemonset: false
@@ -95,3 +99,14 @@ tests:
       # Internal-telemetry OTLP export (which needs the secret) is skipped.
       - notExists:
           path: spec.config.service.telemetry.metrics
+
+  - it: should fail to render when clusterName is not set
+    set:
+      agent.enabled: true
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - failedTemplate:
+          errorMessage: "clusterName is required: it identifies this cluster in telemetry. Set it with --set clusterName=<name> or in your values file."

--- a/charts/opentelemetry-kube-stack/tests/instrumentation_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/instrumentation_test.yaml
@@ -5,6 +5,7 @@ templates:
 tests:
   - it: should not create instrumentation resource when disabled
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: false
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -16,6 +17,7 @@ tests:
 
   - it: should create instrumentation resource when enabled with minimal config
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -42,6 +44,7 @@ tests:
 
   - it: should use custom apiVersion when specified
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: true
       autoInstrumentation.apiVersion: "opentelemetry.io/v1beta1"
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
@@ -55,6 +58,7 @@ tests:
 
   - it: should use custom name when nameOverride is set
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: true
       autoInstrumentation.nameOverride: "my-custom-instrumentation"
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
@@ -68,6 +72,7 @@ tests:
 
   - it: should include custom labels
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: true
       autoInstrumentation.labels:
         environment: "production"
@@ -86,6 +91,7 @@ tests:
 
   - it: should include custom annotations
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: true
       autoInstrumentation.annotations:
         description: "Auto-instrumentation for production cluster"
@@ -104,6 +110,7 @@ tests:
 
   - it: should pass through spec configuration for Java
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: true
       autoInstrumentation.spec:
         exporter:
@@ -141,6 +148,7 @@ tests:
 
   - it: should pass through spec configuration for multiple languages
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: true
       autoInstrumentation.spec:
         exporter:
@@ -184,6 +192,7 @@ tests:
 
   - it: should include component labels
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -202,6 +211,7 @@ tests:
 
   - it: should truncate name to 63 characters for long release names
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -217,6 +227,7 @@ tests:
 
   - it: should pass through resource attributes
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: true
       autoInstrumentation.spec:
         resource:
@@ -241,6 +252,7 @@ tests:
 
   - it: should work with custom environment variables in spec
     set:
+      clusterName: "test-cluster"
       autoInstrumentation.enabled: true
       autoInstrumentation.spec:
         env:

--- a/charts/opentelemetry-kube-stack/tests/integration/test-auto-instrumentation.sh
+++ b/charts/opentelemetry-kube-stack/tests/integration/test-auto-instrumentation.sh
@@ -103,6 +103,7 @@ install_chart() {
     
     helm upgrade --install "$RELEASE_NAME" "$CHART_DIR" \
         --namespace "$TEST_NAMESPACE" \
+        --set clusterName="$RELEASE_NAME" \
         --set autoInstrumentation.enabled=true \
         --set autoInstrumentation.spec.exporter.endpoint="http://localhost:4317" \
         --set autoInstrumentation.spec.propagators[0]=tracecontext \
@@ -318,6 +319,7 @@ test_chart_upgrade() {
     
     helm upgrade "$RELEASE_NAME" "$CHART_DIR" \
         --namespace "$TEST_NAMESPACE" \
+        --set clusterName="$RELEASE_NAME" \
         --set autoInstrumentation.enabled=true \
         --set autoInstrumentation.spec.exporter.endpoint="http://modified-endpoint:4317" \
         --set autoInstrumentation.spec.propagators[0]=tracecontext \
@@ -355,6 +357,7 @@ test_disable_instrumentation() {
     
     helm upgrade "$RELEASE_NAME" "$CHART_DIR" \
         --namespace "$TEST_NAMESPACE" \
+        --set clusterName="$RELEASE_NAME" \
         --set autoInstrumentation.enabled=false \
         --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
         --set tsuga.apiKey="<TSUGA_API_KEY>" \

--- a/charts/opentelemetry-kube-stack/tests/integration/test-deployment.sh
+++ b/charts/opentelemetry-kube-stack/tests/integration/test-deployment.sh
@@ -26,6 +26,7 @@ kubectl create namespace "$NAMESPACE"
 echo "Test 1: Deploying with minimal configuration..."
 helm install "$RELEASE_NAME" "$CHART_PATH" \
     -n "$NAMESPACE" \
+    --set clusterName="$RELEASE_NAME" \
     --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
     --set tsuga.apiKey="<TSUGA_API_KEY>" \
     --wait --timeout=300s
@@ -43,6 +44,7 @@ kubectl get deployment -n "$NAMESPACE" | grep opentelemetry-kube-stack
 echo "Test 2: Testing upgrade..."
 helm upgrade "$RELEASE_NAME" "$CHART_PATH" \
     -n "$NAMESPACE" \
+    --set clusterName="$RELEASE_NAME" \
     --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
     --set tsuga.apiKey="<TSUGA_API_KEY>" \
     --set resources.limits.memory="1Gi" \
@@ -64,6 +66,7 @@ kubectl create secret generic existing-otel-secret \
 
 helm install "$RELEASE_NAME" "$CHART_PATH" \
     -n "$NAMESPACE" \
+    --set clusterName="$RELEASE_NAME" \
     --set secret.existing.enabled=true \
     --set secret.existing.name="existing-otel-secret" \
     --wait --timeout=300s

--- a/charts/opentelemetry-kube-stack/tests/rbac_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/rbac_test.yaml
@@ -5,6 +5,7 @@ templates:
 tests:
   - it: should create cluster role and role binding
     set:
+      clusterName: "test-cluster"
       rbac.create: true
       serviceAccount.create: true
       serviceAccount.name: ""
@@ -16,6 +17,7 @@ tests:
 
   - it: should not include monitoring.coreos.com rules by default
     set:
+      clusterName: "test-cluster"
       rbac.create: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -30,6 +32,7 @@ tests:
 
   - it: should include monitoring.coreos.com rules when prometheusCR enabled
     set:
+      clusterName: "test-cluster"
       rbac.create: true
       targetAllocator.enabled: true
       targetAllocator.spec.prometheusCR.enabled: true
@@ -48,6 +51,7 @@ tests:
 
   - it: should not include endpointslices permission by default
     set:
+      clusterName: "test-cluster"
       rbac.create: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -62,6 +66,7 @@ tests:
 
   - it: should include endpointslices permission when targetAllocator enabled
     set:
+      clusterName: "test-cluster"
       rbac.create: true
       targetAllocator.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"

--- a/charts/opentelemetry-kube-stack/tests/secret_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/secret_test.yaml
@@ -5,6 +5,7 @@ templates:
 tests:
   - it: should create secret with default values
     set:
+      clusterName: "test-cluster"
       secret.create: true
       secret.name: "otel-secret"
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"

--- a/charts/opentelemetry-kube-stack/tests/security/security-scan.sh
+++ b/charts/opentelemetry-kube-stack/tests/security/security-scan.sh
@@ -25,12 +25,14 @@ kubectl create namespace "$NAMESPACE"
 # Deploy chart for security scanning
 helm install "$RELEASE_NAME" "$CHART_PATH" \
     -n "$NAMESPACE" \
+    --set clusterName="$RELEASE_NAME" \
     --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
     --set tsuga.apiKey="<TSUGA_API_KEY>" \
     --wait --timeout=300s
 
 # Get rendered manifests
 helm template "$RELEASE_NAME" "$CHART_PATH" \
+    --set clusterName="$RELEASE_NAME" \
     --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
     --set tsuga.apiKey="<TSUGA_API_KEY>" > /tmp/otel-manifests.yaml
 

--- a/charts/opentelemetry-kube-stack/tests/serviceaccount_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/serviceaccount_test.yaml
@@ -5,6 +5,7 @@ templates:
 tests:
   - it: should create service account with default values
     set:
+      clusterName: "test-cluster"
       serviceAccount.create: true
       serviceAccount.name: ""
     release:

--- a/charts/opentelemetry-kube-stack/tests/statefulset_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/statefulset_test.yaml
@@ -5,6 +5,7 @@ templates:
 tests:
   - it: should not render when targetAllocator disabled
     set:
+      clusterName: "test-cluster"
       targetAllocator.enabled: false
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -16,6 +17,7 @@ tests:
 
   - it: should create statefulset collector when targetAllocator enabled
     set:
+      clusterName: "test-cluster"
       targetAllocator.enabled: true
       serviceAccount.create: true
       serviceAccount.name: ""
@@ -38,6 +40,7 @@ tests:
 
   - it: should not set serviceAccount when serviceAccount.create is false
     set:
+      clusterName: "test-cluster"
       targetAllocator.enabled: true
       serviceAccount.create: false
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
@@ -52,6 +55,7 @@ tests:
 
   - it: should use custom replicas when specified
     set:
+      clusterName: "test-cluster"
       targetAllocator.enabled: true
       statefulset.replicas: 3
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
@@ -65,6 +69,7 @@ tests:
 
   - it: should not include tsuga exporter when enabledForStatefulset is false
     set:
+      clusterName: "test-cluster"
       targetAllocator.enabled: true
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -77,3 +82,29 @@ tests:
       - equal:
           path: spec.config.service.pipelines.metrics.exporters
           value: []
+
+  - it: should convert cumulative metrics to delta before export
+    set:
+      clusterName: "test-cluster"
+      targetAllocator.enabled: true
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - isNotNull:
+          path: spec.config.processors.cumulativetodelta
+      - equal:
+          path: spec.config.service.pipelines.metrics.processors
+          value: [memory_limiter, cumulativetodelta, k8s_attributes, resource, batch]
+
+  - it: should fail to render when clusterName is not set
+    set:
+      targetAllocator.enabled: true
+      tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
+      tsuga.apiKey: "<TSUGA_API_KEY>"
+    release:
+      name: "test-release"
+    asserts:
+      - failedTemplate:
+          errorMessage: "clusterName is required: it identifies this cluster in telemetry. Set it with --set clusterName=<name> or in your values file."

--- a/charts/opentelemetry-kube-stack/tests/target-allocator_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/target-allocator_test.yaml
@@ -5,6 +5,7 @@ templates:
 tests:
   - it: should not render when targetAllocator disabled
     set:
+      clusterName: "test-cluster"
       targetAllocator.enabled: false
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
       tsuga.apiKey: "<TSUGA_API_KEY>"
@@ -16,6 +17,7 @@ tests:
 
   - it: should create TargetAllocator CR when enabled
     set:
+      clusterName: "test-cluster"
       targetAllocator.enabled: true
       targetAllocator.spec.allocationStrategy: "consistent-hashing"
       serviceAccount.create: true
@@ -36,6 +38,7 @@ tests:
 
   - it: should not set serviceAccount when serviceAccount.create is false
     set:
+      clusterName: "test-cluster"
       targetAllocator.enabled: true
       serviceAccount.create: false
       tsuga.otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"
@@ -50,6 +53,7 @@ tests:
 
   - it: should set prometheusCR fields when enabled
     set:
+      clusterName: "test-cluster"
       targetAllocator.enabled: true
       targetAllocator.spec.prometheusCR.enabled: true
       targetAllocator.spec.prometheusCR.serviceMonitorSelector.matchLabels.release: "test"

--- a/charts/opentelemetry-kube-stack/tests/values/agent-only.yaml
+++ b/charts/opentelemetry-kube-stack/tests/values/agent-only.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 # Agent-only configuration
 tsuga:
   otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"

--- a/charts/opentelemetry-kube-stack/tests/values/auto-instrumentation.yaml
+++ b/charts/opentelemetry-kube-stack/tests/values/auto-instrumentation.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 # Test values file for auto-instrumentation feature
 # This file configures the chart to enable OpenTelemetry auto-instrumentation
 # Use with: helm install my-release . -f tests/values/auto-instrumentation.yaml

--- a/charts/opentelemetry-kube-stack/tests/values/cluster-only.yaml
+++ b/charts/opentelemetry-kube-stack/tests/values/cluster-only.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 # Cluster receiver only configuration
 tsuga:
   otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"

--- a/charts/opentelemetry-kube-stack/tests/values/existing-secret.yaml
+++ b/charts/opentelemetry-kube-stack/tests/values/existing-secret.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 # Configuration using existing secret
 tsuga:
   otlpEndpoint: ""

--- a/charts/opentelemetry-kube-stack/tests/values/minimal.yaml
+++ b/charts/opentelemetry-kube-stack/tests/values/minimal.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 # Minimal configuration for testing
 tsuga:
   otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"

--- a/charts/opentelemetry-kube-stack/tests/values/production.yaml
+++ b/charts/opentelemetry-kube-stack/tests/values/production.yaml
@@ -1,4 +1,5 @@
 ---
+clusterName: test-cluster
 # Production configuration with resource limits and security
 tsuga:
   otlpEndpoint: "https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp"

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -15,11 +15,13 @@
 #
 # Option 1: Generate new secret (default)
 # helm install my-otel-stack ./charts/opentelemetry-kube-stack \
+#   --set clusterName="<CLUSTER_NAME>" \
 #   --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" \
 #   --set tsuga.apiKey="<TSUGA_API_KEY>"
 #
 # Option 2: Use existing secret
 # helm install my-otel-stack ./charts/opentelemetry-kube-stack \
+#   --set clusterName="<CLUSTER_NAME>" \
 #   --set secret.create=false \
 #   --set secret.name="my-existing-secret" \
 #   --set secret.keyMapping.TSUGA_API_KEY="<API_KEY_SECRET_KEY>" \

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -58,11 +58,17 @@
 # GLOBAL CONFIGURATION
 # =============================================================================
 
-# -- The name of the cluster to be used in the resource attributes
-# This value is added to all telemetry data as k8s.cluster.name
-# RECOMMENDED: Set this value to identify your cluster in telemetry data
-# If not set, the k8s.cluster.name attribute will be omitted from telemetry
-# @default -- ""
+# -- REQUIRED. The name of the cluster, added to all telemetry as
+# k8s.cluster.name.
+#
+# Installation fails if this is empty. Telemetry from a cluster that does not
+# name itself cannot be told apart from any other cluster's once it reaches
+# Tsuga, and the omission only becomes visible during an incident, which is
+# the worst time to discover it.
+#
+#   --set clusterName=<name>
+#
+# @default -- "" (must be set)
 clusterName: ""
 
 # -- Override the chart name used in resource naming


### PR DESCRIPTION
⚠️ **Breaking:** installs and upgrades now fail if `clusterName` is empty.

`clusterName` shipped empty while `values.yaml` called it RECOMMENDED, and `NOTES.txt` has been warning about it for several releases. Telemetry from a cluster that never named itself can't be told apart from any other cluster's in Tsuga, and you find out during an incident.

Enforced with `required` at each point of use, so it fails at install time naming the flag to set:

```
Error: execution error at (opentelemetry-kube-stack/templates/daemonset.yaml:6:16):
clusterName is required: it identifies this cluster in telemetry.
Set it with --set clusterName=<name> or in your values file.
```

## Migration

Add `--set clusterName=<name>`, or set `clusterName` in your values file.

The failure is safe: Helm renders before it touches the cluster, so a failed upgrade leaves the existing release running untouched. Two things worth knowing:

- `--reuse-values` does **not** rescue a release that never set it — the stored value is the empty string, which still fails. You have to pass the flag.
- `deploy.sh` now suggests `--reuse-values` on upgrade, so a release that *did* set it keeps it.

## What it simplifies

Making it mandatory removes the reason it was ever optional, so **thirteen `{{- if .Values.clusterName }}` conditionals across four templates collapse**: the cluster receiver and statefulset always define their `resource` processor and always reference it, the agent always stamps the attribute, internal telemetry always carries it. The `NOTES.txt` warning is unreachable and dropped.