### PR TITLE
fix(kube-stack): correct the collector internal-telemetry notes

### DIFF
--- a/charts/opentelemetry-kube-stack/CHANGELOG.md
+++ b/charts/opentelemetry-kube-stack/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [opentelemetry-kube-stack-0.10.10] - 2026-07-28
+
+### Fixed
+- Correct the internal-metrics design notes: the operator preserves the chart's OTLP reader
+
 ## [opentelemetry-kube-stack-0.10.9] - 2026-07-28
 
 ### Fixed

--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.9
+version: 0.10.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-kube-stack
 
-![Version: 0.10.9](https://img.shields.io/badge/Version-0.10.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
+![Version: 0.10.10](https://img.shields.io/badge/Version-0.10.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
 
 A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet + cluster receiver), secure credential management, and production-ready configurations for telemetry collection to Tsuga platform.
 

--- a/charts/opentelemetry-kube-stack/docs/collector-internal-metrics.md
+++ b/charts/opentelemetry-kube-stack/docs/collector-internal-metrics.md
@@ -1,69 +1,117 @@
 # Collector Internal Metrics: Design Notes
 
-## Problem
+## Summary
 
-The OpenTelemetry Operator permanently overrides `service.telemetry.metrics` in every collector
-ConfigMap it manages. No matter what the `OpenTelemetryCollector` CR specifies under
-`spec.config.service.telemetry.metrics`, the operator's mutating webhook replaces it with a
-Prometheus pull reader on port 8888 before the ConfigMap is written to Kubernetes.
+The chart configures the collector's own metrics to be pushed to Tsuga over OTLP through
+`service::telemetry.metrics.readers`, and the OpenTelemetry Operator preserves that
+configuration. Earlier versions of this document claimed the operator overrode it. That was
+wrong, and the sections below record what the operator actually does, so the claim is not
+reintroduced.
 
-This means the intended OTLP-push path — configuring a `periodic` reader with an `otlp` exporter
-in the CR — is silently discarded at deploy time. Relevant upstream history:
+## What the operator does with `service::telemetry`
 
-- [#3730](https://github.com/open-telemetry/opentelemetry-operator/issues/3730) — operator ignores
-  user-configured readers and falls back to the deprecated `address` field; supposedly fixed by
-  [PR #3874](https://github.com/open-telemetry/opentelemetry-operator/pull/3874)
-- [#3913](https://github.com/open-telemetry/opentelemetry-operator/issues/3913) — PR #3874
-  introduced a regression where the intermediate Go type dropped all non-metrics telemetry fields
-  (e.g. `logs.level`)
-- [PR #3915](https://github.com/open-telemetry/opentelemetry-operator/pull/3915) (merged April 16,
-  2025, first shipped in v0.149.0) — replaces the overwrite with `mergo.Merge` to preserve
-  user-specified telemetry fields
+The operator only supplies its own metrics reader when the user has configured none. From
+`internal/otelconfig/config.go` at operator v0.152.0, the version this chart bundles via
+opentelemetry-operator helm chart 0.114.1:
 
-PR #3915 is included in the operator version this chart bundles (v0.152.0 via helm chart 0.114.1)
-and does fix the orthogonal regression from #3913 (non-metrics fields like `logs.level` are now
-preserved). However, **the metrics readers are still forced by the operator** — even with the fix,
-the webhook replaces `service.telemetry.metrics.readers` with its own prometheus pull reader on
-port 8888, discarding any user-configured periodic/OTLP reader. This was confirmed by inspecting
-the live ConfigMap after deployment with operator v0.152.0.
+```go
+if tel.Metrics.Address != "" || len(tel.Metrics.Readers) != 0 {
+    // The user already set the address or the readers, so we don't need to do anything
+    logger.V(1).Info("telemetry configuration already provided by user, skipping defaults", ...)
+    return events, nil
+}
+```
 
-## Current approach: `service::telemetry`
+Only when `readers` is empty does it add a Prometheus pull reader on port 8888, and it merges
+that with `mergo.Merge` without `WithOverride`, so it does not clobber neighbouring fields
+either. The same function runs from both call sites that matter — the defaulting webhook
+(`internal/webhook/collector_webhook.go`) and the ConfigMap builder
+(`internal/manifests/collector/configmap.go`) — so the CR and the rendered ConfigMap agree.
 
-There is no self-scrape pipeline. Internal telemetry is configured through `service::telemetry`
-alone, rendered by the `opentelemetry-kube-stack.otelTelemetry` helper in `templates/_config.tpl`
-and included by all three default configs (`_default-deamonset-config.tpl`,
-`_default-statefulset-config.tpl`, `_default-cluster-receiver-config.tpl`).
+This behaviour comes from [PR #3915](https://github.com/open-telemetry/opentelemetry-operator/pull/3915),
+which replaced an unconditional overwrite with a merge. Relevant history:
 
-The helper emits two things:
+- [#3730](https://github.com/open-telemetry/opentelemetry-operator/issues/3730) — operator ignored
+  user-configured readers and fell back to the deprecated `address` field
+- [#3913](https://github.com/open-telemetry/opentelemetry-operator/issues/3913) — the first fix
+  regressed by dropping non-metrics telemetry fields such as `logs.level`
+- [PR #3915](https://github.com/open-telemetry/opentelemetry-operator/pull/3915) — merged April 2025,
+  and the behaviour quoted above, which is what operator v0.152.0 does. The only later commits to
+  that file adjust metric shape and promote a gate; neither restores overwriting.
 
-**`telemetry.resource`** — a map of `k8s.cluster.name` (from `clusterName`) and
-`service.instance.id: ${POD_UID}` (see below).
+`service::telemetry.logs` is untouched on this version for a structural reason: the operator's
+intermediate telemetry type models only `metrics` and `resource`, with no `logs` field at all, so
+there is nothing in the code path that could rewrite it.
+
+## Current configuration
+
+Internal telemetry is configured through `service::telemetry` alone, with no self-scrape
+pipeline. It is rendered by the `opentelemetry-kube-stack.otelTelemetry` helper in
+`templates/_config.tpl` and included by all three default configs.
+
+**`telemetry.resource`** — `k8s.cluster.name` from `clusterName`, and
+`service.instance.id: ${POD_UID}`.
 
 **`telemetry.metrics.readers`** — a single `periodic` reader with an OTLP `http/protobuf` exporter
 pointed at `${TSUGA_OTLP_ENDPOINT}/v1/metrics` with a bearer-token header. Emitted only when the
-Tsuga exporter is enabled; without credentials there is nowhere to push.
+Tsuga exporter is enabled, since without credentials there is nowhere to push. The `/v1/metrics`
+suffix is required because the telemetry reader sends metrics directly rather than through OTLP
+base-path expansion.
 
-This is the configuration the chart *asks* for. As described above, the operator webhook still
-replaces `readers` with its own Prometheus pull reader on `:8888`, so in practice internal metrics
-are exposed for scraping rather than pushed. The block is kept so the intended behaviour lands as
-soon as the operator stops overriding it. Getting those metrics into Tsuga today requires scraping
-`:8888` yourself — e.g. a `prometheus` receiver added via `agent.config.extraReceivers` plus a
-matching pipeline, or the Target Allocator statefulset.
+One side effect worth knowing: because the chart supplies a `periodic` reader and no `pull`
+reader, the operator's port lookup falls through to its default of 8888, and it still opens a
+monitoring port on the Service and container that nothing serves. Setting
+`spec.observability.metrics.disablePrometheusAnnotations: true` stops the `prometheus.io/*`
+annotations advertising it, but does not remove the port itself — there is no CR field that does.
 
-## Why POD_UID, not POD_NAME
+## Why `POD_UID`, not `POD_NAME`
 
-`POD_NAME` is only unique within a namespace at a given moment. It gets reused after rollouts and
-pod restarts, which means two different collector processes can emit the same `service.instance.id`
-over their lifetimes.
+`POD_NAME` is only unique within a namespace at a given moment. It is reused after rollouts and
+pod restarts, so two different collector processes can emit the same `service.instance.id` over
+their lifetimes.
 
 The OpenTelemetry semantic conventions
-([service resource](https://opentelemetry.io/docs/specs/semconv/resource/service/)) recommend
-using a UUID or a platform-specific ID that is tightly coupled to the service instance:
+([service resource](https://opentelemetry.io/docs/specs/semconv/resource/service/)) prefer a random
+UUID but allow an inherent identifier where stability matters:
 
-> "You could reuse an already-existing unique identifier tightly coupled with the service instance,
-> like a Kubernetes pod UID."
+> "Implementations, such as SDKs, are recommended to generate a random Version 1 or Version 4 UUID,
+> but are free to use an inherent unique ID as the source of this value if stability is desirable."
 
-`POD_UID` is assigned by the Kubernetes API server, is unique across the entire cluster, and is
-never reused — even after the pod is deleted and recreated with the same name. It is injected via
-the downward API (`metadata.uid`) and referenced as `${POD_UID}` in the
-`service.telemetry.resource` block.
+They also caution that a Collector should not set `service.instance.id` when it cannot unambiguously
+determine the instance — which is not the case here, since the value identifies the collector's own
+pod rather than a workload's.
+
+`POD_UID` is assigned by the API server, is unique across the cluster, and is never reused, even
+when a pod is recreated with the same name. It is injected through the downward API
+(`metadata.uid`) and referenced as `${POD_UID}`.
+
+## The collector's own logs are not exported
+
+Only metrics are pushed. The collector's logs stay on stdout for `kubectl logs`, and this is a
+deliberate stop rather than an oversight.
+
+Exporting them is technically possible: `service::telemetry.logs.processors` accepts declarative
+log record processors with an OTLP exporter, it is wired to a real `LoggerProvider`, and no
+feature gate guards it. What is not possible is exporting warning-and-above over OTLP while
+keeping stdout useful. The OTLP path is a tee off the console logger, and the tee is deliberately
+gated on the console core accepting the record first — from `logger_tee.go` in the collector's
+`service/telemetry`:
+
+> "we intentionally do not use zapcore.NewTee here… The provided Zap core may have sampling or a
+> minimum log level applied to it, so in order to maintain consistency, we need to ensure that
+> only the logs accepted by the provided core are copied to the log.LoggerProvider."
+
+So `logs.level` is a single control for both destinations. Exporting warnings and above would mean
+setting the level to `warn` globally, which removes info-level output from `kubectl logs` for
+everyone — the first thing anyone reads when a collector misbehaves. Exporting at `info` instead
+would push a high-volume, low-value stream into ingest.
+
+Note that the upstream `docs/observability.md` at this collector version is stale on this point
+and still says logs cannot be emitted at all; the code above contradicts it.
+
+If you need collector logs centrally, the route that does not touch `logs.level` is to collect
+them as ordinary container logs: `agent.collectOtelLogs=true` removes the filelog exclusion on the
+collector's own container. That keeps `kubectl logs` intact and is filterable downstream like any
+other log source. It is off by default for a reason, though — the agent then ingests its own
+output, which is a feedback loop that produces container-parser errors — so weigh it against
+simply reading `kubectl logs` when something breaks.


### PR DESCRIPTION
**No template changes, and that is the point.** `docs/collector-internal-metrics.md` stated that the operator's webhook replaces `service::telemetry.metrics.readers` with its own Prometheus pull reader, and that the OTLP push block this chart renders is therefore discarded. That is wrong on the operator version we bundle.

`internal/otelconfig/config.go` returns early when the user has already supplied readers — *"The user already set the address or the readers, so we don't need to do anything"* — and only injects a Prometheus reader when the list is empty, via `mergo.Merge` without `WithOverride`. Both call sites, the defaulting webhook and the ConfigMap builder, run the same function. So the chart's periodic OTLP reader survives into the rendered ConfigMap, and internal metrics have been reaching Tsuga all along rather than merely being offered for scraping.

Left uncorrected, that note would have justified either ripping out a working block or building a second mechanism beside it — which is why this is a documentation fix and nothing else.

**Also records why the collector's own logs are not exported**, since that was the other half of the original plan. It is reachable — `service::telemetry.logs.processors` accepts an OTLP log record processor with no feature gate — but warning-and-above over OTLP *while keeping stdout useful* is not. The OTLP path is a tee off the console logger, deliberately gated on the console core accepting the record first, so `logs.level` controls both destinations. Exporting warnings would strip info-level output from `kubectl logs` for everyone; exporting at info would push a high-volume stream into ingest. Neither is worth it, so the notes point at `agent.collectOtelLogs` instead, with its feedback-loop caveat.

**Verified:** operator behaviour read at v0.152.0 and confirmed unchanged by later commits to that file; the logger tee comment quoted from the collector's `service/telemetry`. Two claims corrected on review: the semconv pod-UID quote was misattributed and is now the real sentence, and `disablePrometheusAnnotations` stops the advertisement but cannot remove the port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)