### PR TITLE
Derive service.name and service.version from Kubernetes metadata

### DIFF
--- a/charts/opentelemetry-kube-stack/CHANGELOG.md
+++ b/charts/opentelemetry-kube-stack/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [opentelemetry-kube-stack-0.12.0] - 2026-07-30
+
+### Added
+- agent.deriveServiceIdentity resolves service.name and service.version from Kubernetes metadata, following the chain OpenTelemetry's semantic conventions define: the resource.opentelemetry.io/service.name annotation, then the app.kubernetes.io/instance and app.kubernetes.io/name labels, then the name of the owning workload. Off by default. It also clears the SDK placeholder first, which is what makes the chain apply at all: an instrumented workload that never set a name emits service.name=unknown_service:<executable>, and the k8s_attributes processor writes only to a key that is absent or empty, so without this every service name it derives for such a pod is computed and discarded. Agent only — the cluster receiver watches Kubernetes objects rather than service-emitted telemetry.
+
+### Upgrade notes
+- deriveServiceIdentity is off by default and the rendered config is unchanged until you set it. Semantic conventions ask that deriving identity from well-known labels be opt-in, because users may not know their labels are being read this way.
+- Enabling it on an existing install renames services. Anything reporting as unknown_service:* becomes its workload name, and container logs and pod metrics that carry no service name today start creating one service entry per workload — on a 21-pod test cluster, kubeletstats went from 2 distinct service names to 15.
+- A workload that sets its own name via OTEL_SERVICE_NAME keeps it, but that name is invisible to Kubernetes, so the same pod's container logs and pod metrics resolve to the workload name instead and the workload appears under two identities. Give such pods a resource.opentelemetry.io/service.name annotation matching their OTEL_SERVICE_NAME to keep every signal on one name.
+- If you map your own label keys, prefer extraAnnotationsMapping over extraLabelMapping. The processor copies the well-known app.kubernetes.io labels over user label rules with an unconditional write, so on a pod carrying both, an extraLabelMapping rule targeting service.name loses — and because that rule works while the flag is off, enabling the flag renames such a pod away from the value it already had. Annotation rules are applied last and win over both.
+- service.version falls back to the container image tag when no version label or annotation is present, so pods running an untagged image report a version of latest.
+
 ## [opentelemetry-kube-stack-0.11.1] - 2026-07-29
 
 ### Fixed

--- a/charts/opentelemetry-kube-stack/Chart.yaml
+++ b/charts/opentelemetry-kube-stack/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.1
+version: 0.12.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-kube-stack/README.md
+++ b/charts/opentelemetry-kube-stack/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-kube-stack
 
-![Version: 0.11.1](https://img.shields.io/badge/Version-0.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
+![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1](https://img.shields.io/badge/AppVersion-v1-informational?style=flat-square)
 
 A comprehensive Helm chart for OpenTelemetry Kubernetes operator with Tsuga integration, featuring dual deployment pattern (agent DaemonSet + cluster receiver), secure credential management, and production-ready configurations for telemetry collection to Tsuga platform.
 
@@ -350,6 +350,7 @@ helm install my-otel-stack ./opentelemetry-kube-stack -f my-values.yaml
 | agent.config.service.pipelines.traces.extraProcessors | list | [] | Additional processors to add to the traces pipeline Added to default processors (memory_limiter, k8s_attributes, resource, resource/node, batch) |
 | agent.config.service.pipelines.traces.extraReceivers | list | [] | Additional receivers to add to the traces pipeline Added to default receivers (otlp) |
 | agent.customConfig | object | {} | Replace default config with complete custom configuration When set, this completely replaces the default collector configuration Use this for full control over the OpenTelemetry Collector config See cluster.customConfig for example format |
+| agent.deriveServiceIdentity | bool | false | Derive service.name and service.version from Kubernetes metadata. |
 | agent.enabled | bool | true | Enable agent daemonset deployment |
 | agent.extraAnnotationsMapping | list | [] | Annotations mapping configuration for agent Maps Kubernetes pod annotations to OpenTelemetry resource attributes These are appended to default annotation mappings Format: List of objects with tag_name, key, and from fields |
 | agent.extraEnvs | list | [] | Extra environment variables for agent These are in addition to automatic secret env vars (TSUGA_API_KEY, TSUGA_OTLP_ENDPOINT, MY_POD_IP) |

--- a/charts/opentelemetry-kube-stack/templates/_config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_config.tpl
@@ -88,6 +88,38 @@ collectors. Emitted as a bare list, so callers supply their own indentation.
 {{- end }}
 
 {{/*
+Clears the SDK's placeholder service name so k8s_attributes can fill a real one.
+
+The SDK side of the problem: semconv requires an SDK to emit
+service.name=unknown_service:<executable> when nothing configured one. The
+collector side: k8s_attributes writes an extracted attribute only when the key
+is absent or empty (setResourceAttribute, processor.go), and it has no override
+flag. A placeholder is neither absent nor empty, so every service.name
+k8s_attributes derives for an instrumented pod is computed and discarded.
+
+Deleting the placeholder first is what upstream recommends for exactly this —
+contrib #43194, closed with the maintainers declining an override option in
+favour of composing the two processors. That makes the ordering load-bearing:
+this must run before k8s_attributes, never after.
+
+Matched as a prefix, not equality, because the spec appends the executable name
+— but anchored on the delimiter. The spec emits only "unknown_service" or
+"unknown_service:<exe>", so a bare ^unknown_service would also swallow a real
+service that merely starts with those letters, and silently rename it.
+*/}}
+{{- define "opentelemetry-kube-stack.clearUnknownService" -}}
+{{- $stmt := `delete_key(resource.attributes, "service.name") where resource.attributes["service.name"] != nil and IsMatch(resource.attributes["service.name"], "^unknown_service(:|$)")` -}}
+transform/clear_unknown_service:
+  error_mode: ignore
+  trace_statements:
+    - '{{ $stmt }}'
+  metric_statements:
+    - '{{ $stmt }}'
+  log_statements:
+    - '{{ $stmt }}'
+{{- end }}
+
+{{/*
 Generate Tsuga exporters configuration
 */}}
 {{- define "opentelemetry-kube-stack.tsugaExporters" -}}

--- a/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
+++ b/charts/opentelemetry-kube-stack/templates/_default-deamonset-config.tpl
@@ -186,10 +186,22 @@ processors:
 {{- if .Values.resourceDetection.enabled }}
   {{- include "opentelemetry-kube-stack.resourceDetection" . | nindent 2 }}
 {{- end }}
+{{- if .Values.agent.deriveServiceIdentity }}
+  {{- include "opentelemetry-kube-stack.clearUnknownService" . | nindent 2 }}
+{{- end }}
   k8s_attributes:
     extract:
       metadata:
         {{- include "opentelemetry-kube-stack.k8sAttributesMetadata" . | nindent 8 }}
+{{- if .Values.agent.deriveServiceIdentity }}
+        # Off by default in the processor, so listing them is what turns the
+        # semconv resolution chain on: the resource.opentelemetry.io/service.name
+        # annotation, then app.kubernetes.io/instance, then /name, then the
+        # owning workload's name. service.version resolves from
+        # app.kubernetes.io/version or the container image tag.
+        - service.name
+        - service.version
+{{- end }}
       labels:
         - tag_name: service.name
           key: resource.opentelemetry.io/service.name
@@ -294,6 +306,9 @@ service:
 {{- if .Values.resourceDetection.enabled }}
         - resource_detection
 {{- end }}
+{{- if .Values.agent.deriveServiceIdentity }}
+        - transform/clear_unknown_service
+{{- end }}
         - k8s_attributes
         - resource
         - resource/node
@@ -316,6 +331,9 @@ service:
 {{- if .Values.resourceDetection.enabled }}
         - resource_detection
 {{- end }}
+{{- if .Values.agent.deriveServiceIdentity }}
+        - transform/clear_unknown_service
+{{- end }}
         - k8s_attributes
         - resource
         - resource/node
@@ -336,6 +354,9 @@ service:
         - memory_limiter
 {{- if .Values.resourceDetection.enabled }}
         - resource_detection
+{{- end }}
+{{- if .Values.agent.deriveServiceIdentity }}
+        - transform/clear_unknown_service
 {{- end }}
         - k8s_attributes
         - resource

--- a/charts/opentelemetry-kube-stack/tests/daemonset_test.yaml
+++ b/charts/opentelemetry-kube-stack/tests/daemonset_test.yaml
@@ -688,3 +688,84 @@ tests:
           path: spec.config.receivers.host_metrics.scrapers.processes
       - notExists:
           path: spec.securityContext
+
+  - it: should not derive service identity by default
+    set:
+      clusterName: "test-cluster"
+      agent.enabled: true
+    release:
+      name: "test-release"
+    asserts:
+      - notExists:
+          path: spec.config.processors["transform/clear_unknown_service"]
+      - notContains:
+          path: spec.config.processors.k8s_attributes.extract.metadata
+          content: service.name
+      - notContains:
+          path: spec.config.processors.k8s_attributes.extract.metadata
+          content: service.version
+      - notContains:
+          path: spec.config.service.pipelines.logs.processors
+          content: transform/clear_unknown_service
+      - notContains:
+          path: spec.config.service.pipelines.metrics.processors
+          content: transform/clear_unknown_service
+      - notContains:
+          path: spec.config.service.pipelines.traces.processors
+          content: transform/clear_unknown_service
+
+  - it: should clear the placeholder before k8s_attributes when deriving service identity
+    set:
+      clusterName: "test-cluster"
+      agent.enabled: true
+      agent.deriveServiceIdentity: true
+    release:
+      name: "test-release"
+    asserts:
+      # Ordering is the whole mechanism: k8s_attributes only writes a key that is
+      # absent, so the delete has to land before it. After it, this is a no-op.
+      - equal:
+          path: spec.config.service.pipelines.logs.processors
+          value: [memory_limiter, transform/clear_unknown_service, k8s_attributes, resource, resource/node, batch]
+      - equal:
+          path: spec.config.service.pipelines.metrics.processors
+          value: [memory_limiter, cumulative_to_delta, transform/clear_unknown_service, k8s_attributes, resource, resource/node, batch]
+      - equal:
+          path: spec.config.service.pipelines.traces.processors
+          value: [memory_limiter, transform/clear_unknown_service, k8s_attributes, resource, resource/node, batch]
+      # Both are enabled: false in the processor, so listing them is what turns
+      # the semconv resolution chain on.
+      - contains:
+          path: spec.config.processors.k8s_attributes.extract.metadata
+          content: service.name
+      - contains:
+          path: spec.config.processors.k8s_attributes.extract.metadata
+          content: service.version
+
+  - it: should clear only the placeholder forms the spec defines
+    set:
+      clusterName: "test-cluster"
+      agent.enabled: true
+      agent.deriveServiceIdentity: true
+    release:
+      name: "test-release"
+    asserts:
+      # The delimiter anchor is load-bearing. A bare ^unknown_service prefix also
+      # matches a real service whose name merely starts with those letters, and
+      # renames it to its workload. Asserted verbatim so that cannot regress.
+      - equal:
+          path: spec.config.processors["transform/clear_unknown_service"].trace_statements
+          value:
+            - 'delete_key(resource.attributes, "service.name") where resource.attributes["service.name"] != nil and IsMatch(resource.attributes["service.name"], "^unknown_service(:|$)")'
+      - equal:
+          path: spec.config.processors["transform/clear_unknown_service"].metric_statements
+          value:
+            - 'delete_key(resource.attributes, "service.name") where resource.attributes["service.name"] != nil and IsMatch(resource.attributes["service.name"], "^unknown_service(:|$)")'
+      - equal:
+          path: spec.config.processors["transform/clear_unknown_service"].log_statements
+          value:
+            - 'delete_key(resource.attributes, "service.name") where resource.attributes["service.name"] != nil and IsMatch(resource.attributes["service.name"], "^unknown_service(:|$)")'
+      # A malformed statement would otherwise fail the batch instead of the record.
+      - equal:
+          path: spec.config.processors["transform/clear_unknown_service"].error_mode
+          value: ignore

--- a/charts/opentelemetry-kube-stack/values.schema.json
+++ b/charts/opentelemetry-kube-stack/values.schema.json
@@ -107,6 +107,9 @@
                 "customConfig": {
                     "type": "object"
                 },
+                "deriveServiceIdentity": {
+                    "type": "boolean"
+                },
                 "enabled": {
                     "type": "boolean"
                 },

--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -749,6 +749,52 @@ agent:
           # @default -- []
           extraReceivers: []
         extraPipelines: {}
+  # Resolves service.name and service.version from Kubernetes metadata, using
+  # the chain OpenTelemetry's semantic conventions define: the
+  # resource.opentelemetry.io/service.name annotation, then the
+  # app.kubernetes.io/instance and app.kubernetes.io/name labels, then the name
+  # of the owning Deployment / StatefulSet / DaemonSet / CronJob / Job.
+  # service.version resolves from app.kubernetes.io/version or the image tag.
+  #
+  # Also clears the SDK placeholder first. An instrumented workload that never
+  # set a service name emits service.name=unknown_service:<executable>, which
+  # k8s_attributes will not overwrite — so without this, spans and metrics from
+  # every such workload stay anonymous no matter what labels the pod carries.
+  # Only that prefix is cleared: a workload that sets its own name, via
+  # OTEL_SERVICE_NAME or otherwise, keeps it.
+  #
+  # Off by default, and deliberately. Semconv asks that deriving identity from
+  # well-known labels be opt-in, because users may not know their labels are
+  # being read this way. On an existing install, turning this on renames
+  # services: anything reporting as unknown_service:* becomes its workload name,
+  # and container logs and pod metrics that carry no service name today will
+  # start creating one service entry per workload.
+  #
+  # For a cluster whose labels do not follow the convention, map your own keys
+  # with extraLabelMapping or extraAnnotationsMapping below.
+  #
+  # If you do, prefer extraAnnotationsMapping. The processor applies label rules,
+  # then copies the well-known labels over the top with an unconditional write,
+  # then applies annotation rules. So on a pod carrying BOTH a custom label and
+  # an app.kubernetes.io/name, an extraLabelMapping rule targeting service.name
+  # loses — and because that rule works today while the flag is off, turning the
+  # flag on renames such a pod away from the value it already had. Annotation
+  # rules are applied last and win over both.
+  #
+  # One more asymmetry to expect: this fills a service name only where none is
+  # present. A workload that sets its own name via OTEL_SERVICE_NAME keeps it on
+  # its spans and OTLP metrics, but that name is invisible to Kubernetes, so the
+  # same pod's container logs and kubeletstats metrics resolve to the workload
+  # name instead and the workload shows up under two identities. Give such pods
+  # a resource.opentelemetry.io/service.name annotation matching their
+  # OTEL_SERVICE_NAME to keep every signal on one name.
+  #
+  # Agent only. The cluster receiver watches Kubernetes objects rather than
+  # service-emitted telemetry, so a service name there would turn every
+  # Deployment into a service.
+  # -- Derive service.name and service.version from Kubernetes metadata.
+  # @default -- false
+  deriveServiceIdentity: false
   # -- Label mapping configuration for agent
   # Maps Kubernetes pod labels to OpenTelemetry resource attributes
   # These are appended to default label mappings


### PR DESCRIPTION
Adds `agent.deriveServiceIdentity`, off by default.

## Why

The `k8s_attributes` processor can already resolve `service.name` and `service.version` from Kubernetes metadata, following the chain [semantic conventions define](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/non-normative/k8s-attributes.md): the `resource.opentelemetry.io/service.name` annotation, then `app.kubernetes.io/instance`, then `app.kubernetes.io/name`, then the name of the owning workload. Those metadata keys are `enabled: false` in the processor, so listing them is what turns the chain on.

On its own, that is not enough for an instrumented workload — and this is the part worth knowing before reviewing:

- Semantic conventions **require** an SDK to emit `service.name` as `unknown_service:<executable>` when nothing configured a name ([spec](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/service.md)).
- `k8s_attributes` writes an extracted attribute only when the key is absent or empty — `setResourceAttribute` in [processor.go](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/processor.go), which has no override option.

A placeholder is neither absent nor empty. So for any SDK-instrumented pod, every service name the processor derives is computed and then discarded, and the telemetry stays anonymous no matter which labels the pod carries. The chart already ships `resource.opentelemetry.io/*` label and annotation mappings, and those are inert for the same reason.

Deleting the placeholder first is what upstream recommends for exactly this case. [contrib #43194](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/43194) reported it and was closed with the maintainers declining to add an override flag:

> Given that the ask can be addressed with extra transform processor, I think we should reject the issue here and keep the k8sattributes processor behavior consistent without special treatment for specific attribute keys.

That composition is what this adds — one OTTL statement, and the ordering is load-bearing, so the transform is inserted immediately before `k8s_attributes` in all three agent pipelines. After it, it would do nothing.

```
delete_key(resource.attributes, "service.name")
  where resource.attributes["service.name"] != nil
    and IsMatch(resource.attributes["service.name"], "^unknown_service(:|$)")
```

The delimiter is anchored deliberately. The spec emits only `unknown_service` or `unknown_service:<exe>`, so a bare `^unknown_service` prefix also matches a real service whose name happens to start with those letters — a workload called `unknown_serviceable-widget` was silently renamed to its Deployment during testing. There is a test asserting the statement verbatim so that cannot regress.

## Scope

Agent only. The cluster receiver watches Kubernetes objects rather than service-emitted telemetry, so a service name there would turn every Deployment into a service. Its config and pod are untouched.

Off by default. Semantic conventions ask for this specifically:

> Tools offering this functionality should provide an opt-in flag for the use of well-known labels, since users may not be aware that their labels are being used for this purpose.

With the flag off the rendered config is byte-identical to `main` — verified by diffing all nine `examples/*` renders against a `main` worktree, which is also why no rendered example needed regenerating.

## Tested

Deployed to a local cluster, one workload per row, reading resource attributes out of a `debug` exporter at `verbosity: detailed`. Every row sends `service.name=unknown_service:java` unless stated.

| Pod metadata | Flag off | Flag on |
|---|---|---|
| none | `unknown_service:java` | `row1-plain` (Deployment name) |
| `app.kubernetes.io/{name,instance,version}` | `unknown_service:java` | `row2-wk-instance` \| `2.0.0` — instance beats name |
| `resource.opentelemetry.io/service.name` annotation, plus competing `app.kubernetes.io/*` | `unknown_service:java` | `row3-annotation-svc` — annotation wins |
| sets its own `service.name=my-real-app` | `my-real-app` | `my-real-app` — untouched |
| custom labels + `extraLabelMapping` to `service.name`/`service.version` | `unknown_service:java` | `com.example.service` \| `1e98846_752620f` |
| same, but also carrying `app.kubernetes.io/name` | mapped value | `something-else` — the well-known label wins, see below |

Other observations from the same run:

- `hostmetrics` gains no service name in either state — it touches no pod, so association can never resolve.
- Static pods with no owning workload stay unnamed; the chain has no fallback for them.
- No OTTL parse errors, no path-rewrite warnings, one restart on upgrade then stable.
- 97/97 unit tests pass.

## Upgrade notes, all documented in values.yaml

- Enabling this on an existing install renames services. Anything reporting as `unknown_service:*` becomes its workload name, and container logs and pod metrics that carry no service name today start creating one service entry per workload — on the 21-pod test cluster, `kubeletstats` went from 2 distinct service names to 15.
- A workload that sets `OTEL_SERVICE_NAME` keeps that name on its spans and OTLP metrics, but the name is invisible to Kubernetes, so the same pod's container logs and pod metrics resolve to the workload name and it appears under two identities. A matching `resource.opentelemetry.io/service.name` annotation keeps every signal on one name.
- Prefer `extraAnnotationsMapping` over `extraLabelMapping` when mapping your own keys. The processor copies the well-known labels over user label rules with an unconditional write, so on a pod carrying both, a label rule targeting `service.name` loses — and because that rule works while the flag is off, enabling the flag renames such a pod away from a value it already had. Annotation rules are applied last and win over both.
- `service.version` falls back to the container image tag, so pods on an untagged image report `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)