### PR TITLE
fix(kube-stack): drop zero-valued replicaset metrics

### DIFF
--- a/charts/opentelemetry-kube-stack/CHANGELOG.md
+++ b/charts/opentelemetry-kube-stack/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [opentelemetry-kube-stack-0.10.9] - 2026-07-28
+
+### Fixed
+- Drop permanently-zero replicaset metrics from historical ReplicaSets
+
 ## [opentelemetry-kube-stack-0.10.8] - 2026-07-28
 
 ### Added

--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.8
+version: 0.10.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-kube-stack
 
-![Version: 0.10.8](https://img.shields.io/badge/Version-0.10.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
+![Version: 0.10.9](https://img.shields.io/badge/Version-0.10.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
 
 A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet + cluster receiver), secure credential management, and production-ready configurations for telemetry collection to Tsuga platform.
 

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
@@ -44,7 +44,6 @@ spec:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
   resources:
     limits:
       cpu: 500m

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
@@ -44,6 +44,7 @@ spec:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
   resources:
     limits:
       cpu: 500m
@@ -127,6 +128,11 @@ spec:
       batch:
         send_batch_max_size: 5000
         send_batch_size: 5000
+      filter/empty_replicasets:
+        error_mode: ignore
+        metric_conditions:
+        - (metric.name == "k8s.replicaset.available" or metric.name == "k8s.replicaset.desired")
+          and datapoint.value_int == 0
       k8s_attributes:
         extract:
           annotations:
@@ -232,6 +238,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - filter/empty_replicasets
           - k8s_attributes
           - resource
           - batch

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
@@ -44,7 +44,6 @@ spec:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
   resources:
     limits:
       cpu: 500m

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
@@ -44,6 +44,7 @@ spec:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
   resources:
     limits:
       cpu: 500m
@@ -127,6 +128,11 @@ spec:
       batch:
         send_batch_max_size: 5000
         send_batch_size: 5000
+      filter/empty_replicasets:
+        error_mode: ignore
+        metric_conditions:
+        - (metric.name == "k8s.replicaset.available" or metric.name == "k8s.replicaset.desired")
+          and datapoint.value_int == 0
       k8s_attributes:
         extract:
           annotations:
@@ -232,6 +238,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - filter/empty_replicasets
           - k8s_attributes
           - resource
           - batch

--- a/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
@@ -44,7 +44,6 @@ spec:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
   resources:
     limits:
       cpu: 500m

--- a/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
@@ -44,6 +44,7 @@ spec:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
   resources:
     limits:
       cpu: 500m
@@ -127,6 +128,11 @@ spec:
       batch:
         send_batch_max_size: 5000
         send_batch_size: 5000
+      filter/empty_replicasets:
+        error_mode: ignore
+        metric_conditions:
+        - (metric.name == "k8s.replicaset.available" or metric.name == "k8s.replicaset.desired")
+          and datapoint.value_int == 0
       k8s_attributes:
         extract:
           annotations:
@@ -232,6 +238,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - filter/empty_replicasets
           - k8s_attributes
           - resource
           - batch

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
@@ -44,7 +44,6 @@ spec:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
   resources:
     limits:
       cpu: 500m

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
@@ -44,6 +44,7 @@ spec:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
   resources:
     limits:
       cpu: 500m
@@ -127,6 +128,11 @@ spec:
       batch:
         send_batch_max_size: 5000
         send_batch_size: 5000
+      filter/empty_replicasets:
+        error_mode: ignore
+        metric_conditions:
+        - (metric.name == "k8s.replicaset.available" or metric.name == "k8s.replicaset.desired")
+          and datapoint.value_int == 0
       k8s_attributes:
         extract:
           annotations:
@@ -232,6 +238,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - filter/empty_replicasets
           - k8s_attributes
           - resource
           - batch

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
@@ -44,7 +44,6 @@ spec:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
   resources:
     limits:
       cpu: 500m

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
@@ -44,6 +44,7 @@ spec:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
   resources:
     limits:
       cpu: 500m
@@ -127,6 +128,11 @@ spec:
       batch:
         send_batch_max_size: 5000
         send_batch_size: 5000
+      filter/empty_replicasets:
+        error_mode: ignore
+        metric_conditions:
+        - (metric.name == "k8s.replicaset.available" or metric.name == "k8s.replicaset.desired")
+          and datapoint.value_int == 0
       k8s_attributes:
         extract:
           annotations:
@@ -232,6 +238,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - filter/empty_replicasets
           - k8s_attributes
           - resource
           - batch

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
@@ -44,7 +44,6 @@ spec:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
   resources:
     limits:
       cpu: 500m

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
@@ -44,6 +44,7 @@ spec:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
   resources:
     limits:
       cpu: 500m
@@ -127,6 +128,11 @@ spec:
       batch:
         send_batch_max_size: 5000
         send_batch_size: 5000
+      filter/empty_replicasets:
+        error_mode: ignore
+        metric_conditions:
+        - (metric.name == "k8s.replicaset.available" or metric.name == "k8s.replicaset.desired")
+          and datapoint.value_int == 0
       k8s_attributes:
         extract:
           annotations:
@@ -232,6 +238,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - filter/empty_replicasets
           - k8s_attributes
           - resource
           - batch

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
@@ -44,7 +44,6 @@ spec:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
   resources:
     limits:
       cpu: 500m

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
@@ -44,6 +44,7 @@ spec:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
   resources:
     limits:
       cpu: 500m
@@ -127,6 +128,11 @@ spec:
       batch:
         send_batch_max_size: 5000
         send_batch_size: 5000
+      filter/empty_replicasets:
+        error_mode: ignore
+        metric_conditions:
+        - (metric.name == "k8s.replicaset.available" or metric.name == "k8s.replicaset.desired")
+          and datapoint.value_int == 0
       k8s_attributes:
         extract:
           annotations:
@@ -232,6 +238,7 @@ spec:
           - otlp_http/tsuga
           processors:
           - memory_limiter
+          - filter/empty_replicasets
           - k8s_attributes
           - resource
           - batch

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
@@ -44,7 +44,6 @@ spec:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
   resources:
     limits:
       cpu: 500m

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
@@ -44,6 +44,7 @@ spec:
     rollingUpdate:
       maxSurge: 0
       maxUnavailable: 1
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
   resources:
     limits:
       cpu: 500m
@@ -117,6 +118,11 @@ spec:
       batch:
         send_batch_max_size: 5000
         send_batch_size: 5000
+      filter/empty_replicasets:
+        error_mode: ignore
+        metric_conditions:
+        - (metric.name == "k8s.replicaset.available" or metric.name == "k8s.replicaset.desired")
+          and datapoint.value_int == 0
       k8s_attributes:
         extract:
           annotations:
@@ -216,6 +222,7 @@ spec:
           - debug
           processors:
           - memory_limiter
+          - filter/empty_replicasets
           - k8s_attributes
           - resource
           - batch

--- a/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
@@ -95,6 +95,26 @@ processors:
       - set(log.severity_text, "WARN")
       - set(log.severity_number, SEVERITY_NUMBER_WARN)
 {{- end }}
+  # Kubernetes keeps 10 historical ReplicaSets per Deployment by default, and
+  # k8s_cluster emits both of these for every ReplicaSet object in its informer
+  # cache, guarded only on spec.replicas being non-nil. Old revisions are scaled
+  # to zero, so most of these series are permanent zeros that say nothing.
+  #
+  # value_int, not value_double: both metrics are Gauge/Int. Reading
+  # value_double on an integer datapoint does not error, it returns 0.0, so a
+  # condition written that way would match every integer datapoint and drop far
+  # more than intended.
+  #
+  # metric_conditions rather than the older metrics.datapoint form, which is
+  # deprecated at this chart's floor. error_mode: ignore because the default,
+  # propagate, drops the whole payload when a condition errors.
+  #
+  # When every datapoint of a metric is dropped the metric goes with it, so no
+  # empty shells are exported.
+  filter/empty_replicasets:
+    error_mode: ignore
+    metric_conditions:
+      - (metric.name == "k8s.replicaset.available" or metric.name == "k8s.replicaset.desired") and datapoint.value_int == 0
   k8s_attributes:
     extract:
 {{- include "opentelemetry-kube-stack.k8sAttributesExtract" (dict "root" . "extraLabelMapping" .Values.cluster.extraLabelMapping "extraAnnotationsMapping" .Values.cluster.extraAnnotationsMapping) | nindent 6 }}
@@ -168,6 +188,7 @@ service:
         - k8s_cluster
       processors:
         - memory_limiter
+        - filter/empty_replicasets
 {{- if .Values.resourceDetection.enabled }}
         - resourcedetection
 {{- end }}

--- a/charts/opentelemetry-kube-stack/tests/cluster-receiver_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/cluster-receiver_test.yaml
@@ -122,7 +122,7 @@ tests:
           value: [memory_limiter, k8s_attributes, resource, batch]
       - equal:
           path: spec.config.service.pipelines.metrics.processors
-          value: [memory_limiter, k8s_attributes, resource, batch]
+          value: [memory_limiter, filter/empty_replicasets, k8s_attributes, resource, batch]
 
   - it: should fail to render when clusterName is not set
     set:
@@ -225,7 +225,7 @@ tests:
       # clusterName afterwards, so the explicit value stays authoritative.
       - equal:
           path: spec.config.service.pipelines.metrics.processors
-          value: [memory_limiter, resourcedetection, k8s_attributes, resource, batch]
+          value: [memory_limiter, filter/empty_replicasets, resourcedetection, k8s_attributes, resource, batch]
 
   - it: should collect only Warning events, filtered at the API server
     set:
@@ -329,3 +329,26 @@ tests:
       - equal:
           path: spec.config.service.pipelines["logs/events"].processors
           value: [memory_limiter, resourcedetection, transform/k8s_event_severity, resource, batch]
+  - it: should drop zero-valued replicaset metrics
+    set:
+      clusterName: "test-cluster"
+      cluster.enabled: true
+    release:
+      name: "test-release"
+    asserts:
+      # value_int because both metrics are Gauge/Int. value_double on an int
+      # datapoint returns 0.0 rather than erroring, so it would match every
+      # integer datapoint.
+      - equal:
+          path: spec.config.processors["filter/empty_replicasets"].metric_conditions
+          value:
+            - (metric.name == "k8s.replicaset.available" or metric.name == "k8s.replicaset.desired") and datapoint.value_int == 0
+      # propagate, the default, would drop the whole payload on a condition
+      # error.
+      - equal:
+          path: spec.config.processors["filter/empty_replicasets"].error_mode
+          value: ignore
+      # Early, so the drop happens before enrichment does work on them.
+      - equal:
+          path: spec.config.service.pipelines.metrics.processors
+          value: [memory_limiter, filter/empty_replicasets, k8s_attributes, resource, batch]


### PR DESCRIPTION
Kubernetes keeps 10 historical ReplicaSets per Deployment by default, and `k8s_cluster` emits `k8s.replicaset.available` and `k8s.replicaset.desired` for every ReplicaSet in its informer cache, guarded only on `spec.replicas` being non-nil. Old revisions are scaled to zero, so most of these series are permanent zeros.

**`value_int`, not `value_double`.** Both metrics are Gauge/Int. Reading `value_double` on an integer datapoint does not error — it returns `0.0` — so the condition written that way would have matched every integer datapoint in the pipeline and dropped far more than intended.

`metric_conditions` rather than the older `metrics.datapoint` form, which is deprecated at our floor, and `error_mode: ignore` because the default of `propagate` drops the entire payload when a condition errors. Placed directly after `memory_limiter` so the drop happens before enrichment spends work on datapoints it is about to discard.

**Verified:** metric names, instrument type and default-enabled status read from `k8sclusterreceiver/documentation.md`; the emit-for-every-ReplicaSet behaviour read from `replicasets.go`; `metric_conditions` confirmed present at our floor with the `datapoint.` prefix; the `value_double` zero-return read from the OTTL datapoint context. Dropping all datapoints of a metric drops the metric too, so no empty shells are exported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)