### PR TITLE
docs(opentelemetry-kube-stack): Fix misplaced and misleading APM comments

### DIFF
--- a/charts/opentelemetry-kube-stack/values.yaml
+++ b/charts/opentelemetry-kube-stack/values.yaml
@@ -80,17 +80,12 @@ fullnameOverride: ""
 image: ""
 
 # =============================================================================
-# AUTO-INSTRUMENTATION (APM) CONFIGURATION
+# OPENTELEMETRY OPERATOR (subchart)
 # =============================================================================
 #
-# This creates an OpenTelemetry Operator `Instrumentation` resource.
-# Workloads can then opt-in via pod annotations like:
-#   instrumentation.opentelemetry.io/inject-java: "true"
-#   instrumentation.opentelemetry.io/inject-python: "true"
-#   instrumentation.opentelemetry.io/inject-nodejs: "true"
-#   instrumentation.opentelemetry.io/inject-dotnet: "true"
-#
-# Top level field related to the OpenTelemetry Operator
+# Installs the OpenTelemetry Operator itself. Required by autoInstrumentation
+# below, but can be left disabled if the operator is already installed in the
+# cluster.
 opentelemetry-operator:
   # Field indicating whether the operator is enabled or not
   enabled: false
@@ -112,6 +107,21 @@ opentelemetry-operator:
   crds:
     create: false
 
+# =============================================================================
+# AUTO-INSTRUMENTATION (APM) CONFIGURATION
+# =============================================================================
+#
+# This creates an OpenTelemetry Operator `Instrumentation` resource in the
+# release namespace. Workloads opt-in via pod annotations like:
+#   instrumentation.opentelemetry.io/inject-java: "<release-namespace>/<cr-name>"
+#   instrumentation.opentelemetry.io/inject-python: "<release-namespace>/<cr-name>"
+#   instrumentation.opentelemetry.io/inject-nodejs: "<release-namespace>/<cr-name>"
+#   instrumentation.opentelemetry.io/inject-dotnet: "<release-namespace>/<cr-name>"
+# The shorthand "true" only works for pods in the same namespace as the CR.
+#
+# NOTE: `spec` below is empty by default. Without an exporter endpoint the
+# operator defaults to http://localhost:4317 and telemetry goes nowhere — set
+# spec.exporter.endpoint to your collector when enabling this.
 autoInstrumentation:
   # -- Enable OpenTelemetry Operator auto-instrumentation (Instrumentation CR)
   # Requires the OpenTelemetry Operator to be installed in the cluster.


### PR DESCRIPTION
## Problem

The `AUTO-INSTRUMENTATION (APM) CONFIGURATION` comment block in `charts/opentelemetry-kube-stack/values.yaml` sat directly above the `opentelemetry-operator:` key and claimed *"This creates an OpenTelemetry Operator `Instrumentation` resource."*

It doesn't. The Instrumentation CR is gated on `autoInstrumentation.enabled` (`templates/instrumentation.yaml:1`); the `opentelemetry-operator:` key only installs the operator subchart (`Chart.yaml:55`). Following the comment — setting `opentelemetry-operator.enabled=true` — produces no Instrumentation resource at all.

## Changes

Comments only. No template or default-value changes.

- Moved the APM block down to `autoInstrumentation:`, where it's accurate.
- Gave `opentelemetry-operator:` a header describing what it actually does.
- Corrected the annotation example: `inject-*: "true"` only works for pods in the **same namespace** as the CR. The chart creates it in the release namespace, so workloads elsewhere need the `"<ns>/<name>"` form — as `tests/AUTO_INSTRUMENTATION_TESTING.md:143` already does.
- Added a note that `spec: {}` is the default and renders literally, leaving the operator to fall back to `http://localhost:4317`. Enabling auto-instrumentation without setting `spec.exporter.endpoint` silently exports nowhere.

## Verification

```
helm template t charts/opentelemetry-kube-stack --set autoInstrumentation.enabled=true  # 1 Instrumentation CR
helm template t charts/opentelemetry-kube-stack                                          # 0
helm lint charts/opentelemetry-kube-stack                                                # 0 failed
helm unittest charts/opentelemetry-kube-stack                                            # 33 passed
```

## Not included

- `README.md` / `README.md.gotmpl` (lines 248-251 / 238-241) document the same bare `inject-*: "true"` form and have the same namespace gap. Generated from the gotmpl, so it's a separate pass.
- `autoInstrumentation.apiVersion` is dead flexibility — the bundled CRD serves only `v1alpha1` (`otel-crds/crds/opentelemetry.io_instrumentations.yaml:33`), so the knob can't point anywhere valid. Removing it is a breaking values change.
- `deploy.sh:514` waits on `-l app.kubernetes.io/name=opentelemetry-kube-stack`, but that label is on the CRs and the operator doesn't propagate CR labels to collector pods. The `|| true` suggests it's been matching nothing. Unconfirmed against a live cluster.
- No `Chart.yaml` version bump — comment-only change, nothing to release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)