### PR TITLE
fix(kube-stack): raise the collector version floor to 0.152.0

### DIFF
--- a/charts/opentelemetry-kube-stack/CHANGELOG.md
+++ b/charts/opentelemetry-kube-stack/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [opentelemetry-kube-stack-0.10.2] - 2026-07-28
+
+### Fixed
+- Raise the collector version floor to 0.152.0, the version the configured component names require
+
 ## [opentelemetry-kube-stack-0.10.1] - 2026-07-27
 
 ### Added

--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.1
+version: 0.10.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-kube-stack
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
+![Version: 0.10.2](https://img.shields.io/badge/Version-0.10.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
 
 A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet + cluster receiver), secure credential management, and production-ready configurations for telemetry collection to Tsuga platform.
 

--- a/charts/opentelemetry-kube-stack/templates/_config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_config.tpl
@@ -58,8 +58,10 @@ otlp_http/tsuga:
 {{- end }}
 
 {{/*
-Fail the render if a pinned collector image is older than v0.119.0, where the
-service::telemetry headers schema switched from map to list. Only images with a
+Fail the render if a pinned collector image is older than v0.152.0, the release
+that renamed the kubeletstats receiver to kubelet_stats — the newest component
+name the default configs use. An older collector rejects the config at startup
+with `unknown type: "kubelet_stats"` and crash-loops. Only images with a
 parseable semver tag can be checked; untagged/":latest"/operator-default images
 resolve at runtime and cannot be verified here.
 */}}
@@ -68,8 +70,8 @@ resolve at runtime and cannot be verified here.
 {{- if . -}}
 {{- $tag := trimPrefix "v" (. | toString | splitList ":" | last) -}}
 {{- if regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+" $tag -}}
-{{- if semverCompare "< 0.119.0" $tag -}}
-{{- fail (printf "collector image %q is < v0.119.0; service::telemetry headers require the v0.119+ config schema (list-form headers)" .) -}}
+{{- if semverCompare "< 0.152.0" $tag -}}
+{{- fail (printf "collector image %q is < v0.152.0; this chart's default config uses the kubelet_stats receiver type, which older collectors reject with `unknown type`. Pin a v0.152.0+ image." .) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
`assertCollectorVersion` still guarded v0.119.0, the release where the `service::telemetry` headers schema switched from map to list. The default configs have moved well past that, and the newest component name they use sets the real floor: `kubeletstats` was renamed to `kubelet_stats` in v0.152.0. Below that the collector rejects the config with `unknown type` and crash-loops, so the guard was passing images that cannot run this chart.

The other names in use are older — `k8s_attributes` v0.146.0, `file_log` v0.149.0, `host_metrics` and `span_metrics` v0.151.0 — so 0.152.0 covers them all.

**Deliberately no higher.** 0.152.0 is both what this config requires and what the operator subchart this chart bundles supplies by default, so the floor never declares a minimum a default install does not meet. Only user-pinned images with a parseable semver tag are checked; an untagged reference or the operator-supplied default resolves at runtime and cannot be verified at render time.