### PR TITLE
Make hardcoded collector settings configurable, and correct the README

### DIFF
--- a/charts/opentelemetry-kube-stack/CHANGELOG.md
+++ b/charts/opentelemetry-kube-stack/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [opentelemetry-kube-stack-0.10.6] - 2026-07-29
+
+### Added
+- agent.kubeletStats.metricGroups, for controlling kubelet metric cardinality
+
 ## [opentelemetry-kube-stack-0.10.5] - 2026-07-28
 
 ### Added

--- a/charts/opentelemetry-kube-stack/CHANGELOG.md
+++ b/charts/opentelemetry-kube-stack/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - agent.kubeletStats.metricGroups, for controlling kubelet metric cardinality
+- tsuga.encoding and tsuga.compression, for the OTLP exporter wire format
+- Collection intervals: agent.kubeletStats.collectionInterval, agent.hostMetrics.collectionInterval, cluster.collectionInterval, statefulset.scrapeInterval
+- agent.fileLog.include and agent.fileLog.exclude, for scoping log collection
+- agent.spanMetrics.enabled and agent.spanMetrics.dimensions
+- agent.otlp.grpcEndpoint, agent.otlp.httpEndpoint, and per-collector healthCheckEndpoint
+- Kubelet TLS settings: agent.kubeletStats.authType, insecureSkipVerify and caFile
+- Shared k8sAttributes.metadata and batch settings
+- cluster.nodeConditionsToReport and cluster.allocatableTypesToReport
+
+### Fixed
+- The cluster receiver and statefulset collectors now get a health_check extension, so they have a liveness probe
+- agent.fileLog.exclude is no longer discarded when agent.collectOtelLogs is true
 
 ## [opentelemetry-kube-stack-0.10.5] - 2026-07-28
 

--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.5
+version: 0.10.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -26,56 +26,60 @@ A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga inte
 
 ## Features
 
-- **Dual Deployment Pattern**: Implements the recommended OpenTelemetry architecture with both agent (DaemonSet) and cluster receiver (Deployment) components
-- **Agent (DaemonSet)**: Collects host metrics, Kubernetes objects, and application telemetry from each node
-- **Cluster Receiver (Deployment)**: Collects cluster metrics and events using the Kubernetes API server
+- **Dual Deployment Pattern**: Implements the recommended OpenTelemetry architecture with an agent (DaemonSet) and a cluster receiver (Deployment)
+- **Agent (DaemonSet)**: Collects host metrics, kubelet metrics, container logs and application telemetry from each node
+- **Cluster Receiver (Deployment)**: Collects cluster metrics, pod objects and Kubernetes Warning events from the API server
+- **StatefulSet Collector + Target Allocator (optional)**: Scrapes Prometheus targets, sharded across replicas (`targetAllocator.enabled`)
 - **Secret Management**: Configurable secrets for OpenTelemetry configuration with external secret support
 - **RBAC Support**: Comprehensive service account and role-based access control
 - **Resource Management**: Configurable resource limits and requests for both components
 - **Host Metrics Collection**: Built-in support for node-level metrics collection
-- **Kubernetes Objects Monitoring**: Automatic collection of pods, services, and other K8s resources
+- **Kubernetes Objects Monitoring**: Watches pod objects, and optionally Warning events
 - **Comprehensive Observability**: Logs, metrics, and traces collection with intelligent defaults
 - **Security First**: Built-in security best practices and credential management
 - **Production Ready**: Optimized configurations for production environments
-- **Flexible Configuration**: Merge-based or full custom configuration options
+- **Flexible Configuration**: Chart values for the common settings, `extraReceivers`/`extraProcessors`/`extraExporters` to add components, or `customConfig` to replace a collector's configuration outright
 
 ## Architecture
 
-The chart implements the recommended OpenTelemetry architecture with two main components:
+The chart deploys two collectors by default, plus a third that is opt-in:
 
 ### Agent (DaemonSet)
 
 - Runs on every node in the cluster
-- Collects host metrics, Kubernetes objects, and application telemetry
-- Forwards data to the cluster receiver or external backends
+- Collects host metrics, kubelet metrics, container logs and application telemetry from its own node
+- Exports directly to Tsuga. There is no agent-to-cluster-receiver hop — the collectors are independent and each exports on its own.
 - Uses host networking for optimal performance (configurable)
 
 **Default Receivers:**
 - **Host Metrics** (`host_metrics`): CPU, memory, disk, filesystem, load, paging, optional network and process metrics. Kernel pseudo filesystems (`cgroup2`, `proc`, `sysfs`, …), container overlay filesystems and container mount points are excluded to keep series counts sane. The `fs_types` list is Prometheus node_exporter's default `--collector.filesystem.fs-types-exclude` set (no official OpenTelemetry chart ships an equivalent default); the mount-point list is node_exporter's, with anchored regexes and the Kubernetes-specific paths added. `tmpfs` is kept: `/run` usage is worth watching. Excluding fs type `overlay` also drops the root filesystem series on nodes whose `/` is itself an overlay mount, which means kind and k3d — local and test clusters. Cloud nodes (ext4/xfs) are unaffected.
-- **Kubelet Stats** (`kubelet_stats`): Node and pod metrics via kubelet
+- **Kubelet Stats** (`kubelet_stats`): Node, pod, container and volume metrics, plus the eight limit/request utilization metrics. The groups collected are configurable via `agent.kubeletStats.metricGroups` — `container` and `volume` are the expensive ones, roughly eleven metrics per container and five per volume. The utilization metrics and the `k8s.volume.type` label both require the kubelet `/pods` endpoint, which authorizes against `nodes/proxy`; when that call fails the receiver discards the whole scrape, so `agent.kubeletStats.usePodsEndpoint=false` exists for clusters that cannot grant it (GKE Autopilot).
 - **OTLP**: Receives traces, metrics, and logs over gRPC (`:4317`) and HTTP (`:4318`)
 - **File Logs** (`file_log`): Collects container logs from `/var/log/pods/*/*/*.log` (controlled by `agent.collectLogs`)
 
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit). First in every default pipeline, so load is shed before the pipeline spends work on data it is about to reject.
 - **Cumulative To Delta**: Converts cumulative counters to delta. Wired into the metrics pipeline only, and placed before enrichment: delta state is keyed on the full resource, so a series that starts unenriched and later gains pod metadata would look like a brand-new series and lose a datapoint.
-- **K8s Attributes** (`k8s_attributes`): Enriches telemetry with Kubernetes metadata and selected pod labels/annotations
+- **Resource Detection** (`resourcedetection`): Adds cloud and host attributes (`cloud.provider`, `cloud.region`, `host.id`). **Off by default** — enable with `resourceDetection.enabled=true`. When enabled it runs first among the enrichment processors, in every pipeline.
+- **K8s Attributes** (`k8s_attributes`): Enriches telemetry with Kubernetes metadata and selected pod labels/annotations. The attribute list is configurable via `k8sAttributes.metadata`.
 - **Resource**: Adds `k8s.cluster.name` to everything
 - **Resource/node** (`resource/node`): Adds `k8s.node.name` from the downward API with action `insert`, so it only writes when the attribute is missing and anything that already carries a node name keeps it. `kubelet_stats` sets it on its node metric group and `k8s_attributes` sets it for every pod it could associate; what is left is `host_metrics`, which reads the node's kernel and touches no pod so `k8s_attributes` can never associate it, plus records whose pod missed the informer cache. Those all belong to this node: the operator gives `daemonset` collectors a Service with `internalTrafficPolicy: Local`, so OTLP sent to the agent Service reaches the agent on the sender's own node.
 - **Batch**: Batches telemetry for efficient processing (`send_batch_size`/`send_batch_max_size` = 5000). Last in every default pipeline. User `extraProcessors` are appended after the default list, so anything you add runs on already-batched data.
 
 **Default Connectors:**
-- **Spanmetrics** (`span_metrics`): Generates RED metrics from spans (see dimensions below)
+- **Span Metrics** (`span_metrics`): Generates RED metrics from spans (see dimensions below). Note the underscored type name — the canonical name at this chart's collector floor. Disable with `agent.spanMetrics.enabled=false`.
 
 **Default Exporters:**
 - **otlp_http/tsuga**: Forwards all telemetry to the Tsuga endpoint with authentication (enabled unless `tsuga.enabledForDaemonset=false`)
 
 **Service Pipelines:**
-- **Logs**: `otlp` (+`file_log` when `agent.collectLogs`) → `memory_limiter`, `k8s_attributes`, `resource`, `resource/node`, `batch` → `otlp_http/tsuga`
-- **Metrics**: `otlp`, `kubelet_stats`, `span_metrics`, `host_metrics` → `memory_limiter`, `cumulativetodelta`, `k8s_attributes`, `resource`, `resource/node`, `batch` → `otlp_http/tsuga`
-- **Traces**: `otlp` → `memory_limiter`, `k8s_attributes`, `resource`, `resource/node`, `batch` → `otlp_http/tsuga`, `span_metrics`
+- **Logs**: `otlp` (+`file_log` when `agent.collectLogs`) → `memory_limiter`, [`resourcedetection`], `k8s_attributes`, `resource`, `resource/node`, `batch` → `otlp_http/tsuga`
+- **Metrics**: `otlp`, `kubelet_stats`, [`span_metrics`], `host_metrics` → `memory_limiter`, `cumulativetodelta`, [`resourcedetection`], `k8s_attributes`, `resource`, `resource/node`, `batch` → `otlp_http/tsuga`
+- **Traces**: `otlp` → `memory_limiter`, [`resourcedetection`], `k8s_attributes`, `resource`, `resource/node`, `batch` → `otlp_http/tsuga`, [`span_metrics`]
 
-Collector self-telemetry is exported through `service::telemetry`, not a pipeline.
+Components in [brackets] are conditional: `resourcedetection` appears only when `resourceDetection.enabled=true`, and `span_metrics` only while `agent.spanMetrics.enabled` is true.
+
+Collector self-telemetry is configured under `service::telemetry` rather than in a pipeline — but be aware that **it does not currently reach Tsuga**: the operator's webhook replaces the configured OTLP reader with a Prometheus reader on `:8888`. See [docs/collector-internal-metrics.md](docs/collector-internal-metrics.md) for the detail and the workaround.
 
 **Default Spanmetrics Dimensions:**
 - `http.request.method`
@@ -84,37 +88,33 @@ Collector self-telemetry is exported through `service::telemetry`, not a pipelin
 
 `http.route` is preferred over raw URL/path attributes because it represents the logical route template and keeps metric cardinality under control. URL-like attributes such as `http.url`, `url.full`, `http.path`, and `http.target` are intentionally excluded from the default metric dimensions because they fragment metrics with IDs, query strings, and other request-specific values.
 
-This default targets modern OpenTelemetry HTTP semantic conventions and is most useful for server spans. If your workloads still emit legacy attributes such as `http.method` and `http.status_code`, or if you want client-focused dependency metrics, override the connector dimensions through the existing merge-based config.
+This default targets modern OpenTelemetry HTTP semantic conventions and is most useful for server spans. If your workloads still emit legacy attributes such as `http.method` and `http.status_code`, or if you want client-focused dependency metrics, replace the dimensions with `agent.spanMetrics.dimensions`.
 
-Example override for client-oriented HTTP dependency metrics:
-
-```yaml
-agent:
-  config:
-    additionalConfig:
-      connectors:
-        spanmetrics:
-          dimensions:
-            - name: http.request.method
-              default: GET
-            - name: http.response.status_code
-            - name: server.address
-```
-
-Example override for workloads still emitting legacy HTTP semantic conventions:
+Example for client-oriented HTTP dependency metrics:
 
 ```yaml
 agent:
-  config:
-    additionalConfig:
-      connectors:
-        spanmetrics:
-          dimensions:
-            - name: http.method
-              default: GET
-            - name: http.status_code
-            - name: http.route
+  spanMetrics:
+    dimensions:
+      - name: http.request.method
+        default: GET
+      - name: http.response.status_code
+      - name: server.address
 ```
+
+Example for workloads still emitting legacy HTTP semantic conventions:
+
+```yaml
+agent:
+  spanMetrics:
+    dimensions:
+      - name: http.method
+        default: GET
+      - name: http.status_code
+      - name: http.route
+```
+
+> **`extraReceivers` and friends can only add components, not retune existing ones.** They are merged with the chart defaults winning on any conflicting key, so a value you set for a component the chart already defines is silently discarded. Use the dedicated chart values above to change a default, or `customConfig` to replace a collector's configuration wholesale.
 
 ### Cluster Receiver (Deployment)
 
@@ -123,11 +123,14 @@ agent:
 
 **Default Receivers:**
 - **Kubernetes Cluster** (`k8s_cluster`): Collects cluster-level metrics and entity events
-- **Kubernetes Objects** (`k8s_objects`): Watches pods (enabled by default, disable with `cluster.collectk8sobjects=false`)
+- **Kubernetes Objects** (`k8s_objects`): Watches pod objects only (enabled by default, disable with `cluster.collectk8sobjects=false`)
+- **Kubernetes Warning Events** (`k8s_objects/events`): Watches `events.k8s.io` filtered to `type=Warning` at the API server. **Off by default** — enable with `cluster.collectk8sevents=true`. A second receiver instance, so events can set `include_initial_state: false` while the pods stream keeps its snapshot.
 
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit). First in every default pipeline.
+- **Resource Detection** (`resourcedetection`): As on the agent. Off by default.
 - **K8s Attributes**: Enriches telemetry with Kubernetes metadata and selected pod labels/annotations
+- **Transform** (`transform/k8s_event_severity`): Sets `WARN` severity on event records. Only present when `cluster.collectk8sevents=true`, and only in the events pipeline — `k8s_objects` sets no severity, and a missing level would be normalized to `INFO`.
 - **Resource**: Adds `k8s.cluster.name`
 - **Batch**: Batches telemetry for efficient processing. Last in every default pipeline; user `extraProcessors` are appended after it.
 
@@ -137,8 +140,22 @@ There is no `cumulativetodelta` in this collector. `k8s_cluster` emits gauges an
 - **otlp_http/tsuga**: Forwards to the Tsuga endpoint (enabled unless `tsuga.enabledForClusterReceiver=false`)
 
 **Service Pipelines:**
-- **Metrics**: `k8s_cluster` → `memory_limiter`, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`
-- **Entity Events (Logs)**: `k8s_cluster` (+`k8s_objects` when enabled) → `memory_limiter`, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`
+- **Metrics**: `k8s_cluster` → `memory_limiter`, [`resourcedetection`], `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`
+- **Entity Events (Logs)**: `k8s_cluster` (+`k8s_objects` when enabled) → `memory_limiter`, [`resourcedetection`], `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`
+- **Warning Events (`logs/events`)**: `k8s_objects/events` → `memory_limiter`, [`resourcedetection`], `transform/k8s_event_severity`, `resource`, `batch` → `otlp_http/tsuga`. Only rendered when `cluster.collectk8sevents=true`. `k8s_attributes` is deliberately absent: a `k8s_objects` watch record carries only `k8s.namespace.name`, which none of the configured `pod_association` sources can match.
+
+Components in [brackets] are conditional, as above.
+
+### StatefulSet Collector + Target Allocator (optional)
+
+Disabled by default; enable with `targetAllocator.enabled=true`. Intended for Prometheus scraping, where the Target Allocator shards scrape jobs across collector replicas so no two replicas scrape the same target.
+
+- **Receiver**: `prometheus`, with its scrape config supplied by the Target Allocator at runtime. The static config in the chart is a placeholder the allocator replaces.
+- **Processors**: `memory_limiter`, `cumulativetodelta`, [`resourcedetection`], `k8s_attributes`, `resource`, `batch`
+- **Exporter**: `otlp_http/tsuga` (unless `tsuga.enabledForStatefulset=false`)
+- **Replicas**: `statefulset.replicas` (default 1). Unlike the cluster receiver this is safe to scale, because the allocator partitions the targets.
+- **Discovery**: set `targetAllocator.spec.prometheusCR.enabled=true` to pick up `ServiceMonitor`/`PodMonitor` resources. This requires those CRDs to exist in the cluster, i.e. prometheus-operator.
+- **Scrape interval**: `statefulset.scrapeInterval` (default `30s`) sets both the scrape interval and how often the collector refreshes its target list.
 
 ## Quick Start
 
@@ -311,7 +328,7 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | agent.collectNetwork | bool | false | Collect host network metrics When true, enables network scraper in hostmetrics receiver |
 | agent.collectOtelLogs | bool | false | Collect OpenTelemetry collector logs When false (default), excludes the collector's own container logs to avoid a self-ingestion feedback loop that produces container-parser errors |
 | agent.collectProcesses | bool | false | Collect host processes metrics When true, enables processes and process scrapers in hostmetrics receiver |
-| agent.config | object | `{"extraConnectors":{},"extraExporters":{},"extraExtensions":{},"extraProcessors":{},"extraReceivers":{},"extraTelemetry":{},"service":{"extraExtensions":[],"pipelines":{"extraPipelines":{},"logs":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"metrics":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"traces":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}}}}` | Agent collector configuration (merge-based approach) Use this to extend the default configuration Default receivers: file_log (when agent.collectLogs), kubelet_stats, host_metrics, otlp Default processors: memory_limiter, cumulativetodelta, k8s_attributes, resource, resource/node, batch Default connectors: span_metrics |
+| agent.config | object | `{"extraConnectors":{},"extraExporters":{},"extraExtensions":{},"extraProcessors":{},"extraReceivers":{},"extraTelemetry":{},"service":{"extraExtensions":[],"pipelines":{"extraPipelines":{},"logs":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"metrics":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"traces":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}}}}` | Agent collector configuration (merge-based approach) Use this to extend the default configuration Default receivers: file_log (when agent.collectLogs), kubelet_stats, host_metrics, otlp Default processors: memory_limiter, cumulativetodelta, resourcedetection (when resourceDetection.enabled), k8s_attributes, resource, resource/node, batch Default connectors: span_metrics (when agent.spanMetrics.enabled) |
 | agent.config.extraConnectors | object | {} | Additional connectors to merge into the collector configuration These are merged with default connectors |
 | agent.config.extraExporters | object | {} | Additional exporters to merge into the collector configuration These are merged with default exporters (otlp_http/tsuga) |
 | agent.config.extraExtensions | object | {} | Additional extensions to merge into the collector configuration These are merged with default extensions (health_check) |
@@ -375,8 +392,8 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | cluster.allocatableTypesToReport | list | [cpu, memory, storage] | Node allocatable resource types reported as metrics. `pods` and `ephemeral-storage` are also valid. |
 | cluster.collectionInterval | string | "10s" | How often to collect cluster metrics, e.g. `30s`. |
 | cluster.collectk8sevents | bool | false | Collect Kubernetes Warning events as logs |
-| cluster.collectk8sobjects | bool | `true` |  |
-| cluster.config | object | `{"extraConnectors":{},"extraExporters":{},"extraProcessors":{},"extraReceivers":{},"extraTelemetry":{},"service":{"extraExtensions":[],"pipelines":{"extraPipelines":{},"logs":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"metrics":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}}}}` | Gateway collector configuration (merge-based approach) Use this to extend the default configuration Default receivers: k8s_cluster, k8s_objects (when cluster.collectk8sobjects) Default processors: memory_limiter, k8s_attributes, resource, batch |
+| cluster.collectk8sobjects | bool | true | Watch pod objects and send them as logs. Powers the Kubernetes view, which uses them to show pod configuration. |
+| cluster.config | object | `{"extraConnectors":{},"extraExporters":{},"extraProcessors":{},"extraReceivers":{},"extraTelemetry":{},"service":{"extraExtensions":[],"pipelines":{"extraPipelines":{},"logs":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"metrics":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}}}}` | Gateway collector configuration (merge-based approach) Use this to extend the default configuration Default receivers: k8s_cluster, k8s_objects (when cluster.collectk8sobjects), k8s_objects/events (when cluster.collectk8sevents) Default processors: memory_limiter, resourcedetection (when resourceDetection.enabled), k8s_attributes, resource, batch |
 | cluster.config.extraConnectors | object | {} | Additional connectors to merge into the collector configuration These are merged with default connectors |
 | cluster.config.extraExporters | object | {} | Additional exporters to merge into the collector configuration These are merged with default exporters (otlp_http/tsuga) |
 | cluster.config.extraProcessors | object | {} | Additional processors to merge into the collector configuration These are merged with default processors (memory_limiter, k8s_attributes, resource, batch) |
@@ -581,6 +598,5 @@ This chart is licensed under the Apache 2.0 License. See the [LICENSE](LICENSE) 
 For support and questions:
 
 - Create an issue in the repository
-- Check the troubleshooting section above
 - Review the OpenTelemetry documentation
 - Join the OpenTelemetry community Slack

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-kube-stack
 
-![Version: 0.10.5](https://img.shields.io/badge/Version-0.10.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
+![Version: 0.10.6](https://img.shields.io/badge/Version-0.10.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
 
 A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet + cluster receiver), secure credential management, and production-ready configurations for telemetry collection to Tsuga platform.
 
@@ -340,8 +340,9 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | agent.extraLabelMapping | list | [] | Label mapping configuration for agent Maps Kubernetes pod labels to OpenTelemetry resource attributes These are appended to default label mappings Format: List of objects with tag_name, key, and from fields Example:   extraLabelMapping:     - tag_name: "app.version"       key: "app.version"       from: "pod" |
 | agent.hostNetwork | bool | true | Enable host network for agent (recommended for optimal performance) When true, agent uses host networking for better performance |
 | agent.image | string | "" | OpenTelemetry Collector image for agent Defaults to: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s |
-| agent.kubeletStats | object | `{"usePodsEndpoint":true}` | kubelet_stats receiver options |
-| agent.kubeletStats.usePodsEndpoint | bool | true | Use the kubelet /pods endpoint for pod metadata |
+| agent.kubeletStats | object | `{"metricGroups":["node","pod","container","volume"],"usePodsEndpoint":true}` | kubelet_stats receiver options |
+| agent.kubeletStats.metricGroups | list | [node, pod, container, volume] | Kubelet metric groups to collect |
+| agent.kubeletStats.usePodsEndpoint | bool | true | Use the kubelet /pods endpoint for pod metadata  The receiver calls /pods in addition to /stats/summary whenever volume type labels or any limit/request utilization metric are requested. When that call fails the receiver discards the ENTIRE scrape for that interval, node and pod metrics included — not just the attributes it could not resolve.  /pods authorizes against the nodes/proxy subresource, which this chart's ClusterRole grants. GKE Autopilot does not allow nodes/proxy to be granted at all, so on Autopilot set this to false: the collector then asks for neither volume type labels nor utilization metrics, and keeps the node, pod, container and volume metrics that only need /stats/summary. |
 | agent.nodeSelector | object | {} | Agent-specific node selector If not set, inherits from global nodeSelector configuration |
 | agent.resources | object | {} | Agent-specific resource limits and requests If not set, inherits from global resources configuration |
 | agent.tolerations | list | [] | Agent-specific tolerations If not set, inherits from global tolerations configuration |
@@ -352,7 +353,6 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | autoInstrumentation.nameOverride | string | "" | Override the name of the Instrumentation resource If empty, defaults to "<release-fullname>-instrumentation" |
 | autoInstrumentation.spec | object | {} | Instrumentation spec (full passthrough) This is passed directly to the Instrumentation Custom Resource spec. It can include (non-exhaustive): exporter, propagators, sampler, env, resource, and language blocks like java, nodejs, python, dotnet, go, apacheHttpd. Ref: https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#instrumentation |
 | cluster.affinity | object | {} | Cluster-specific affinity rules If not set, inherits from global affinity configuration |
-| cluster.collectk8sevents | bool | false | Collect Kubernetes Warning events as logs |
 | cluster.collectk8sobjects | bool | `true` |  |
 | cluster.config | object | `{"extraConnectors":{},"extraExporters":{},"extraProcessors":{},"extraReceivers":{},"extraTelemetry":{},"service":{"extraExtensions":[],"pipelines":{"extraPipelines":{},"logs":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"metrics":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}}}}` | Gateway collector configuration (merge-based approach) Use this to extend the default configuration Default receivers: k8s_cluster, k8s_objects (when cluster.collectk8sobjects) Default processors: memory_limiter, k8s_attributes, resource, batch |
 | cluster.config.extraConnectors | object | {} | Additional connectors to merge into the collector configuration These are merged with default connectors |

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -338,13 +338,29 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | agent.extraAnnotationsMapping | list | [] | Annotations mapping configuration for agent Maps Kubernetes pod annotations to OpenTelemetry resource attributes These are appended to default annotation mappings Format: List of objects with tag_name, key, and from fields |
 | agent.extraEnvs | list | [] | Extra environment variables for agent These are in addition to automatic secret env vars (TSUGA_API_KEY, TSUGA_OTLP_ENDPOINT, MY_POD_IP) |
 | agent.extraLabelMapping | list | [] | Label mapping configuration for agent Maps Kubernetes pod labels to OpenTelemetry resource attributes These are appended to default label mappings Format: List of objects with tag_name, key, and from fields Example:   extraLabelMapping:     - tag_name: "app.version"       key: "app.version"       from: "pod" |
+| agent.fileLog | object | `{"exclude":[],"include":["/var/log/pods/*/*/*.log"]}` | file_log receiver paths (used when collectLogs is true) |
+| agent.fileLog.exclude | list | [] | Log file globs to skip. |
+| agent.fileLog.include | list | ["/var/log/pods/*/*/*.log"] | Log file globs to read. |
+| agent.healthCheckEndpoint | string | "${env:MY_POD_IP}:13133" | Address for the health_check extension, which backs the liveness probe. Set to "" to omit the extension entirely. |
+| agent.hostMetrics | object | `{"collectionInterval":"10s"}` | host_metrics receiver options |
+| agent.hostMetrics.collectionInterval | string | "10s" | How often to collect host metrics, e.g. `60s`. |
 | agent.hostNetwork | bool | true | Enable host network for agent (recommended for optimal performance) When true, agent uses host networking for better performance |
 | agent.image | string | "" | OpenTelemetry Collector image for agent Defaults to: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s |
-| agent.kubeletStats | object | `{"metricGroups":["node","pod","container","volume"],"usePodsEndpoint":true}` | kubelet_stats receiver options |
+| agent.kubeletStats | object | `{"authType":"serviceAccount","caFile":"","collectionInterval":"20s","insecureSkipVerify":true,"metricGroups":["node","pod","container","volume"],"usePodsEndpoint":true}` | kubelet_stats receiver options |
+| agent.kubeletStats.authType | string | "serviceAccount" | Kubelet authentication method. One of `serviceAccount`, `tls`, `none`. |
+| agent.kubeletStats.caFile | string | "" | CA bundle path used to verify the kubelet, e.g. `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. Requires insecureSkipVerify to be false, and the file to be mounted in the pod. |
+| agent.kubeletStats.collectionInterval | string | "20s" | How often to collect kubelet metrics, e.g. `60s`. |
+| agent.kubeletStats.insecureSkipVerify | bool | true | Skip verification of the kubelet's serving certificate. |
 | agent.kubeletStats.metricGroups | list | [node, pod, container, volume] | Kubelet metric groups to collect |
-| agent.kubeletStats.usePodsEndpoint | bool | true | Use the kubelet /pods endpoint for pod metadata  The receiver calls /pods in addition to /stats/summary whenever volume type labels or any limit/request utilization metric are requested. When that call fails the receiver discards the ENTIRE scrape for that interval, node and pod metrics included — not just the attributes it could not resolve.  /pods authorizes against the nodes/proxy subresource, which this chart's ClusterRole grants. GKE Autopilot does not allow nodes/proxy to be granted at all, so on Autopilot set this to false: the collector then asks for neither volume type labels nor utilization metrics, and keeps the node, pod, container and volume metrics that only need /stats/summary. |
+| agent.kubeletStats.usePodsEndpoint | bool | true | Use the kubelet /pods endpoint for pod metadata |
 | agent.nodeSelector | object | {} | Agent-specific node selector If not set, inherits from global nodeSelector configuration |
+| agent.otlp | object | `{"grpcEndpoint":"${env:MY_POD_IP}:4317","httpEndpoint":"${env:MY_POD_IP}:4318"}` | OTLP receiver listen addresses |
+| agent.otlp.grpcEndpoint | string | "${env:MY_POD_IP}:4317" | gRPC listen address. Set to "" to disable the gRPC protocol. |
+| agent.otlp.httpEndpoint | string | "${env:MY_POD_IP}:4318" | HTTP listen address. Set to "" to disable the HTTP protocol. |
 | agent.resources | object | {} | Agent-specific resource limits and requests If not set, inherits from global resources configuration |
+| agent.spanMetrics | object | `{"dimensions":[{"default":"GET","name":"http.request.method"},{"name":"http.response.status_code"},{"name":"http.route"}],"enabled":true}` | span_metrics connector options (RED metrics generated from spans) |
+| agent.spanMetrics.dimensions | list | see values.yaml | Span attributes to keep as metric dimensions. `default` supplies a value when the attribute is absent. |
+| agent.spanMetrics.enabled | bool | true | Generate metrics from spans. |
 | agent.tolerations | list | [] | Agent-specific tolerations If not set, inherits from global tolerations configuration |
 | autoInstrumentation.annotations | object | {} | Extra annotations to add to the Instrumentation resource |
 | autoInstrumentation.apiVersion | string | "opentelemetry.io/v1alpha1" | apiVersion for the Instrumentation CR (depends on operator version) Common values: "opentelemetry.io/v1alpha1" |
@@ -352,7 +368,13 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | autoInstrumentation.labels | object | {} | Extra labels to add to the Instrumentation resource |
 | autoInstrumentation.nameOverride | string | "" | Override the name of the Instrumentation resource If empty, defaults to "<release-fullname>-instrumentation" |
 | autoInstrumentation.spec | object | {} | Instrumentation spec (full passthrough) This is passed directly to the Instrumentation Custom Resource spec. It can include (non-exhaustive): exporter, propagators, sampler, env, resource, and language blocks like java, nodejs, python, dotnet, go, apacheHttpd. Ref: https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#instrumentation |
+| batch.sendBatchMaxSize | int | 5000 | Hard cap on items per batch. Lower this if the backend rejects large requests. Keeping it equal to sendBatchSize means a timeout can never build an oversized batch. |
+| batch.sendBatchSize | int | 5000 | Item count that triggers a send. |
+| batch.timeout | string | "" | Maximum time to wait before sending an undersized batch, e.g. `5s`. Empty uses the processor's own default of 200ms. |
 | cluster.affinity | object | {} | Cluster-specific affinity rules If not set, inherits from global affinity configuration |
+| cluster.allocatableTypesToReport | list | [cpu, memory, storage] | Node allocatable resource types reported as metrics. `pods` and `ephemeral-storage` are also valid. |
+| cluster.collectionInterval | string | "10s" | How often to collect cluster metrics, e.g. `30s`. |
+| cluster.collectk8sevents | bool | false | Collect Kubernetes Warning events as logs |
 | cluster.collectk8sobjects | bool | `true` |  |
 | cluster.config | object | `{"extraConnectors":{},"extraExporters":{},"extraProcessors":{},"extraReceivers":{},"extraTelemetry":{},"service":{"extraExtensions":[],"pipelines":{"extraPipelines":{},"logs":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]},"metrics":{"extraExporters":[],"extraProcessors":[],"extraReceivers":[]}}}}` | Gateway collector configuration (merge-based approach) Use this to extend the default configuration Default receivers: k8s_cluster, k8s_objects (when cluster.collectk8sobjects) Default processors: memory_limiter, k8s_attributes, resource, batch |
 | cluster.config.extraConnectors | object | {} | Additional connectors to merge into the collector configuration These are merged with default connectors |
@@ -377,13 +399,16 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | cluster.extraAnnotationsMapping | list | [] | Annotations mapping configuration for cluster receiver Maps Kubernetes pod annotations to OpenTelemetry resource attributes These are appended to default annotation mappings Format: List of objects with tag_name, key, and from fields |
 | cluster.extraEnvs | list | [] | Extra environment variables for cluster receiver These are in addition to automatic secret env vars (TSUGA_API_KEY, TSUGA_OTLP_ENDPOINT, MY_POD_IP) Example:   extraEnvs:     - name: CUSTOM_VAR       value: "custom-value" |
 | cluster.extraLabelMapping | list | [] | Label mapping configuration for cluster receiver Maps Kubernetes pod labels to OpenTelemetry resource attributes These are appended to default label mappings Format: List of objects with tag_name, key, and from fields Example:   extraLabelMapping:     - tag_name: "app.version"       key: "app.version"       from: "pod" |
+| cluster.healthCheckEndpoint | string | "${env:MY_POD_IP}:13133" | Address for the health_check extension, which backs the liveness probe. Set to "" to omit the extension entirely. |
 | cluster.image | string | "" | OpenTelemetry Collector image for cluster receiver Defaults to: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s |
+| cluster.nodeConditionsToReport | list | [Ready, MemoryPressure, DiskPressure, PIDPressure] | Node conditions reported as metrics. Add `NetworkUnavailable`, or the custom conditions node-problem-detector writes, to alert on them. |
 | cluster.nodeSelector | object | {} | Cluster-specific node selector If not set, inherits from global nodeSelector configuration |
 | cluster.resources | object | {} | Cluster-specific resource limits and requests If not set, inherits from global resources configuration |
 | cluster.tolerations | list | [] | Cluster-specific tolerations If not set, inherits from global tolerations configuration |
 | clusterName | string | "" (must be set) | REQUIRED. The name of the cluster, added to all telemetry as k8s.cluster.name.  Installation fails if this is empty. Telemetry from a cluster that does not name itself cannot be told apart from any other cluster's once it reaches Tsuga, and the omission only becomes visible during an incident, which is the worst time to discover it.    --set clusterName=<name>  |
 | fullnameOverride | string | "" | Override the full name used in resource naming |
 | image | string | "" | Default OpenTelemetry Collector image Used as fallback when cluster.image or agent.image are not set Format: registry/repository:tag |
+| k8sAttributes.metadata | list | see values.yaml | Kubernetes metadata to attach to telemetry. |
 | nameOverride | string | "" | Override the chart name used in resource naming |
 | nodeSelector | object | {} | Node selector for daemonset mode (agent) Used as default when agent.nodeSelector is not set |
 | opentelemetry-operator.admissionWebhooks.failurePolicy | string | `"Ignore"` |  |
@@ -432,10 +457,12 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | statefulset.extraAnnotationsMapping | list | [] | Annotations mapping configuration for agent Maps Kubernetes pod annotations to OpenTelemetry resource attributes These are appended to default annotation mappings Format: List of objects with tag_name, key, and from fields |
 | statefulset.extraEnvs | list | [] | Extra environment variables for statefulset collector |
 | statefulset.extraLabelMapping | list | [] | Label mapping configuration for agent Maps Kubernetes pod labels to OpenTelemetry resource attributes These are appended to default label mappings Format: List of objects with tag_name, key, and from fields Example:   extraLabelMapping:     - tag_name: "app.version"       key: "app.version"       from: "pod" |
+| statefulset.healthCheckEndpoint | string | "${env:MY_POD_IP}:13133" | Address for the health_check extension, which backs the liveness probe. Set to "" to omit the extension entirely. |
 | statefulset.image | string | "" | OpenTelemetry Collector image for statefulset collector |
 | statefulset.nodeSelector | object | {} | StatefulSet-specific node selector |
 | statefulset.replicas | int | 1 | Number of StatefulSet collector replicas The Target Allocator distributes targets evenly across replicas. |
 | statefulset.resources | object | {} | StatefulSet-specific resource limits and requests |
+| statefulset.scrapeInterval | string | "30s" | How often to scrape Prometheus targets, e.g. `60s`. Also the interval at which the collector refreshes its target list from the Target Allocator. |
 | statefulset.tolerations | list | [] | StatefulSet-specific tolerations |
 | targetAllocator.enabled | bool | false | Enable Target Allocator and paired StatefulSet collector |
 | targetAllocator.spec | object | {} | TargetAllocator CR spec (full passthrough) All fields are passed directly to the TargetAllocator CR spec. Ref: https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#targetallocator |
@@ -446,9 +473,11 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | targetAllocator.spec.prometheusCR.serviceMonitorSelector | object | {} | Selector for ServiceMonitor resources An empty selector ({}) matches all ServiceMonitors in all namespaces. |
 | tolerations | list | [] | Tolerations for daemonset mode (agent) Used as default when agent.tolerations is not set |
 | tsuga.apiKey | string | "" | Tsuga API key for authentication Set via: --set tsuga.apiKey="<TSUGA_API_KEY>" Or use external secrets: --set tsuga.apiKey="" |
+| tsuga.compression | string | "gzip" | Compression for the OTLP exporter. One of `gzip`, `zstd`, `snappy`, `none`. |
 | tsuga.enabledForClusterReceiver | bool | true | Enable Tsuga OTLP exporter for the cluster receiver (gateway) |
 | tsuga.enabledForDaemonset | bool | true | Enable Tsuga OTLP exporter for the agent DaemonSet |
 | tsuga.enabledForStatefulset | bool | true | Enable Tsuga OTLP exporter for the StatefulSet collector (when targetAllocator is enabled) |
+| tsuga.encoding | string | "json" | Payload encoding for the OTLP exporter. One of `json`, `proto`. |
 | tsuga.otlpEndpoint | string | "" | Tsuga OTLP endpoint for telemetry data Set via: --set tsuga.otlpEndpoint="https://intake.<CLUSTER_ID>.tsuga.com:443/api/v1/otlp" |
 | validation | object | `{"enabled":true,"enforceNamingConventions":true,"maxNameLength":63}` | Resource naming validation |
 | validation.enabled | bool | true | Enable resource name validation When enabled, validates resource names meet Kubernetes requirements |

--- a/charts/opentelemetry-kube-stack/README.md.gotmpl
+++ b/charts/opentelemetry-kube-stack/README.md.gotmpl
@@ -16,56 +16,60 @@
 
 ## Features
 
-- **Dual Deployment Pattern**: Implements the recommended OpenTelemetry architecture with both agent (DaemonSet) and cluster receiver (Deployment) components
-- **Agent (DaemonSet)**: Collects host metrics, Kubernetes objects, and application telemetry from each node
-- **Cluster Receiver (Deployment)**: Collects cluster metrics and events using the Kubernetes API server
+- **Dual Deployment Pattern**: Implements the recommended OpenTelemetry architecture with an agent (DaemonSet) and a cluster receiver (Deployment)
+- **Agent (DaemonSet)**: Collects host metrics, kubelet metrics, container logs and application telemetry from each node
+- **Cluster Receiver (Deployment)**: Collects cluster metrics, pod objects and Kubernetes Warning events from the API server
+- **StatefulSet Collector + Target Allocator (optional)**: Scrapes Prometheus targets, sharded across replicas (`targetAllocator.enabled`)
 - **Secret Management**: Configurable secrets for OpenTelemetry configuration with external secret support
 - **RBAC Support**: Comprehensive service account and role-based access control
 - **Resource Management**: Configurable resource limits and requests for both components
 - **Host Metrics Collection**: Built-in support for node-level metrics collection
-- **Kubernetes Objects Monitoring**: Automatic collection of pods, services, and other K8s resources
+- **Kubernetes Objects Monitoring**: Watches pod objects, and optionally Warning events
 - **Comprehensive Observability**: Logs, metrics, and traces collection with intelligent defaults
 - **Security First**: Built-in security best practices and credential management
 - **Production Ready**: Optimized configurations for production environments
-- **Flexible Configuration**: Merge-based or full custom configuration options
+- **Flexible Configuration**: Chart values for the common settings, `extraReceivers`/`extraProcessors`/`extraExporters` to add components, or `customConfig` to replace a collector's configuration outright
 
 ## Architecture
 
-The chart implements the recommended OpenTelemetry architecture with two main components:
+The chart deploys two collectors by default, plus a third that is opt-in:
 
 ### Agent (DaemonSet)
 
 - Runs on every node in the cluster
-- Collects host metrics, Kubernetes objects, and application telemetry
-- Forwards data to the cluster receiver or external backends
+- Collects host metrics, kubelet metrics, container logs and application telemetry from its own node
+- Exports directly to Tsuga. There is no agent-to-cluster-receiver hop — the collectors are independent and each exports on its own.
 - Uses host networking for optimal performance (configurable)
 
 **Default Receivers:**
 - **Host Metrics** (`host_metrics`): CPU, memory, disk, filesystem, load, paging, optional network and process metrics. Kernel pseudo filesystems (`cgroup2`, `proc`, `sysfs`, …), container overlay filesystems and container mount points are excluded to keep series counts sane. The `fs_types` list is Prometheus node_exporter's default `--collector.filesystem.fs-types-exclude` set (no official OpenTelemetry chart ships an equivalent default); the mount-point list is node_exporter's, with anchored regexes and the Kubernetes-specific paths added. `tmpfs` is kept: `/run` usage is worth watching. Excluding fs type `overlay` also drops the root filesystem series on nodes whose `/` is itself an overlay mount, which means kind and k3d — local and test clusters. Cloud nodes (ext4/xfs) are unaffected.
-- **Kubelet Stats** (`kubelet_stats`): Node and pod metrics via kubelet
+- **Kubelet Stats** (`kubelet_stats`): Node, pod, container and volume metrics, plus the eight limit/request utilization metrics. The groups collected are configurable via `agent.kubeletStats.metricGroups` — `container` and `volume` are the expensive ones, roughly eleven metrics per container and five per volume. The utilization metrics and the `k8s.volume.type` label both require the kubelet `/pods` endpoint, which authorizes against `nodes/proxy`; when that call fails the receiver discards the whole scrape, so `agent.kubeletStats.usePodsEndpoint=false` exists for clusters that cannot grant it (GKE Autopilot).
 - **OTLP**: Receives traces, metrics, and logs over gRPC (`:4317`) and HTTP (`:4318`)
 - **File Logs** (`file_log`): Collects container logs from `/var/log/pods/*/*/*.log` (controlled by `agent.collectLogs`)
 
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit). First in every default pipeline, so load is shed before the pipeline spends work on data it is about to reject.
 - **Cumulative To Delta**: Converts cumulative counters to delta. Wired into the metrics pipeline only, and placed before enrichment: delta state is keyed on the full resource, so a series that starts unenriched and later gains pod metadata would look like a brand-new series and lose a datapoint.
-- **K8s Attributes** (`k8s_attributes`): Enriches telemetry with Kubernetes metadata and selected pod labels/annotations
+- **Resource Detection** (`resourcedetection`): Adds cloud and host attributes (`cloud.provider`, `cloud.region`, `host.id`). **Off by default** — enable with `resourceDetection.enabled=true`. When enabled it runs first among the enrichment processors, in every pipeline.
+- **K8s Attributes** (`k8s_attributes`): Enriches telemetry with Kubernetes metadata and selected pod labels/annotations. The attribute list is configurable via `k8sAttributes.metadata`.
 - **Resource**: Adds `k8s.cluster.name` to everything
 - **Resource/node** (`resource/node`): Adds `k8s.node.name` from the downward API with action `insert`, so it only writes when the attribute is missing and anything that already carries a node name keeps it. `kubelet_stats` sets it on its node metric group and `k8s_attributes` sets it for every pod it could associate; what is left is `host_metrics`, which reads the node's kernel and touches no pod so `k8s_attributes` can never associate it, plus records whose pod missed the informer cache. Those all belong to this node: the operator gives `daemonset` collectors a Service with `internalTrafficPolicy: Local`, so OTLP sent to the agent Service reaches the agent on the sender's own node.
 - **Batch**: Batches telemetry for efficient processing (`send_batch_size`/`send_batch_max_size` = 5000). Last in every default pipeline. User `extraProcessors` are appended after the default list, so anything you add runs on already-batched data.
 
 **Default Connectors:**
-- **Spanmetrics** (`span_metrics`): Generates RED metrics from spans (see dimensions below)
+- **Span Metrics** (`span_metrics`): Generates RED metrics from spans (see dimensions below). Note the underscored type name — the canonical name at this chart's collector floor. Disable with `agent.spanMetrics.enabled=false`.
 
 **Default Exporters:**
 - **otlp_http/tsuga**: Forwards all telemetry to the Tsuga endpoint with authentication (enabled unless `tsuga.enabledForDaemonset=false`)
 
 **Service Pipelines:**
-- **Logs**: `otlp` (+`file_log` when `agent.collectLogs`) → `memory_limiter`, `k8s_attributes`, `resource`, `resource/node`, `batch` → `otlp_http/tsuga`
-- **Metrics**: `otlp`, `kubelet_stats`, `span_metrics`, `host_metrics` → `memory_limiter`, `cumulativetodelta`, `k8s_attributes`, `resource`, `resource/node`, `batch` → `otlp_http/tsuga`
-- **Traces**: `otlp` → `memory_limiter`, `k8s_attributes`, `resource`, `resource/node`, `batch` → `otlp_http/tsuga`, `span_metrics`
+- **Logs**: `otlp` (+`file_log` when `agent.collectLogs`) → `memory_limiter`, [`resourcedetection`], `k8s_attributes`, `resource`, `resource/node`, `batch` → `otlp_http/tsuga`
+- **Metrics**: `otlp`, `kubelet_stats`, [`span_metrics`], `host_metrics` → `memory_limiter`, `cumulativetodelta`, [`resourcedetection`], `k8s_attributes`, `resource`, `resource/node`, `batch` → `otlp_http/tsuga`
+- **Traces**: `otlp` → `memory_limiter`, [`resourcedetection`], `k8s_attributes`, `resource`, `resource/node`, `batch` → `otlp_http/tsuga`, [`span_metrics`]
 
-Collector self-telemetry is exported through `service::telemetry`, not a pipeline.
+Components in [brackets] are conditional: `resourcedetection` appears only when `resourceDetection.enabled=true`, and `span_metrics` only while `agent.spanMetrics.enabled` is true.
+
+Collector self-telemetry is configured under `service::telemetry` rather than in a pipeline — but be aware that **it does not currently reach Tsuga**: the operator's webhook replaces the configured OTLP reader with a Prometheus reader on `:8888`. See [docs/collector-internal-metrics.md](docs/collector-internal-metrics.md) for the detail and the workaround.
 
 **Default Spanmetrics Dimensions:**
 - `http.request.method`
@@ -74,37 +78,33 @@ Collector self-telemetry is exported through `service::telemetry`, not a pipelin
 
 `http.route` is preferred over raw URL/path attributes because it represents the logical route template and keeps metric cardinality under control. URL-like attributes such as `http.url`, `url.full`, `http.path`, and `http.target` are intentionally excluded from the default metric dimensions because they fragment metrics with IDs, query strings, and other request-specific values.
 
-This default targets modern OpenTelemetry HTTP semantic conventions and is most useful for server spans. If your workloads still emit legacy attributes such as `http.method` and `http.status_code`, or if you want client-focused dependency metrics, override the connector dimensions through the existing merge-based config.
+This default targets modern OpenTelemetry HTTP semantic conventions and is most useful for server spans. If your workloads still emit legacy attributes such as `http.method` and `http.status_code`, or if you want client-focused dependency metrics, replace the dimensions with `agent.spanMetrics.dimensions`.
 
-Example override for client-oriented HTTP dependency metrics:
-
-```yaml
-agent:
-  config:
-    additionalConfig:
-      connectors:
-        spanmetrics:
-          dimensions:
-            - name: http.request.method
-              default: GET
-            - name: http.response.status_code
-            - name: server.address
-```
-
-Example override for workloads still emitting legacy HTTP semantic conventions:
+Example for client-oriented HTTP dependency metrics:
 
 ```yaml
 agent:
-  config:
-    additionalConfig:
-      connectors:
-        spanmetrics:
-          dimensions:
-            - name: http.method
-              default: GET
-            - name: http.status_code
-            - name: http.route
+  spanMetrics:
+    dimensions:
+      - name: http.request.method
+        default: GET
+      - name: http.response.status_code
+      - name: server.address
 ```
+
+Example for workloads still emitting legacy HTTP semantic conventions:
+
+```yaml
+agent:
+  spanMetrics:
+    dimensions:
+      - name: http.method
+        default: GET
+      - name: http.status_code
+      - name: http.route
+```
+
+> **`extraReceivers` and friends can only add components, not retune existing ones.** They are merged with the chart defaults winning on any conflicting key, so a value you set for a component the chart already defines is silently discarded. Use the dedicated chart values above to change a default, or `customConfig` to replace a collector's configuration wholesale.
 
 ### Cluster Receiver (Deployment)
 
@@ -113,11 +113,14 @@ agent:
 
 **Default Receivers:**
 - **Kubernetes Cluster** (`k8s_cluster`): Collects cluster-level metrics and entity events
-- **Kubernetes Objects** (`k8s_objects`): Watches pods (enabled by default, disable with `cluster.collectk8sobjects=false`)
+- **Kubernetes Objects** (`k8s_objects`): Watches pod objects only (enabled by default, disable with `cluster.collectk8sobjects=false`)
+- **Kubernetes Warning Events** (`k8s_objects/events`): Watches `events.k8s.io` filtered to `type=Warning` at the API server. **Off by default** — enable with `cluster.collectk8sevents=true`. A second receiver instance, so events can set `include_initial_state: false` while the pods stream keeps its snapshot.
 
 **Default Processors:**
 - **Memory Limiter**: Prevents memory issues (80% limit, 25% spike limit). First in every default pipeline.
+- **Resource Detection** (`resourcedetection`): As on the agent. Off by default.
 - **K8s Attributes**: Enriches telemetry with Kubernetes metadata and selected pod labels/annotations
+- **Transform** (`transform/k8s_event_severity`): Sets `WARN` severity on event records. Only present when `cluster.collectk8sevents=true`, and only in the events pipeline — `k8s_objects` sets no severity, and a missing level would be normalized to `INFO`.
 - **Resource**: Adds `k8s.cluster.name`
 - **Batch**: Batches telemetry for efficient processing. Last in every default pipeline; user `extraProcessors` are appended after it.
 
@@ -127,8 +130,22 @@ There is no `cumulativetodelta` in this collector. `k8s_cluster` emits gauges an
 - **otlp_http/tsuga**: Forwards to the Tsuga endpoint (enabled unless `tsuga.enabledForClusterReceiver=false`)
 
 **Service Pipelines:**
-- **Metrics**: `k8s_cluster` → `memory_limiter`, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`
-- **Entity Events (Logs)**: `k8s_cluster` (+`k8s_objects` when enabled) → `memory_limiter`, `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`
+- **Metrics**: `k8s_cluster` → `memory_limiter`, [`resourcedetection`], `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`
+- **Entity Events (Logs)**: `k8s_cluster` (+`k8s_objects` when enabled) → `memory_limiter`, [`resourcedetection`], `k8s_attributes`, `resource`, `batch` → `otlp_http/tsuga`
+- **Warning Events (`logs/events`)**: `k8s_objects/events` → `memory_limiter`, [`resourcedetection`], `transform/k8s_event_severity`, `resource`, `batch` → `otlp_http/tsuga`. Only rendered when `cluster.collectk8sevents=true`. `k8s_attributes` is deliberately absent: a `k8s_objects` watch record carries only `k8s.namespace.name`, which none of the configured `pod_association` sources can match.
+
+Components in [brackets] are conditional, as above.
+
+### StatefulSet Collector + Target Allocator (optional)
+
+Disabled by default; enable with `targetAllocator.enabled=true`. Intended for Prometheus scraping, where the Target Allocator shards scrape jobs across collector replicas so no two replicas scrape the same target.
+
+- **Receiver**: `prometheus`, with its scrape config supplied by the Target Allocator at runtime. The static config in the chart is a placeholder the allocator replaces.
+- **Processors**: `memory_limiter`, `cumulativetodelta`, [`resourcedetection`], `k8s_attributes`, `resource`, `batch`
+- **Exporter**: `otlp_http/tsuga` (unless `tsuga.enabledForStatefulset=false`)
+- **Replicas**: `statefulset.replicas` (default 1). Unlike the cluster receiver this is safe to scale, because the allocator partitions the targets.
+- **Discovery**: set `targetAllocator.spec.prometheusCR.enabled=true` to pick up `ServiceMonitor`/`PodMonitor` resources. This requires those CRDs to exist in the cluster, i.e. prometheus-operator.
+- **Scrape interval**: `statefulset.scrapeInterval` (default `30s`) sets both the scrape interval and how often the collector refreshes its target list.
 
 ## Quick Start
 
@@ -390,6 +407,5 @@ This chart is licensed under the Apache 2.0 License. See the [LICENSE](LICENSE) 
 For support and questions:
 
 - Create an issue in the repository
-- Check the troubleshooting section above
 - Review the OpenTelemetry documentation
 - Join the OpenTelemetry community Slack

--- a/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/auto-instrumentation/rendered/cluster-receiver.yaml
@@ -161,8 +161,12 @@ spec:
         endpoint: ${TSUGA_OTLP_ENDPOINT}
         headers:
           Authorization: Bearer ${TSUGA_API_KEY}
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
     service:
-      extensions: []
+      extensions:
+      - health_check
       pipelines:
         logs:
           exporters:

--- a/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/create-secret/rendered/cluster-receiver.yaml
@@ -161,8 +161,12 @@ spec:
         endpoint: ${TSUGA_OTLP_ENDPOINT}
         headers:
           Authorization: Bearer ${TSUGA_API_KEY}
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
     service:
-      extensions: []
+      extensions:
+      - health_check
       pipelines:
         logs:
           exporters:

--- a/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/custom-config/rendered/cluster-receiver.yaml
@@ -161,8 +161,12 @@ spec:
         endpoint: ${TSUGA_OTLP_ENDPOINT}
         headers:
           Authorization: Bearer ${TSUGA_API_KEY}
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
     service:
-      extensions: []
+      extensions:
+      - health_check
       pipelines:
         logs:
           exporters:

--- a/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/default/rendered/cluster-receiver.yaml
@@ -161,8 +161,12 @@ spec:
         endpoint: ${TSUGA_OTLP_ENDPOINT}
         headers:
           Authorization: Bearer ${TSUGA_API_KEY}
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
     service:
-      extensions: []
+      extensions:
+      - health_check
       pipelines:
         logs:
           exporters:

--- a/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/extra-service/rendered/cluster-receiver.yaml
@@ -161,8 +161,12 @@ spec:
         endpoint: ${TSUGA_OTLP_ENDPOINT}
         headers:
           Authorization: Bearer ${TSUGA_API_KEY}
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
     service:
-      extensions: []
+      extensions:
+      - health_check
       pipelines:
         logs:
           exporters:

--- a/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/k8s-objects/rendered/cluster-receiver.yaml
@@ -161,8 +161,12 @@ spec:
         endpoint: ${TSUGA_OTLP_ENDPOINT}
         headers:
           Authorization: Bearer ${TSUGA_API_KEY}
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
     service:
-      extensions: []
+      extensions:
+      - health_check
       pipelines:
         logs:
           exporters:

--- a/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/otel-demo/rendered/cluster-receiver.yaml
@@ -161,8 +161,12 @@ spec:
         endpoint: ${TSUGA_OTLP_ENDPOINT}
         headers:
           Authorization: Bearer ${TSUGA_API_KEY}
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
     service:
-      extensions: []
+      extensions:
+      - health_check
       pipelines:
         logs:
           exporters:

--- a/charts/opentelemetry-kube-stack/examples/target-allocator/rendered/statefulset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/target-allocator/rendered/statefulset.yaml
@@ -150,8 +150,12 @@ spec:
         endpoint: ${TSUGA_OTLP_ENDPOINT}
         headers:
           Authorization: Bearer ${TSUGA_API_KEY}
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
     service:
-      extensions: []
+      extensions:
+      - health_check
       pipelines:
         metrics:
           exporters:

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/cluster-receiver.yaml
@@ -146,8 +146,12 @@ spec:
           value: test-cluster
     exporters:
       debug: {}
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
     service:
-      extensions: []
+      extensions:
+      - health_check
       pipelines:
         logs:
           exporters:

--- a/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/statefulset.yaml
+++ b/charts/opentelemetry-kube-stack/examples/tusga-less/rendered/statefulset.yaml
@@ -135,8 +135,12 @@ spec:
           value: test-cluster
     exporters:
       debug: {}
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
     service:
-      extensions: []
+      extensions:
+      - health_check
       pipelines:
         metrics:
           exporters:

--- a/charts/opentelemetry-kube-stack/templates/_config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_config.tpl
@@ -68,6 +68,30 @@ resourcedetection:
 {{- end }}
 
 {{/*
+The batch processor, shared by all three collectors.
+
+send_batch_max_size defaults to the same value as send_batch_size so the timeout
+can never assemble a batch larger than the exporter will accept. timeout is only
+emitted when set, so the processor's own 200ms default applies otherwise.
+*/}}
+{{- define "opentelemetry-kube-stack.batch" -}}
+batch:
+  send_batch_size: {{ .Values.batch.sendBatchSize | default 5000 }}
+  send_batch_max_size: {{ .Values.batch.sendBatchMaxSize | default 5000 }}
+  {{- with .Values.batch.timeout }}
+  timeout: {{ . }}
+  {{- end }}
+{{- end }}
+
+{{/*
+The Kubernetes metadata that k8s_attributes attaches, shared by all three
+collectors. Emitted as a bare list, so callers supply their own indentation.
+*/}}
+{{- define "opentelemetry-kube-stack.k8sAttributesMetadata" -}}
+{{ toYaml (.Values.k8sAttributes.metadata | default (list "k8s.namespace.name" "k8s.deployment.name" "k8s.statefulset.name" "k8s.daemonset.name" "k8s.cronjob.name" "k8s.job.name" "k8s.node.name" "k8s.pod.name" "k8s.pod.uid" "k8s.pod.start_time")) }}
+{{- end }}
+
+{{/*
 Generate Tsuga exporters configuration
 */}}
 {{- define "opentelemetry-kube-stack.tsugaExporters" -}}
@@ -75,8 +99,8 @@ otlp_http/tsuga:
   endpoint: ${TSUGA_OTLP_ENDPOINT}
   headers:
     Authorization: Bearer ${TSUGA_API_KEY}
-  encoding: json
-  compression: gzip
+  encoding: {{ .Values.tsuga.encoding | default "json" }}
+  compression: {{ .Values.tsuga.compression | default "gzip" }}
 {{- end }}
 
 {{/*

--- a/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-cluster-receiver-config.tpl
@@ -1,9 +1,15 @@
 {{- define "tsuga-otel.cluster-receiver.config.default" -}}
+{{- $healthCheck := .Values.cluster.healthCheckEndpoint | default "" }}
+{{- if $healthCheck }}
+extensions:
+  health_check:
+    endpoint: {{ $healthCheck }}
+{{- end }}
 receivers:
   k8s_cluster:
-    collection_interval: 10s
-    allocatable_types_to_report: [cpu, memory, storage]
-    node_conditions_to_report: [Ready, MemoryPressure, DiskPressure, PIDPressure]
+    collection_interval: {{ .Values.cluster.collectionInterval | default "10s" }}
+    allocatable_types_to_report: {{ toYaml (.Values.cluster.allocatableTypesToReport | default (list "cpu" "memory" "storage")) | nindent 6 }}
+    node_conditions_to_report: {{ toYaml (.Values.cluster.nodeConditionsToReport | default (list "Ready" "MemoryPressure" "DiskPressure" "PIDPressure")) | nindent 6 }}
     metrics:
       k8s.pod.status_reason:
         enabled: true
@@ -45,11 +51,7 @@ processors:
     check_interval: 5s
     limit_percentage: 80
     spike_limit_percentage: 25
-  batch:
-    # Send at 5000 items, and cap batches at the same number so the timeout
-    # cannot build one larger than the exporter accepts.
-    send_batch_size: 5000
-    send_batch_max_size: 5000
+  {{- include "opentelemetry-kube-stack.batch" . | nindent 2 }}
 {{- if .Values.resourceDetection.enabled }}
   {{- include "opentelemetry-kube-stack.resourceDetection" . | nindent 2 }}
 {{- end }}
@@ -68,16 +70,7 @@ processors:
   k8s_attributes:
     extract:
       metadata:
-        - k8s.namespace.name
-        - k8s.deployment.name
-        - k8s.statefulset.name
-        - k8s.daemonset.name
-        - k8s.cronjob.name
-        - k8s.job.name
-        - k8s.node.name
-        - k8s.pod.name
-        - k8s.pod.uid
-        - k8s.pod.start_time
+        {{- include "opentelemetry-kube-stack.k8sAttributesMetadata" . | nindent 8 }}
       labels:
         - tag_name: service.name
           key: resource.opentelemetry.io/service.name
@@ -132,6 +125,10 @@ exporters:
   {}
 {{- end }}
 service:
+{{- if $healthCheck }}
+  extensions:
+    - health_check
+{{- end }}
   pipelines:
     logs:
       receivers:

--- a/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
@@ -34,7 +34,8 @@ receivers:
     # container, which is the cost of being able to see which container in a pod
     # is consuming the pod's budget — the question a pod-level total cannot
     # answer. volume adds five per volume.
-    metric_groups: [node, pod, container, volume]
+    metric_groups:
+      {{- toYaml (.Values.agent.kubeletStats.metricGroups | default (list "node" "pod" "container" "volume")) | nindent 6 }}
 {{- if .Values.agent.kubeletStats.usePodsEndpoint }}
     # Both of the blocks below make the receiver call the kubelet's /pods
     # endpoint in addition to /stats/summary: the scraper fetches pod metadata

--- a/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
@@ -1,19 +1,23 @@
 {{- define "tsuga-otel.deamonset.config.default" -}}
+{{- $healthCheck := .Values.agent.healthCheckEndpoint | default "" }}
+{{- if $healthCheck }}
 extensions:
   health_check:
-    endpoint: ${env:MY_POD_IP}:13133
+    endpoint: {{ $healthCheck }}
+{{- end }}
 receivers:
 {{- if .Values.agent.collectLogs }}
   file_log:
-  {{- if not .Values.agent.collectOtelLogs }}
-    # Exclude the collector's own container logs to avoid a self-ingestion
-    # feedback loop (the operator names the collector container "otc-container").
+    # User excludes and the self-ingestion excludes are merged here. Rendering
+    # them in one place matters: a user exclude used to be dropped whenever
+    # collectOtelLogs was true, because the whole key was inside that guard.
+    {{- $exclude := concat (.Values.agent.fileLog.exclude | default list) (ternary (list) (list "/var/log/pods/*/otc-container/*.log" "/var/log/pods/*/otel-collector/*.log") (.Values.agent.collectOtelLogs | default false)) }}
+    {{- if $exclude }}
     exclude:
-      - /var/log/pods/*/otc-container/*.log
-      - /var/log/pods/*/otel-collector/*.log
-  {{- end }}
+      {{- toYaml $exclude | nindent 6 }}
+    {{- end }}
     include:
-      - /var/log/pods/*/*/*.log
+      {{- toYaml (.Values.agent.fileLog.include | default (list "/var/log/pods/*/*/*.log")) | nindent 6 }}
     include_file_name: false
     include_file_path: true
     operators:
@@ -25,10 +29,13 @@ receivers:
     start_at: end
   {{- end }}
   kubelet_stats:
-    auth_type: serviceAccount
-    collection_interval: 20s
+    auth_type: {{ .Values.agent.kubeletStats.authType | default "serviceAccount" }}
+    collection_interval: {{ .Values.agent.kubeletStats.collectionInterval | default "20s" }}
     endpoint: ${env:NODE_IP}:10250
-    insecure_skip_verify: true
+    insecure_skip_verify: {{ ne .Values.agent.kubeletStats.insecureSkipVerify false }}
+    {{- with .Values.agent.kubeletStats.caFile }}
+    ca_file: {{ . }}
+    {{- end }}
     # container is included deliberately, reversing an earlier decision to omit
     # it "to manage cardinality". It adds eleven default-on metrics per
     # container, which is the cost of being able to see which container in a pod
@@ -73,7 +80,7 @@ receivers:
 {{- end }}
   host_metrics:
     root_path: /hostfs
-    collection_interval: 10s
+    collection_interval: {{ .Values.agent.hostMetrics.collectionInterval | default "10s" }}
     scrapers:
       paging:
         metrics:
@@ -155,33 +162,24 @@ receivers:
       {{- end }}
   otlp:
     protocols:
+      {{- with .Values.agent.otlp.grpcEndpoint }}
       grpc:
-        endpoint: ${env:MY_POD_IP}:4317
+        endpoint: {{ . }}
+      {{- end }}
+      {{- with .Values.agent.otlp.httpEndpoint }}
       http:
-        endpoint: ${env:MY_POD_IP}:4318
+        endpoint: {{ . }}
+      {{- end }}
 
 processors:
-  batch:
-    # Send at 5000 items, and cap batches at the same number so the timeout
-    # cannot build one larger than the exporter accepts.
-    send_batch_size: 5000
-    send_batch_max_size: 5000
+  {{- include "opentelemetry-kube-stack.batch" . | nindent 2 }}
 {{- if .Values.resourceDetection.enabled }}
   {{- include "opentelemetry-kube-stack.resourceDetection" . | nindent 2 }}
 {{- end }}
   k8s_attributes:
     extract:
       metadata:
-        - k8s.namespace.name
-        - k8s.deployment.name
-        - k8s.statefulset.name
-        - k8s.daemonset.name
-        - k8s.cronjob.name
-        - k8s.job.name
-        - k8s.node.name
-        - k8s.pod.name
-        - k8s.pod.uid
-        - k8s.pod.start_time
+        {{- include "opentelemetry-kube-stack.k8sAttributesMetadata" . | nindent 8 }}
       labels:
         - tag_name: service.name
           key: resource.opentelemetry.io/service.name
@@ -260,15 +258,16 @@ exporters:
   {}
 {{- end }}
 connectors:
+{{- if ne .Values.agent.spanMetrics.enabled false }}
   span_metrics:
     dimensions:
-      - name: http.request.method
-        default: GET
-      - name: http.response.status_code
-      - name: http.route
+      {{- toYaml .Values.agent.spanMetrics.dimensions | nindent 6 }}
+{{- end }}
 service:
+{{- if $healthCheck }}
   extensions:
     - health_check
+{{- end }}
   pipelines:
     logs:
       receivers:
@@ -297,7 +296,9 @@ service:
       receivers:
         - otlp
         - kubelet_stats
+{{- if ne .Values.agent.spanMetrics.enabled false }}
         - span_metrics
+{{- end }}
         - host_metrics
       processors:
         - memory_limiter
@@ -318,7 +319,9 @@ service:
         {{- if ne (index .Values "tsuga" "enabledForDaemonset") false }}
         - otlp_http/tsuga
         {{- end }}
+        {{- if ne .Values.agent.spanMetrics.enabled false }}
         - span_metrics
+        {{- end }}
       processors:
         - memory_limiter
 {{- if .Values.resourceDetection.enabled }}

--- a/charts/opentelemetry-kube-stack/templates/_default-statefulset-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-statefulset-config.tpl
@@ -1,4 +1,10 @@
 {{- define "tsuga-otel.statefulset.config.default" -}}
+{{- $healthCheck := .Values.statefulset.healthCheckEndpoint | default "" }}
+{{- if $healthCheck }}
+extensions:
+  health_check:
+    endpoint: {{ $healthCheck }}
+{{- end }}
 receivers:
   prometheus:
     config:
@@ -6,12 +12,12 @@ receivers:
         # This placeholder config is required but the Target Allocator
         # will override it with dynamically discovered targets
         - job_name: 'otel-collector'
-          scrape_interval: 30s
+          scrape_interval: {{ .Values.statefulset.scrapeInterval | default "30s" }}
           static_configs:
             - targets: ['localhost:8888']
     target_allocator:
       endpoint: http://{{ include "opentelemetry-kube-stack.fullname" . }}-ta:80
-      interval: 30s
+      interval: {{ .Values.statefulset.scrapeInterval | default "30s" }}
       collector_id: ${POD_NAME}
 
 processors:
@@ -19,9 +25,7 @@ processors:
     check_interval: 5s
     limit_percentage: 80
     spike_limit_percentage: 25
-  batch:
-    send_batch_size: 5000
-    send_batch_max_size: 5000
+  {{- include "opentelemetry-kube-stack.batch" . | nindent 2 }}
   # Runs before enrichment in the pipeline: delta state is keyed on the full
   # resource, so a series that starts unenriched and later gains pod metadata
   # would look like a new series and lose a datapoint to initial_value: auto.
@@ -32,16 +36,7 @@ processors:
   k8s_attributes:
     extract:
       metadata:
-        - k8s.namespace.name
-        - k8s.deployment.name
-        - k8s.statefulset.name
-        - k8s.daemonset.name
-        - k8s.cronjob.name
-        - k8s.job.name
-        - k8s.node.name
-        - k8s.pod.name
-        - k8s.pod.uid
-        - k8s.pod.start_time
+        {{- include "opentelemetry-kube-stack.k8sAttributesMetadata" . | nindent 8 }}
       labels:
         - tag_name: service.name
           key: resource.opentelemetry.io/service.name
@@ -99,6 +94,10 @@ exporters:
   {}
 {{- end }}
 service:
+{{- if $healthCheck }}
+  extensions:
+    - health_check
+{{- end }}
   pipelines:
     metrics:
       receivers:

--- a/charts/opentelemetry-kube-stack/tests/cluster-receiver_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/cluster-receiver_test.yaml
@@ -261,3 +261,55 @@ tests:
       - equal:
           path: spec.config.service.pipelines["logs/events"].processors
           value: [memory_limiter, resourcedetection, transform/k8s_event_severity, resource, batch]
+
+  - it: should give the cluster receiver a health_check extension
+    set:
+      clusterName: "test-cluster"
+      cluster.enabled: true
+    release:
+      name: "test-release"
+    asserts:
+      # Without this the deployment has no liveness probe, so a wedged cluster
+      # receiver is never restarted.
+      - equal:
+          path: spec.config.extensions.health_check.endpoint
+          value: ${env:MY_POD_IP}:13133
+      - equal:
+          path: spec.config.service.extensions
+          value: [health_check]
+
+  - it: should let the cluster collection interval and reported conditions change
+    set:
+      clusterName: "test-cluster"
+      cluster.enabled: true
+      cluster.collectionInterval: 60s
+      cluster.nodeConditionsToReport: [Ready, NetworkUnavailable]
+      cluster.allocatableTypesToReport: [cpu, memory, pods]
+    release:
+      name: "test-release"
+    asserts:
+      - equal:
+          path: spec.config.receivers.k8s_cluster.collection_interval
+          value: 60s
+      - equal:
+          path: spec.config.receivers.k8s_cluster.node_conditions_to_report
+          value: [Ready, NetworkUnavailable]
+      - equal:
+          path: spec.config.receivers.k8s_cluster.allocatable_types_to_report
+          value: [cpu, memory, pods]
+
+  - it: should let the exporter encoding and compression change
+    set:
+      clusterName: "test-cluster"
+      cluster.enabled: true
+      tsuga.encoding: proto
+      tsuga.compression: zstd
+    release:
+      name: "test-release"
+    asserts:
+      - equal:
+          path: spec.config.exporters['otlp_http/tsuga'].encoding
+          value: proto
+      - equal:
+          path: spec.config.exporters['otlp_http/tsuga'].compression
+          value: zstd

--- a/charts/opentelemetry-kube-stack/tests/daemonset_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/daemonset_test.yaml
@@ -299,6 +299,31 @@ tests:
       - isNull:
           path: spec.config.receivers.kubelet_stats.metrics["container.cpu.usage"]
 
+  - it: should collect only the kubelet metric groups asked for
+    set:
+      clusterName: "test-cluster"
+      agent.enabled: true
+      agent.kubeletStats.metricGroups: [node, pod]
+    release:
+      name: "test-release"
+    asserts:
+      - equal:
+          path: spec.config.receivers.kubelet_stats.metric_groups
+          value: [node, pod]
+
+  - it: should fall back to a usable set of kubelet metric groups
+    set:
+      clusterName: "test-cluster"
+      agent.enabled: true
+      agent.kubeletStats.metricGroups: null
+    release:
+      name: "test-release"
+    asserts:
+      # An empty metric_groups would collect nothing from the kubelet.
+      - equal:
+          path: spec.config.receivers.kubelet_stats.metric_groups
+          value: [node, pod, container, volume]
+
   - it: should avoid the kubelet /pods endpoint when told to
     set:
       clusterName: "test-cluster"

--- a/charts/opentelemetry-kube-stack/tests/daemonset_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/daemonset_test.yaml
@@ -342,3 +342,192 @@ tests:
       - equal:
           path: spec.config.receivers.kubelet_stats.metric_groups
           value: [node, pod, container, volume]
+
+  - it: should let the kubelet TLS settings be tightened
+    set:
+      clusterName: "test-cluster"
+      agent.enabled: true
+      agent.kubeletStats.insecureSkipVerify: false
+      agent.kubeletStats.caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    release:
+      name: "test-release"
+    asserts:
+      - equal:
+          path: spec.config.receivers.kubelet_stats.insecure_skip_verify
+          value: false
+      - equal:
+          path: spec.config.receivers.kubelet_stats.ca_file
+          value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+  - it: should omit ca_file when it is not set
+    set:
+      clusterName: "test-cluster"
+      agent.enabled: true
+    release:
+      name: "test-release"
+    asserts:
+      # An empty ca_file would fail the receiver's own config validation.
+      - isNull:
+          path: spec.config.receivers.kubelet_stats.ca_file
+      - equal:
+          path: spec.config.receivers.kubelet_stats.insecure_skip_verify
+          value: true
+
+  - it: should apply the collection intervals
+    set:
+      clusterName: "test-cluster"
+      agent.enabled: true
+      agent.kubeletStats.collectionInterval: 60s
+      agent.hostMetrics.collectionInterval: 90s
+    release:
+      name: "test-release"
+    asserts:
+      - equal:
+          path: spec.config.receivers.kubelet_stats.collection_interval
+          value: 60s
+      - equal:
+          path: spec.config.receivers.host_metrics.collection_interval
+          value: 90s
+
+  - it: should honour a user log exclude even when collecting its own logs
+    set:
+      clusterName: "test-cluster"
+      agent.enabled: true
+      agent.collectOtelLogs: true
+      agent.fileLog.exclude: ["/var/log/pods/kube-system_*/*/*.log"]
+    release:
+      name: "test-release"
+    asserts:
+      # Regression guard: the exclude key used to live inside the
+      # `not collectOtelLogs` branch, so a user exclude vanished whenever
+      # collectOtelLogs was true.
+      - equal:
+          path: spec.config.receivers.file_log.exclude
+          value: ["/var/log/pods/kube-system_*/*/*.log"]
+
+  - it: should merge user excludes with the self-ingestion excludes
+    set:
+      clusterName: "test-cluster"
+      agent.enabled: true
+      agent.fileLog.exclude: ["/var/log/pods/kube-system_*/*/*.log"]
+    release:
+      name: "test-release"
+    asserts:
+      - equal:
+          path: spec.config.receivers.file_log.exclude
+          value:
+            - /var/log/pods/kube-system_*/*/*.log
+            - /var/log/pods/*/otc-container/*.log
+            - /var/log/pods/*/otel-collector/*.log
+
+  - it: should narrow the log include paths
+    set:
+      clusterName: "test-cluster"
+      agent.enabled: true
+      agent.fileLog.include: ["/var/log/pods/prod_*/*/*.log"]
+    release:
+      name: "test-release"
+    asserts:
+      - equal:
+          path: spec.config.receivers.file_log.include
+          value: ["/var/log/pods/prod_*/*/*.log"]
+
+  - it: should remove span metrics entirely when disabled
+    set:
+      clusterName: "test-cluster"
+      agent.enabled: true
+      agent.spanMetrics.enabled: false
+    release:
+      name: "test-release"
+    asserts:
+      # The connector and both pipeline references must all go, or the collector
+      # rejects the config with an unknown component reference.
+      - isNull:
+          path: spec.config.connectors
+      - equal:
+          path: spec.config.service.pipelines.metrics.receivers
+          value: [otlp, kubelet_stats, host_metrics]
+      - equal:
+          path: spec.config.service.pipelines.traces.exporters
+          value: [otlp_http/tsuga]
+
+  - it: should let span metric dimensions be replaced
+    set:
+      clusterName: "test-cluster"
+      agent.enabled: true
+      agent.spanMetrics.dimensions:
+        - name: rpc.method
+    release:
+      name: "test-release"
+    asserts:
+      - equal:
+          path: spec.config.connectors.span_metrics.dimensions
+          value:
+            - name: rpc.method
+
+  - it: should let the OTLP listen addresses be changed
+    set:
+      clusterName: "test-cluster"
+      agent.enabled: true
+      agent.otlp.grpcEndpoint: 0.0.0.0:14317
+      agent.otlp.httpEndpoint: ""
+    release:
+      name: "test-release"
+    asserts:
+      - equal:
+          path: spec.config.receivers.otlp.protocols.grpc.endpoint
+          value: 0.0.0.0:14317
+      # An empty endpoint drops the protocol rather than binding port 0.
+      - isNull:
+          path: spec.config.receivers.otlp.protocols.http
+
+  - it: should apply the shared batch and metadata settings
+    set:
+      clusterName: "test-cluster"
+      agent.enabled: true
+      batch.sendBatchSize: 1000
+      batch.sendBatchMaxSize: 2000
+      batch.timeout: 5s
+      k8sAttributes.metadata: [k8s.namespace.name, k8s.node.name]
+    release:
+      name: "test-release"
+    asserts:
+      - equal:
+          path: spec.config.processors.batch.send_batch_size
+          value: 1000
+      - equal:
+          path: spec.config.processors.batch.send_batch_max_size
+          value: 2000
+      - equal:
+          path: spec.config.processors.batch.timeout
+          value: 5s
+      - equal:
+          path: spec.config.processors.k8s_attributes.extract.metadata
+          value: [k8s.namespace.name, k8s.node.name]
+
+  - it: should omit the batch timeout by default
+    set:
+      clusterName: "test-cluster"
+      agent.enabled: true
+    release:
+      name: "test-release"
+    asserts:
+      # Left unset so the processor's own 200ms default applies.
+      - isNull:
+          path: spec.config.processors.batch.timeout
+
+  - it: should drop the health_check extension when the endpoint is empty
+    set:
+      clusterName: "test-cluster"
+      agent.enabled: true
+      agent.healthCheckEndpoint: ""
+    release:
+      name: "test-release"
+    asserts:
+      - isNull:
+          path: spec.config.extensions
+      # buildService always emits the key, so it renders as an empty list
+      # rather than being omitted.
+      - equal:
+          path: spec.config.service.extensions
+          value: []

--- a/charts/opentelemetry-kube-stack/tests/statefulset_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/statefulset_test.yaml
@@ -123,3 +123,32 @@ tests:
       - equal:
           path: spec.config.service.pipelines.metrics.processors
           value: [memory_limiter, cumulativetodelta, resourcedetection, k8s_attributes, resource, batch]
+
+  - it: should give the statefulset collector a health_check extension
+    set:
+      clusterName: "test-cluster"
+      targetAllocator.enabled: true
+    release:
+      name: "test-release"
+    asserts:
+      - equal:
+          path: spec.config.extensions.health_check.endpoint
+          value: ${env:MY_POD_IP}:13133
+      - equal:
+          path: spec.config.service.extensions
+          value: [health_check]
+
+  - it: should apply the scrape interval to both the scrape config and the allocator
+    set:
+      clusterName: "test-cluster"
+      targetAllocator.enabled: true
+      statefulset.scrapeInterval: 60s
+    release:
+      name: "test-release"
+    asserts:
+      - equal:
+          path: spec.config.receivers.prometheus.config.scrape_configs[0].scrape_interval
+          value: 60s
+      - equal:
+          path: spec.config.receivers.prometheus.target_allocator.interval
+          value: 60s

--- a/charts/opentelemetry-kube-stack/values.schema.json
+++ b/charts/opentelemetry-kube-stack/values.schema.json
@@ -122,6 +122,31 @@
                 "extraLabelMapping": {
                     "type": "array"
                 },
+                "fileLog": {
+                    "type": "object",
+                    "properties": {
+                        "exclude": {
+                            "type": "array"
+                        },
+                        "include": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "healthCheckEndpoint": {
+                    "type": "string"
+                },
+                "hostMetrics": {
+                    "type": "object",
+                    "properties": {
+                        "collectionInterval": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "hostNetwork": {
                     "type": "boolean"
                 },
@@ -131,6 +156,18 @@
                 "kubeletStats": {
                     "type": "object",
                     "properties": {
+                        "authType": {
+                            "type": "string"
+                        },
+                        "caFile": {
+                            "type": "string"
+                        },
+                        "collectionInterval": {
+                            "type": "string"
+                        },
+                        "insecureSkipVerify": {
+                            "type": "boolean"
+                        },
                         "metricGroups": {
                             "type": "array",
                             "items": {
@@ -145,8 +182,41 @@
                 "nodeSelector": {
                     "type": "object"
                 },
+                "otlp": {
+                    "type": "object",
+                    "properties": {
+                        "grpcEndpoint": {
+                            "type": "string"
+                        },
+                        "httpEndpoint": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "resources": {
                     "type": "object"
+                },
+                "spanMetrics": {
+                    "type": "object",
+                    "properties": {
+                        "dimensions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "default": {
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
                 },
                 "tolerations": {
                     "type": "array"
@@ -176,11 +246,34 @@
                 }
             }
         },
+        "batch": {
+            "type": "object",
+            "properties": {
+                "sendBatchMaxSize": {
+                    "type": "integer"
+                },
+                "sendBatchSize": {
+                    "type": "integer"
+                },
+                "timeout": {
+                    "type": "string"
+                }
+            }
+        },
         "cluster": {
             "type": "object",
             "properties": {
                 "affinity": {
                     "type": "object"
+                },
+                "allocatableTypesToReport": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "collectionInterval": {
+                    "type": "string"
                 },
                 "collectk8sevents": {
                     "type": "boolean"
@@ -267,8 +360,17 @@
                 "extraLabelMapping": {
                     "type": "array"
                 },
+                "healthCheckEndpoint": {
+                    "type": "string"
+                },
                 "image": {
                     "type": "string"
+                },
+                "nodeConditionsToReport": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "nodeSelector": {
                     "type": "object"
@@ -289,6 +391,17 @@
         },
         "image": {
             "type": "string"
+        },
+        "k8sAttributes": {
+            "type": "object",
+            "properties": {
+                "metadata": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
         },
         "nameOverride": {
             "type": "string"
@@ -503,6 +616,9 @@
                 "extraLabelMapping": {
                     "type": "array"
                 },
+                "healthCheckEndpoint": {
+                    "type": "string"
+                },
                 "image": {
                     "type": "string"
                 },
@@ -514,6 +630,9 @@
                 },
                 "resources": {
                     "type": "object"
+                },
+                "scrapeInterval": {
+                    "type": "string"
                 },
                 "tolerations": {
                     "type": "array"
@@ -559,6 +678,9 @@
                 "apiKey": {
                     "type": "string"
                 },
+                "compression": {
+                    "type": "string"
+                },
                 "enabledForClusterReceiver": {
                     "type": "boolean"
                 },
@@ -567,6 +689,9 @@
                 },
                 "enabledForStatefulset": {
                     "type": "boolean"
+                },
+                "encoding": {
+                    "type": "string"
                 },
                 "otlpEndpoint": {
                     "type": "string"

--- a/charts/opentelemetry-kube-stack/values.schema.json
+++ b/charts/opentelemetry-kube-stack/values.schema.json
@@ -131,6 +131,12 @@
                 "kubeletStats": {
                     "type": "object",
                     "properties": {
+                        "metricGroups": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
                         "usePodsEndpoint": {
                             "type": "boolean"
                         }

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -38,11 +38,13 @@
 #
 # This chart uses a flexible configuration system with two approaches:
 #
-# 1. MERGE-BASED (Recommended): Uses default configs + your overrides
-#    - Default configs are defined in _default-deamonset-config.tpl and
-#      _default-cluster-receiver-config.tpl
-#    - Use extraReceivers, extraProcessors, extraExporters to add to defaults
-#    - Example: agent.config.extraReceivers adds to default receivers
+# 1. MERGE-BASED (Recommended): Uses default configs + additions
+#    - Default configs are defined in _default-deamonset-config.tpl,
+#      _default-cluster-receiver-config.tpl and _default-statefulset-config.tpl
+#    - Use extraReceivers, extraProcessors, extraExporters to ADD components
+#    - These can only add. A key that the chart already sets is NOT overridden:
+#      the merge keeps the chart's value and silently drops yours. To change a
+#      default, use the dedicated value for it, or customConfig below.
 #
 # 2. FULL CUSTOM: Provide complete OpenTelemetry config
 #    - Set customConfig with your complete YAML configuration
@@ -369,7 +371,9 @@ cluster:
   #           exporters: [otlp_http/tsuga]
   # @default -- {}
   customConfig: {}
-  # This is used in the Kubernetes view to show pod configuration
+  # -- Watch pod objects and send them as logs. Powers the Kubernetes view,
+  # which uses them to show pod configuration.
+  # @default -- true
   collectk8sobjects: true
   # Worth enabling. Events are the only source for OOMKilled, FailedScheduling,
   # Evicted, ErrImagePull, FailedMount and failing probes — no metric receiver
@@ -389,8 +393,10 @@ cluster:
   collectk8sevents: false
   # -- Gateway collector configuration (merge-based approach)
   # Use this to extend the default configuration
-  # Default receivers: k8s_cluster, k8s_objects (when cluster.collectk8sobjects)
-  # Default processors: memory_limiter, k8s_attributes, resource, batch
+  # Default receivers: k8s_cluster, k8s_objects (when cluster.collectk8sobjects),
+  # k8s_objects/events (when cluster.collectk8sevents)
+  # Default processors: memory_limiter, resourcedetection (when
+  # resourceDetection.enabled), k8s_attributes, resource, batch
   config:
     # -- Additional telemetry to merge into the collector configuration
     # Merges with default telemetry
@@ -664,9 +670,10 @@ agent:
   # -- Agent collector configuration (merge-based approach)
   # Use this to extend the default configuration
   # Default receivers: file_log (when agent.collectLogs), kubelet_stats, host_metrics, otlp
-  # Default processors: memory_limiter, cumulativetodelta, k8s_attributes,
-  # resource, resource/node, batch
-  # Default connectors: span_metrics
+  # Default processors: memory_limiter, cumulativetodelta, resourcedetection
+  # (when resourceDetection.enabled), k8s_attributes, resource, resource/node,
+  # batch
+  # Default connectors: span_metrics (when agent.spanMetrics.enabled)
   config:
     # -- Additional telemetry to merge into the collector configuration
     # Merges with default telemetry (Prometheus metrics on port 8888)

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -557,9 +557,9 @@ agent:
   # -- OTLP receiver listen addresses
   otlp:
     # With `hostNetwork: true` these bind on the node's own IP, so they conflict
-    # with any other agent on the node already holding the port — a Datadog
-    # agent or a second collector DaemonSet. Change the port here if that
-    # happens. Use `0.0.0.0:4317` to listen on all interfaces.
+    # with anything else on the node already holding the port — another
+    # monitoring agent, or a second collector DaemonSet. Change the port here if
+    # that happens. Use `0.0.0.0:4317` to listen on all interfaces.
     # -- gRPC listen address. Set to "" to disable the gRPC protocol.
     # @default -- "${env:MY_POD_IP}:4317"
     grpcEndpoint: "${env:MY_POD_IP}:4317"

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -109,11 +109,16 @@ image: ""
 # only cloud.provider and cloud.platform, and ec2 is what adds cloud.region,
 # cloud.account.id, cloud.availability_zone, host.id and host.name.
 #
-# Do NOT list eks off EKS. KUBERNETES_SERVICE_HOST is set on every Kubernetes
-# cluster, so its check falls through to the Kubernetes API and can error on
-# GKE, AKS or kind, which prevents startup. ec2, gcp, azure and aks are safe to
-# list anywhere: they return an empty resource, without error, when their
-# metadata service is unreachable.
+# Prefer leaving eks out unless you are on EKS. KUBERNETES_SERVICE_HOST is set
+# on every Kubernetes cluster, so the detector's own check falls through to a
+# Kubernetes API call rather than short-circuiting. That call failing is what
+# would stop the collector from starting — not merely finding nothing. Tested
+# on Docker Desktop with [env, eks, ec2]: every collector started and the
+# detector returned an empty resource without error. So this is a risk to avoid
+# taking, not a guaranteed breakage.
+#
+# ec2, gcp, azure and aks are safe to list anywhere: they return an empty
+# resource, without error, when their metadata service is unreachable.
 #
 # k8snode is unsupported. It reads the node object from the Kubernetes API and
 # fails startup if that call fails, and the only attribute it adds that this

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -469,6 +469,17 @@ agent:
 
   # -- kubelet_stats receiver options
   kubeletStats:
+    # container adds roughly eleven default-on metrics per container and volume
+    # five per volume, so this is the knob for kubelet metric cardinality. node
+    # and pod are the minimum useful set.
+    # -- Kubelet metric groups to collect
+    # @default -- [node, pod, container, volume]
+    metricGroups:
+      - node
+      - pod
+      - container
+      - volume
+
     # The receiver calls the kubelet /pods endpoint, on top of /stats/summary,
     # whenever volume type labels or any limit/request utilization metric are
     # requested. If that call fails it discards the ENTIRE scrape for the

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -216,6 +216,52 @@ tsuga:
   # -- Enable Tsuga OTLP exporter for the StatefulSet collector (when targetAllocator is enabled)
   # @default -- true
   enabledForStatefulset: true
+  # `proto` sends roughly 2-3x fewer bytes over the wire than `json`, even after
+  # compression, so it is the cheaper choice where the intake accepts it.
+  # -- Payload encoding for the OTLP exporter. One of `json`, `proto`.
+  # @default -- "json"
+  encoding: json
+  # -- Compression for the OTLP exporter. One of `gzip`, `zstd`, `snappy`, `none`.
+  # @default -- "gzip"
+  compression: gzip
+
+# =============================================================================
+# SHARED PROCESSOR CONFIGURATION
+# =============================================================================
+# Applies to all three collectors (agent, cluster receiver, statefulset).
+
+k8sAttributes:
+  # Every entry is added to each log record, metric series and span. Dropping
+  # `k8s.pod.name` and `k8s.pod.uid` cuts metric cardinality noticeably, because
+  # both change on every pod restart and so churn the series on each rollout —
+  # at the cost of not being able to identify individual pods.
+  # -- Kubernetes metadata to attach to telemetry.
+  # @default -- see values.yaml
+  metadata:
+    - k8s.namespace.name
+    - k8s.deployment.name
+    - k8s.statefulset.name
+    - k8s.daemonset.name
+    - k8s.cronjob.name
+    - k8s.job.name
+    - k8s.node.name
+    - k8s.pod.name
+    - k8s.pod.uid
+    - k8s.pod.start_time
+
+batch:
+  # -- Item count that triggers a send.
+  # @default -- 5000
+  sendBatchSize: 5000
+  # -- Hard cap on items per batch. Lower this if the backend rejects large
+  # requests. Keeping it equal to sendBatchSize means a timeout can never build
+  # an oversized batch.
+  # @default -- 5000
+  sendBatchMaxSize: 5000
+  # -- Maximum time to wait before sending an undersized batch, e.g. `5s`.
+  # Empty uses the processor's own default of 200ms.
+  # @default -- ""
+  timeout: ""
 
 # =============================================================================
 # SECRET CONFIGURATION
@@ -265,6 +311,31 @@ cluster:
   # -- Enable cluster receiver (gateway) deployment
   # @default -- true
   enabled: true
+  # Datapoint volume scales inversely with this: every object in the informer
+  # cache is re-reported on each pass, so 10s produces six times the datapoints
+  # of 60s. Raise it to cut ingest on large clusters.
+  # -- How often to collect cluster metrics, e.g. `30s`.
+  # @default -- "10s"
+  collectionInterval: 10s
+  # -- Node conditions reported as metrics. Add `NetworkUnavailable`, or the
+  # custom conditions node-problem-detector writes, to alert on them.
+  # @default -- [Ready, MemoryPressure, DiskPressure, PIDPressure]
+  nodeConditionsToReport:
+    - Ready
+    - MemoryPressure
+    - DiskPressure
+    - PIDPressure
+  # -- Node allocatable resource types reported as metrics. `pods` and
+  # `ephemeral-storage` are also valid.
+  # @default -- [cpu, memory, storage]
+  allocatableTypesToReport:
+    - cpu
+    - memory
+    - storage
+  # -- Address for the health_check extension, which backs the liveness probe.
+  # Set to "" to omit the extension entirely.
+  # @default -- "${env:MY_POD_IP}:13133"
+  healthCheckEndpoint: "${env:MY_POD_IP}:13133"
   # -- OpenTelemetry Collector image for cluster receiver
   # Defaults to: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s
   # @default -- ""
@@ -467,8 +538,83 @@ agent:
   # @default -- true
   addLogsVolumes: true
 
+  # -- Address for the health_check extension, which backs the liveness probe.
+  # Set to "" to omit the extension entirely.
+  # @default -- "${env:MY_POD_IP}:13133"
+  healthCheckEndpoint: "${env:MY_POD_IP}:13133"
+
+  # -- OTLP receiver listen addresses
+  otlp:
+    # With `hostNetwork: true` these bind on the node's own IP, so they conflict
+    # with any other agent on the node already holding the port — a Datadog
+    # agent or a second collector DaemonSet. Change the port here if that
+    # happens. Use `0.0.0.0:4317` to listen on all interfaces.
+    # -- gRPC listen address. Set to "" to disable the gRPC protocol.
+    # @default -- "${env:MY_POD_IP}:4317"
+    grpcEndpoint: "${env:MY_POD_IP}:4317"
+    # -- HTTP listen address. Set to "" to disable the HTTP protocol.
+    # @default -- "${env:MY_POD_IP}:4318"
+    httpEndpoint: "${env:MY_POD_IP}:4318"
+
+  # -- file_log receiver paths (used when collectLogs is true)
+  fileLog:
+    # -- Log file globs to read.
+    # @default -- ["/var/log/pods/*/*/*.log"]
+    include:
+      - /var/log/pods/*/*/*.log
+    # Narrowing this is the single biggest log-cost lever in the chart: excluding
+    # a noisy namespace, e.g. `/var/log/pods/kube-system_*/*/*.log`, drops those
+    # records before they are ever read. The collector's own logs are excluded
+    # separately, via collectOtelLogs.
+    # -- Log file globs to skip.
+    # @default -- []
+    exclude: []
+
+  # -- host_metrics receiver options
+  hostMetrics:
+    # Datapoint volume scales inversely with this, across every node in the
+    # cluster, so 10s costs six times what 60s does.
+    # -- How often to collect host metrics, e.g. `60s`.
+    # @default -- "10s"
+    collectionInterval: 10s
+
+  # -- span_metrics connector options (RED metrics generated from spans)
+  spanMetrics:
+    # -- Generate metrics from spans.
+    # @default -- true
+    enabled: true
+    # `http.route` is a route template in frameworks that expose one, and a raw
+    # path in those that do not (Express, raw net/http, some gRPC gateways) —
+    # where it becomes unbounded, one histogram set per distinct URL. Drop it if
+    # your services cannot template routes.
+    # -- Span attributes to keep as metric dimensions. `default` supplies a value
+    # when the attribute is absent.
+    # @default -- see values.yaml
+    dimensions:
+      - name: http.request.method
+        default: GET
+      - name: http.response.status_code
+      - name: http.route
+
   # -- kubelet_stats receiver options
   kubeletStats:
+    # -- How often to collect kubelet metrics, e.g. `60s`.
+    # @default -- "20s"
+    collectionInterval: 20s
+    # -- Kubelet authentication method. One of `serviceAccount`, `tls`, `none`.
+    # @default -- "serviceAccount"
+    authType: serviceAccount
+    # Kubelets normally serve a self-signed certificate, which is why this
+    # defaults to true. Set it to false and supply caFile where policy requires
+    # the kubelet's serving certificate to be verified.
+    # -- Skip verification of the kubelet's serving certificate.
+    # @default -- true
+    insecureSkipVerify: true
+    # -- CA bundle path used to verify the kubelet, e.g.
+    # `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`. Requires
+    # insecureSkipVerify to be false, and the file to be mounted in the pod.
+    # @default -- ""
+    caFile: ""
     # container adds roughly eleven default-on metrics per container and volume
     # five per volume, so this is the knob for kubelet metric cardinality. node
     # and pod are the minimum useful set.
@@ -734,6 +880,14 @@ statefulset:
   # The Target Allocator distributes targets evenly across replicas.
   # @default -- 1
   replicas: 1
+  # -- How often to scrape Prometheus targets, e.g. `60s`. Also the interval at
+  # which the collector refreshes its target list from the Target Allocator.
+  # @default -- "30s"
+  scrapeInterval: 30s
+  # -- Address for the health_check extension, which backs the liveness probe.
+  # Set to "" to omit the extension entirely.
+  # @default -- "${env:MY_POD_IP}:13133"
+  healthCheckEndpoint: "${env:MY_POD_IP}:13133"
   # -- OpenTelemetry Collector image for statefulset collector
   # @default -- ""
   image: ""


### PR DESCRIPTION
Two halves: new chart values for settings that were hardcoded, and a README correction pass.

## Part 1 — new values

Settings hardcoded in the default collector configs could not be changed. `extraReceivers` looks like the escape hatch, but `templates/_otel_config.yaml` merges with `merge $receivers .extraReceivers`, and Helm's `merge` lets the destination win — so it can only *add* components. Overriding a key the chart already sets is silently discarded, with no error and no warning.

This exposes 25 of them as chart values. **Every default is unchanged.**

| Area | Values |
|---|---|
| Exporter | `tsuga.encoding` (`json`), `tsuga.compression` (`gzip`) |
| Intervals | `agent.kubeletStats.collectionInterval` (`20s`), `agent.hostMetrics.collectionInterval` (`10s`), `cluster.collectionInterval` (`10s`), `statefulset.scrapeInterval` (`30s`) |
| Log collection | `agent.fileLog.include`, `agent.fileLog.exclude` |
| Span metrics | `agent.spanMetrics.enabled`, `agent.spanMetrics.dimensions` |
| Listen addresses | `agent.otlp.grpcEndpoint`, `agent.otlp.httpEndpoint`, and `healthCheckEndpoint` on all three collectors |
| Kubelet | `metricGroups`, `authType`, `insecureSkipVerify`, `caFile` |
| Shared | `k8sAttributes.metadata`, `batch.sendBatchSize`, `batch.sendBatchMaxSize`, `batch.timeout` |
| Cluster metrics | `cluster.nodeConditionsToReport`, `cluster.allocatableTypesToReport` |

Setting an endpoint to `""` drops that protocol or extension entirely.

### Fixed

- **The cluster receiver and statefulset collectors had no `health_check` extension**, so neither had a liveness probe and a wedged collector was never restarted. Only the daemonset had one. This is the only intended change to rendered output.
- **`agent.fileLog.exclude` was discarded when `agent.collectOtelLogs` was true**, because the whole `exclude` key sat inside the `not collectOtelLogs` guard.

`batch` and the `k8s_attributes` metadata list are now shared defines in `_config.tpl` rather than triplicated, matching the existing pattern for `resourceDetection` and `tsugaExporters`.

## Part 2 — README correction

An audit found documentation describing a chart we do not ship. Prose fixes are in `README.md.gotmpl`, since `README.md` is generated.

- **`agent.config.additionalConfig` does not exist** — not in `values.yaml`, the templates, or the schema. And `values.schema.json` sets no `additionalProperties`, so the two examples using it installed cleanly and did nothing. Replaced with `agent.spanMetrics.dimensions`.
- Both examples also used connector key **`spanmetrics`**; the chart's is **`span_metrics`**.
- **The agent does not collect Kubernetes objects** (that is the cluster receiver), and **there is no agent-to-cluster-receiver path** — its only exporter is `otlp_http/tsuga`.
- `k8s_objects` watches **pods only**.
- **The StatefulSet collector and Target Allocator were undocumented**; Architecture claimed two components. Added a section.
- **`resourcedetection` was missing** from every processor list and all six pipeline lines. Conditional components are now marked in `[brackets]`.
- The **Warning events receiver, transform and `logs/events` pipeline** from 0.10.5 were also missing.
- **Self-telemetry does not reach Tsuga** — the operator webhook replaces the OTLP reader with a Prometheus reader on `:8888`. Now stated, and links `docs/collector-internal-metrics.md`.
- Removed a pointer to a troubleshooting section that does not exist.
- `cluster.collectk8sobjects` had no `# --` marker, so its table cell rendered empty.
- Corrected the stale `Default processors:` lists in `values.yaml`.
- **Stopped promising overrides that cannot happen.** The README and the `values.yaml` header said `extra*` overrides defaults; they now say it can only add.

The `eks` detector warning is also softened in its own commit. It stated as fact that listing `eks` off-EKS prevents startup; a local deployment on Docker Desktop with `[env, eks, ec2]` contradicted that — all collectors started and the detector returned an empty resource without error. Startup only fails if the API call errors outright, so it is now worded as a risk to avoid rather than a certainty.
