### PR TITLE
Pin the collector image, fix render bugs, and prepare database-monitoring for more engines

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,11 @@ on:
       - ".pre-commit-config.yaml"
       - ".yamllint.yaml"
   pull_request:
-    branches: [main]
+    # dbm/base is a temporary integration branch for the stacked
+    # opentelemetry-database-monitoring engine PRs, which target it rather than
+    # main. Without it those PRs get no lint or unittest signal. Remove this
+    # entry once that stack has landed.
+    branches: [main, dbm/base]
     paths:
       - "charts/**"
       - ".ansible-lint"

--- a/charts/opentelemetry-database-monitoring/Chart.yaml
+++ b/charts/opentelemetry-database-monitoring/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opentelemetry-database-monitoring/README.md
+++ b/charts/opentelemetry-database-monitoring/README.md
@@ -1,10 +1,10 @@
 # opentelemetry-database-monitoring
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
-A Helm chart that deploys OpenTelemetry-based deep monitoring for PostgreSQL using a sidecar collector pattern. It installs stored functions on the target database, creates a dedicated monitoring user, and runs an `OpenTelemetryCollector` sidecar that emits metrics via OTLP.
-
-When `argoEvents.enabled=true`, the chart also installs [Argo Events](https://argoproj.io/docs/events/) to run the database setup Job after the OTel Operator injects the sidecar into a target Pod.
+Database monitoring for the OpenTelemetry Collector. For each database instance you
+declare, the chart injects a Collector as a **sidecar into the database Pod**,
+provisions a least-privilege monitoring user, and exports metrics over OTLP.
 
 ## Requirements
 
@@ -12,16 +12,30 @@ When `argoEvents.enabled=true`, the chart also installs [Argo Events](https://ar
 |------------|------|---------|
 | https://argoproj.github.io/argo-helm | argo-events | 2.4.22 |
 
+## Supported databases
+
+Every database is disabled by default. Enable the ones you need; they can run side
+by side in one release. Each has its own setup section below, which is the place to
+start — it covers the version requirements, the privileges the monitoring user
+gets, and the metrics collected.
+
+| Database | Values key | Setup |
+|----------|-----------|-------|
+| PostgreSQL | `postgres` | [PostgreSQL](#postgresql) |
+
+All databases export **metrics only**. See [Query collection](#query-collection)
+for how per-query data is collected and why.
+
 ## How it works
 
 ### Sidecar collector
 
 ```
 ┌───────────────────────────────────────────┐
-│  Your PostgreSQL Pod                      │
+│  Your database Pod                        │
 │                                           │
 │  ┌─────────────┐   ┌─────────────────┐    │
-│  │  PostgreSQL │   │  OTel Collector │    │
+│  │  database   │   │  OTel Collector │    │
 │  │  container  │◄──│    (sidecar)    │    │
 │  └─────────────┘   └────────┬────────┘    │
 │                              │ OTLP/gRPC  │
@@ -32,15 +46,30 @@ When `argoEvents.enabled=true`, the chart also installs [Argo Events](https://ar
                   or any OTLP endpoint)
 ```
 
-The chart creates a single shared **ConfigMap** (`postgresql-monitoring-setup`) that embeds `pg-monitoring-setup.sql` (the stored functions), and then for each database entry in `values.yaml`:
+The Collector reaches the database over the Pod's own network namespace, so that
+traffic never leaves the Pod. For each entry in an engine's `databases` list the
+chart creates:
 
-1. **Secret** — a `<name>-pg-monitor-credentials` Secret holding the auto-generated (or idempotently preserved) password for the `otel_monitor` user. When `postgres.databases[*].namespace` differs from the Helm release namespace, the same Secret is replicated into the target namespace so the injected sidecar can resolve `secretKeyRef` in the Pod's namespace.
-2. **Setup Job** — waits for PostgreSQL to be ready, runs the setup SQL on the `otel` database, and rotates the `otel_monitor` password to match the Secret. See [Argo Events setup](#argo-events-setup) below for when and how this Job is created.
-3. **OpenTelemetryCollector** (sidecar) — an `opentelemetry.io/v1beta1` CR in the **Helm release namespace** that configures the contrib collector with all receivers and exports metrics to `$K8S_NODE_IP:4317`.
+1. **Secret** — holds the auto-generated (or idempotently preserved) password for
+   the `otel_monitor` user. When the entry's `namespace` differs from the Helm
+   release namespace, the same Secret is replicated into the target namespace so
+   the injected sidecar can resolve `secretKeyRef` in the Pod's namespace.
+2. **Setup Job** — waits for the database to accept connections, runs the engine's
+   setup script, and rotates the `otel_monitor` password to match the Secret. See
+   [Argo Events setup](#argo-events-setup) for when and how this Job is created.
+3. **OpenTelemetryCollector** (sidecar) — an `opentelemetry.io/v1beta1` CR in the
+   **Helm release namespace** that configures the contrib Collector with the
+   engine's receivers and exports metrics to `$K8S_NODE_IP:4317`.
+
+Each engine also gets one shared **ConfigMap** carrying its setup script.
 
 ### Argo Events setup
 
-When `argoEvents.enabled=true` and `argoEvents.triggerSetupJob=true` (the default), the chart installs Argo Events and uses it to run the setup Job **after** the OTel Operator injects the sidecar into a target Pod. This avoids racing the database setup against sidecar startup and supports deploying DB monitoring in one namespace while Postgres runs in another.
+When `argoEvents.enabled=true` and `argoEvents.triggerSetupJob=true` (the default),
+the chart installs Argo Events and uses it to run the setup Job **after** the OTel
+Operator injects the sidecar into a target Pod. This avoids racing database setup
+against sidecar startup, and supports deploying monitoring in one namespace while
+the database runs in another.
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
@@ -50,7 +79,7 @@ When `argoEvents.enabled=true` and `argoEvents.triggerSetupJob=true` (the defaul
 │                  │                              │                       │
 │  OpenTelemetryCollector CR ◄─────────────────────┘ (same release ns)   │
 │  Monitor Secret (for Job)                                               │
-│  ConfigMap (setup SQL)                                                  │
+│  ConfigMap (setup script)                                               │
 │  Argo Events controller (argo-events subchart)                          │
 └─────────────────────────────────────────────────────────────────────────┘
          ▲                                    │
@@ -60,34 +89,48 @@ When `argoEvents.enabled=true` and `argoEvents.triggerSetupJob=true` (the defaul
 ┌─────────────────────────────────────────────────────────────────────────┐
 │  Target namespace (e.g. demo)                                           │
 │                                                                         │
-│  PostgreSQL Pod  +  injected OTel sidecar                               │
+│  database Pod  +  injected OTel sidecar                                 │
 │  Monitor Secret (replica for sidecar secretKeyRef)                      │
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-The flow for each `postgres.databases` entry:
+The flow for each database entry:
 
-1. **EventBus** — NATS-backed bus in the release namespace (`argoEvents.eventBusName`, default `default`).
-2. **EventSource** — watches Pod `ADD` events in the database target namespace(s). Uses `filter.afterStart: true`, so only Pods created **after** the EventSource starts trigger events (existing Pods are ignored).
-3. **Sensor** (one per database) — subscribes to the EventSource and filters on the `sidecar.opentelemetry.io/inject` annotation (`argoEvents.sidecarInjectAnnotation`). When the annotation matches the expected value, it creates the setup Job in the release namespace.
-4. **Setup Job** — same SQL setup as the Helm-hook path; connects to Postgres using cluster DNS (`<host>.<namespace>.svc.cluster.local`) when the database runs in another namespace.
+1. **EventBus** — NATS-backed bus in the release namespace
+   (`argoEvents.eventBusName`, default `default`).
+2. **EventSource** — watches Pod `ADD` events in the target namespace(s). Uses
+   `filter.afterStart: true`, so only Pods created **after** the EventSource starts
+   trigger events; existing Pods are ignored. It watches the union of the target
+   namespaces of every enabled database.
+3. **Sensor** (one per database entry) — subscribes to the EventSource and filters
+   on the `sidecar.opentelemetry.io/inject` annotation
+   (`argoEvents.sidecarInjectAnnotation`). When the annotation matches the expected
+   value, it creates the setup Job in the release namespace.
+4. **Setup Job** — the same setup as the Helm-hook path; connects using cluster DNS
+   (`<host>.<namespace>.svc.cluster.local`) when the database runs in another
+   namespace.
 
-When `argoEvents.enabled=false`, or `argoEvents.triggerSetupJob=false`, the setup Job is created directly as a Helm `post-install` / `post-upgrade` hook instead.
+When `argoEvents.enabled=false`, or `argoEvents.triggerSetupJob=false`, the setup
+Job is created directly as a Helm `post-install` / `post-upgrade` hook instead.
 
 #### Sidecar inject annotation
 
-The OTel Operator must inject the sidecar before the Sensor fires. Annotate the target Pod (or its controller template) with `sidecar.opentelemetry.io/inject`:
+The OTel Operator must inject the sidecar before the Sensor fires. Annotate the
+target Pod (or its controller template) with `sidecar.opentelemetry.io/inject`:
 
 | Scenario | Expected annotation value |
 |----------|---------------------------|
-| Postgres in the same namespace as the Helm release | `postgres-dbm-sidecar` (the `sidecar-name`) |
-| Postgres in a different namespace | `<releaseNamespace>/<sidecar-name>` (e.g. `observability/postgres-dbm-sidecar`) |
+| Database in the same namespace as the Helm release | the entry's `sidecar-name` |
+| Database in a different namespace | `<releaseNamespace>/<sidecar-name>` (e.g. `observability/postgres-dbm-sidecar`) |
 
-The Sensor filter is derived automatically from `postgres.databases[*].namespace` and `sidecar-name`. The `OpenTelemetryCollector` CR always lives in the release namespace; cross-namespace injection is driven by the annotation prefix.
+The Sensor filter is derived automatically from each entry's `namespace` and
+`sidecar-name`. The `OpenTelemetryCollector` CR always lives in the release
+namespace; cross-namespace injection is driven by the annotation prefix.
 
 #### Cross-namespace example
 
-Install DB monitoring in `observability`, target Postgres in `demo`:
+Install monitoring in `observability`, targeting a database in `demo`. The example
+uses PostgreSQL; the shape is identical for every engine.
 
 ```yaml
 # values.yaml for: helm install dbm … -n observability
@@ -107,19 +150,26 @@ argoEvents:
   triggerSetupJob: true
 ```
 
-On the Postgres Pod (in `demo`):
+On the database Pod (in `demo`):
 
 ```yaml
 podAnnotations:
   sidecar.opentelemetry.io/inject: "observability/postgres-dbm-sidecar"
 ```
 
-After install, restart the Postgres Pod so the EventSource emits a fresh `ADD` event:
+After install, restart the Pod so the EventSource emits a fresh `ADD` event:
 
 ```bash
 kubectl delete pod -n demo -l app.kubernetes.io/name=postgresql
 kubectl get jobs -n observability -l app.kubernetes.io/component=db-monitoring-setup -w
 ```
+
+#### Multiple databases
+
+Add more entries to an engine's `databases` list, or enable several engines at
+once. Every entry gets its own sidecar CR, monitor Secret, and setup Job, and each
+needs a distinct `sidecar-name`. The Argo Events plumbing (EventBus, EventSource,
+RBAC) is shared across all of them.
 
 #### Disabling Argo Events
 
@@ -129,16 +179,22 @@ argoEvents:
   triggerSetupJob: false  # use Helm hook Jobs even when argoEvents.enabled=true
 ```
 
-Argo Events CRDs are bundled under `crds/` and installed before other chart resources. The `argo-events` subchart is gated by `argoEvents.enabled`; its own CRD install is disabled (`argo-events.crds.install: false`) because this chart ships the CRDs.
+Argo Events CRDs are bundled under `crds/` and installed before other chart
+resources. The `argo-events` subchart is gated by `argoEvents.enabled`; its own CRD
+install is disabled (`argo-events.crds.install: false`) because this chart ships
+the CRDs.
 
 ## Prerequisites
 
 - Kubernetes 1.21+
-- [OpenTelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator) installed in the cluster (provides the `OpenTelemetryCollector` CRD and injects sidecars)
-- PostgreSQL 10+ (for `pg_stat_progress_vacuum`)
-- A superuser (or a role with `CREATEROLE` and `CREATEDB`) available to run the setup Job — credentials are passed via `postgres.databases[*].user` / `postgres.databases[*].pwd`
-- An `otel` database must exist on each target PostgreSQL instance before install (the Job connects to it: `psql … -d otel`)
-- When using Argo Events (`argoEvents.enabled=true`): Argo Events CRDs must be available (installed from this chart's `crds/` directory on first install)
+- [OpenTelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator)
+  installed in the cluster. It provides the `OpenTelemetryCollector` CRD and injects
+  the sidecars.
+- An OTLP endpoint reachable at `$K8S_NODE_IP:4317`, such as a DaemonSet Collector.
+- When using Argo Events (`argoEvents.enabled=true`): the Argo Events CRDs, which
+  are installed from this chart's `crds/` directory on first install.
+- Per-database version and privilege requirements are listed in each database's
+  setup section.
 
 ## Installation
 
@@ -146,91 +202,40 @@ Argo Events CRDs are bundled under `crds/` and installed before other chart reso
 helm repo add tsuga-charts https://tsuga-dev.github.io/helm-charts/
 helm repo update
 
-helm install pg-monitoring tsuga-charts/opentelemetry-database-monitoring \
+helm install db-monitoring tsuga-charts/opentelemetry-database-monitoring \
   --set postgres.enabled=true \
   --set postgres.databases[0].name=postgresql \
   --set postgres.databases[0].host=postgresql \
   --set postgres.databases[0].user=root \
-  --set postgres.databases[0].pwd=<superuser-password>
+  --set postgres.databases[0].pwd=<admin-password>
 ```
 
-With Argo Events enabled (default), install into the namespace where you want the sidecar CRs, EventBus, and setup Jobs to live. Set `postgres.databases[*].namespace` when Postgres runs elsewhere.
+Install into the namespace where you want the sidecar CRs, EventBus, and setup Jobs
+to live. Set the entry's `namespace` when the database runs elsewhere.
 
-## Examples
+## PostgreSQL
 
-### Single database (same namespace)
+Enable with `postgres.enabled=true`.
 
-```yaml
-postgres:
-  enabled: true
-  databases:
-    - name: postgresql
-      sidecar-name: postgres-dbm-sidecar
-      user: root
-      pwd: otel
-      port: 5432
-      host: postgresql
+### Requirements
 
-argoEvents:
-  enabled: true
-  triggerSetupJob: true
-```
+- PostgreSQL 10 or later, for `pg_stat_progress_vacuum`.
+- An `otel` database must already exist on the instance. The setup Job connects to
+  it directly (`psql … -d otel`).
+- The admin credentials in `postgres.databases[*].user` / `pwd` must be a superuser,
+  or a role with `CREATEROLE` and `CREATEDB`.
 
-Annotate the Postgres Pod with `sidecar.opentelemetry.io/inject: postgres-dbm-sidecar`.
-
-### Cross-namespace database
-
-```yaml
-postgres:
-  enabled: true
-  databases:
-    - name: postgresql
-      namespace: demo
-      sidecar-name: postgres-dbm-sidecar
-      user: root
-      pwd: otel
-      port: 5432
-      host: postgresql
-
-argoEvents:
-  enabled: true
-  triggerSetupJob: true
-```
-
-Annotate the Postgres Pod in `demo` with `sidecar.opentelemetry.io/inject: <releaseNamespace>/postgres-dbm-sidecar`.
-
-### Multiple databases
-
-Each entry produces an independent set of resources (Secret, Sensor, sidecar CR, and setup Job trigger).
-
-```yaml
-postgres:
-  enabled: true
-  databases:
-    - name: postgresql
-      namespace: demo
-      sidecar-name: postgres-dbm-sidecar
-      user: root
-      pwd: otel
-      port: 5432
-      host: postgresql
-    - name: postgresql2
-      namespace: staging
-      sidecar-name: postgres2-dbm-sidecar
-      user: root
-      pwd: otel
-      port: 5432
-      host: postgresql2
-```
-
-## Database setup
+### Setup
 
 The setup Job runs `assets/pg-monitoring-setup.sql` idempotently. It:
 
-1. Creates the `otel_monitor` user (if absent) and grants it `pg_monitor` + `SELECT` on `pg_stat_database`.
+1. Creates the `otel_monitor` user and grants it `pg_monitor` plus `SELECT` on
+   `pg_stat_database`.
 2. Enables the `pg_stat_statements` extension.
 3. Creates the `otel` schema and grants `USAGE` to `otel_monitor`.
-4. Installs the following stored functions (all `STABLE`, safe for repeated execution):
+4. Installs the stored functions below, all `STABLE` and safe to re-run.
+5. Grants `EXECUTE` on all `otel` functions to `otel_monitor`.
+6. Rotates the `otel_monitor` password to match the Secret.
 
 | Function | Description |
 |----------|-------------|
@@ -242,21 +247,13 @@ The setup Job runs `assets/pg-monitoring-setup.sql` idempotently. It:
 | `otel.pg_idle_in_transaction()` | Idle-in-transaction connection count and max age per database. |
 | `otel.pg_replication_slots()` | Replication slot lag in bytes per slot. |
 | `otel.pg_wal()` | WAL segment file count and total WAL directory size. |
-| `otel.pg_vacuum_progress()` | Active vacuum operations with phase and block progress (PG 10+). |
-| `otel.pg_top_queries()` | Top 20 queries by call count from `pg_stat_statements`. Query text truncated to 200 characters. |
+| `otel.pg_vacuum_progress()` | Active vacuum operations with phase and block progress. |
+| `otel.pg_top_queries()` | Top queries by call count from `pg_stat_statements`. |
 
-5. Grants `EXECUTE` on all `otel` functions to `otel_monitor`.
-6. Rotates the `otel_monitor` password to match the value in the Secret.
+### Metrics
 
-> **Note:** The Job connects to the `otel` database (`-d otel`). This database must exist before the chart is installed.
-
-## Metrics
-
-The sidecar collector runs two categories of receivers.
-
-### Built-in `postgresql` receiver
-
-Polls the PostgreSQL stats system views directly. Default collection interval.
+The `postgresql` receiver polls the PostgreSQL statistics views directly, with 20
+default-disabled metrics additionally enabled by this chart.
 
 | Metric | Unit | Description |
 |--------|------|-------------|
@@ -277,106 +274,181 @@ Polls the PostgreSQL stats system views directly. Default collection interval.
 | `postgresql.wal.age` | `s` | WAL archiver age |
 | `postgresql.wal.lag` | `s` | Replication WAL lag |
 
-### `sqlquery` receivers (stored functions)
+The `sqlquery` receivers read the stored functions installed above:
 
 | Receiver | Interval | Metrics |
 |----------|----------|---------|
 | `sqlquery/postgresql_top_queries` | default | `postgresql.query.calls`, `.rows`, `.exec_time`, `.plan_time`, `.blocks.shared.*`, `.blocks.temp.*` — attributed by `db.namespace`, `db.user.name`, `server.address`, `db.query.text`, `db.version` |
 | `sqlquery/pg_table_stats` | 5 min | `postgresql.table.vacuum.age`, `.autovacuum.age`, `.analyze.age`, `.autoanalyze.age`, `.autovacuum.count`, `.analyze.count`, `.autoanalyze.count`, `.rows.modified.since.analyze` |
 | `sqlquery/pg_bloat` | 1 hour | `postgresql.table.bloat.ratio`, `postgresql.table.bloat.bytes` |
-| `sqlquery/pg_connections` | 30 s | `postgresql.backends` (count), `postgresql.backends.age` (max state age) |
+| `sqlquery/pg_connections` | 30 s | `postgresql.backends`, `postgresql.backends.age` |
 | `sqlquery/pg_locks` | 30 s | `postgresql.lock.count`, `postgresql.lock.blocking_queries`, `postgresql.connection.idle_in_transaction`, `postgresql.connection.idle_in_transaction.age` |
 | `sqlquery/pg_replication` | 30 s | `postgresql.replication.slot.lag` |
 | `sqlquery/pg_wal` | 60 s | `postgresql.wal.file_count`, `postgresql.wal.bytes` |
 | `sqlquery/pg_vacuum_progress` | 60 s | `postgresql.vacuum.heap_blks_total`, `.heap_blks_scanned`, `.heap_blks_vacuumed`, `postgresql.vacuum.age` |
 
-All metrics are batched (max 5000 per batch) and exported via OTLP/gRPC to `$K8S_NODE_IP:4317`.
+### Example
+
+See `examples/pg-single-db/` and `examples/pg-multiple-db/`.
+
+```yaml
+postgres:
+  enabled: true
+  databases:
+    - name: postgresql
+      sidecar-name: postgres-dbm-sidecar
+      user: root
+      pwd: otel
+      port: 5432
+      host: postgresql
+```
+
+Annotate the PostgreSQL Pod with
+`sidecar.opentelemetry.io/inject: postgres-dbm-sidecar`.
+
+## Query collection
+
+Several database receivers can report per-query data through a native
+`top_query_collection` or `query_sample_collection` block. Those blocks emit **log
+records** — the `db.server.top_query` and `db.server.query_sample` events — and
+that logs signal is at **Development** stability. This chart exports metrics only,
+so where per-query data is available it is collected with the `sqlquery` receiver
+against a view or function installed by the setup script.
+
+| Database | Per-query metrics | Mechanism |
+|----------|------------------|-----------|
+| PostgreSQL | yes | `sqlquery` over `otel.pg_top_queries()` |
+
+The native blocks are functional, so this is a choice about signal type rather than
+a workaround. To use the native events instead, enable them on the receiver and add
+a `logs` pipeline by overriding the engine's asset config. Do not run both: they
+report the same data twice.
 
 ## Security notes
 
-- The superuser credentials (`user`/`pwd`) are used only by the setup Job and are not stored in any long-lived secret.
-- The sidecar uses the auto-generated `otel_monitor` password from the Secret. With Helm hook Jobs, the password is rotated on every `helm upgrade`. With Argo Events, rotation happens each time a new setup Job completes.
-- The Secret is created with `lookup` to preserve the existing password across upgrades — a new random 24-character password is only generated on first install.
-- The `otel_monitor` user holds `pg_monitor` (read-only system views) and `EXECUTE` on the `otel.*` functions. It has no write access to application data.
-- All SQL connections from the sidecar use `sslmode=disable`. Enable TLS by overriding `assets/pg-monitoring-config.yaml` if your PostgreSQL requires it.
+- The admin credentials (`user` / `pwd`) are used only by the setup Job. They are
+  interpolated into the Job spec, so they are readable by anyone who can read Jobs
+  in the release namespace, and are not written to a Secret.
+- The sidecar uses the auto-generated `otel_monitor` password from the Secret. With
+  Helm hook Jobs the password is rotated on every `helm upgrade`; with Argo Events,
+  rotation happens each time a new setup Job completes.
+- The Secret is created with `lookup` to preserve the existing password across
+  upgrades. A new random 24-character password is generated only on first install.
+- The `otel_monitor` user is read-only on every database and has no write access to
+  application data. The exact grants are listed in each database's setup section.
+- **Why TLS is off between the sidecar and the database.** The Collector runs as a
+  sidecar *inside the database Pod*, so it reaches the server over the Pod's own
+  network namespace and that traffic never leaves the Pod. That is the assumption
+  behind disabling TLS on the receivers and their `sqlquery` datasources. **If you
+  repoint these configs at a database outside the Pod, the assumption no longer
+  holds** — configure TLS first by overriding the engine's asset config.
+- The export hop to `$K8S_NODE_IP:4317` also runs without TLS. Unlike the database
+  hop this one does leave the Pod, so it relies on the node-local Collector being
+  trusted.
+- The Collector image is pinned to a concrete tag. An untagged image resolves to
+  `:latest`, which forces `imagePullPolicy: Always` and lets the Collector version
+  change under the configuration in `assets/`.
 
 ## Upgrading
 
-**Without Argo Events** (`argoEvents.enabled=false` or `argoEvents.triggerSetupJob=false`): the setup Job runs on both `post-install` and `post-upgrade` Helm hooks with a `before-hook-creation` deletion policy, so it re-runs on every `helm upgrade`.
+**Without Argo Events** (`argoEvents.enabled=false` or
+`argoEvents.triggerSetupJob=false`): the setup Job runs on both `post-install` and
+`post-upgrade` Helm hooks with a `before-hook-creation` deletion policy, so it
+re-runs on every `helm upgrade`.
 
-**With Argo Events** (default): the setup Job is created by a Sensor when a new target Pod is added with the correct inject annotation. Upgrading the chart updates EventSource/Sensor configuration but does not re-run setup on existing Pods. Restart the target Postgres Pod after upgrade if you need setup to run again.
+**With Argo Events** (default): the setup Job is created by a Sensor when a new
+target Pod is added with the correct inject annotation. Upgrading the chart updates
+EventSource and Sensor configuration but does not re-run setup on existing Pods.
+Restart the target Pod after upgrade if you need setup to run again.
 
-All SQL statements are idempotent and the password rotation uses the existing Secret value.
+All setup scripts are idempotent, and password rotation uses the existing Secret
+value.
 
 ## Troubleshooting
 
-**Setup Job never created (Argo Events enabled)**
+**Authentication errors in the sidecar right after a Pod starts**
 
-1. Confirm EventBus, EventSource, and Sensor exist in the **Helm release namespace**:
-   ```bash
-   kubectl get eventbus,eventsource,sensor -n <release-namespace>
-   ```
-2. Verify the Sensor filter matches the Pod annotation (same namespace → `sidecar-name`; cross-namespace → `<releaseNamespace>/<sidecar-name>`):
-   ```bash
-   kubectl get sensor -n <release-namespace> -o yaml | rg 'value:|eventName:'
-   kubectl get pod -n <target-namespace> <postgres-pod> -o jsonpath='{.metadata.annotations.sidecar\.opentelemetry\.io/inject}{"\n"}'
-   ```
-3. The EventSource ignores Pods that existed before it started (`afterStart: true`). Restart the Postgres Pod after install or upgrade:
-   ```bash
-   kubectl delete pod -n <target-namespace> -l app.kubernetes.io/name=postgresql
-   kubectl get jobs -n <release-namespace> -l app.kubernetes.io/component=db-monitoring-setup -w
-   ```
-4. Remove stale EventBus/EventSource/Sensor objects left over from an install in a different release namespace.
+Expected, and self-correcting. With Argo Events driving setup, the sequence is: the
+Pod starts, the operator injects the sidecar, the Sensor sees the Pod and creates
+the setup Job, and the Job creates the `otel_monitor` user. The sidecar therefore
+begins scraping a few seconds before that user exists, and logs one scrape failure
+per interval until it does.
 
-**Job fails immediately**
+Compare the error timestamp against the Job's completion time before treating it as
+a real failure:
 
-Check that the `otel` database exists and the superuser credentials are correct:
 ```bash
-kubectl logs -l app.kubernetes.io/component=db-monitoring-setup -n <release-namespace>
+kubectl -n <release-namespace> get job -l app.kubernetes.io/component=db-monitoring-setup \
+  -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.completionTime}{"\n"}{end}'
 ```
 
-**Sidecar init container fails with secret not found**
+Errors older than the completion time are the startup race. Errors newer than it
+are a real problem: check that the Job succeeded, and that the monitor Secret in
+the database's namespace matches the one in the release namespace.
 
-The monitor Secret must exist in the **Pod's namespace**. Set `postgres.databases[*].namespace` so the chart replicates the Secret into the target namespace.
+**Setup Job never created (Argo Events enabled)**
 
-**No metrics in the collector**
+The EventSource only reports Pods created after it starts (`filter.afterStart:
+true`). Restart the database Pod:
 
-Verify the `OpenTelemetryCollector` CR was injected as a sidecar into the target Pod. The OTel Operator must be running and the Pod must have the `sidecar.opentelemetry.io/inject` annotation (or the operator must be configured for namespace-wide injection).
+```bash
+kubectl delete pod -n <target-namespace> -l <your-database-selector>
+```
 
-**`pg_stat_statements` not available**
+Then confirm the annotation on the Pod matches the value the Sensor expects — see
+[Sidecar inject annotation](#sidecar-inject-annotation).
 
-The extension must be listed in `shared_preload_libraries` in `postgresql.conf` and PostgreSQL must be restarted before it can be created. Add `shared_preload_libraries = 'pg_stat_statements'` to your PostgreSQL configuration and restart the server before installing the chart.
+**Sidecar not injected**
 
-**Top queries missing**
+Check that the OpenTelemetry Operator is running, that the
+`OpenTelemetryCollector` CR exists in the release namespace, and that the Pod
+annotation carries the `<releaseNamespace>/` prefix when the database runs in
+another namespace:
 
-Queries run by the collector itself are excluded via the `/* otel-collector-ignore */` comment prefix. If `otel.pg_top_queries()` returns no rows, check that `pg_stat_statements.track` is not set to `none`.
+```bash
+kubectl get opentelemetrycollectors -A
+kubectl -n <target-namespace> get pod <pod> -o jsonpath='{.spec.initContainers[*].name}'
+```
+
+The operator injects the Collector as a native sidecar, so it appears under
+`initContainers` with `restartPolicy: Always` rather than under `containers`.
+
+**Setup Job failing**
+
+```bash
+kubectl -n <release-namespace> logs job/<db-name>-<engine>-monitoring-setup
+```
+
+The Job waits for the database to accept connections before running setup, so a Job
+stuck in that loop means the `host` and `port` in values do not reach the database.
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| argo-events.crds.install | bool | `false` |  |
-| argo-events.enabled | bool | `true` |  |
-| argoEvents.enabled | bool | `true` |  |
-| argoEvents.eventBus.auth | string | `"none"` |  |
-| argoEvents.eventBus.create | bool | `true` |  |
-| argoEvents.eventBus.replicas | int | `1` |  |
-| argoEvents.eventBusName | string | `"default"` |  |
-| argoEvents.eventSource.name | string | `""` |  |
-| argoEvents.eventSource.serviceAccount.create | bool | `true` |  |
-| argoEvents.eventSource.serviceAccount.name | string | `""` |  |
-| argoEvents.eventSource.watchNamespace | string | `""` |  |
-| argoEvents.job.generateNameSuffix | string | `"setup-"` |  |
-| argoEvents.sensor.serviceAccount.create | bool | `true` |  |
-| argoEvents.sensor.serviceAccount.name | string | `""` |  |
-| argoEvents.sidecarInjectAnnotation | string | `"sidecar.opentelemetry.io/inject"` |  |
-| argoEvents.triggerSetupJob | bool | `true` |  |
-| postgres.databases[0].host | string | `""` |  |
-| postgres.databases[0].name | string | `"postgresql"` |  |
-| postgres.databases[0].namespace | string | `""` |  |
-| postgres.databases[0].port | int | `5432` |  |
-| postgres.databases[0].pwd | string | `""` |  |
-| postgres.databases[0].sidecar-name | string | `"postgres-dbm-sidecar"` |  |
-| postgres.databases[0].user | string | `""` |  |
-| postgres.enabled | bool | `false` |  |
-| postgres.image | string | `"ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib"` |  |
+| argo-events.crds.install | bool | false | Let the Argo Events subchart install its own CRDs. Keep this false: the CRDs are shipped in this chart's crds/ directory. |
+| argo-events.enabled | bool | true | Install the bundled Argo Events controller subchart. |
+| argoEvents.enabled | bool | true | Watch for Pods carrying the sidecar inject annotation and react to them. Also gates the EventBus, EventSource, Sensors, and their RBAC. |
+| argoEvents.eventBus.auth | string | `"none"` | Authentication strategy for the native NATS EventBus. |
+| argoEvents.eventBus.create | bool | true | Create the EventBus. Argo Events requires one in the namespace and the controller subchart does not create it. |
+| argoEvents.eventBus.replicas | int | `1` | Number of NATS replicas in the native EventBus. |
+| argoEvents.eventBusName | string | `"default"` | Name of the EventBus the EventSource and Sensors connect to. |
+| argoEvents.eventSource.name | string | "" | Name of the EventSource. Defaults to `<fullname>-pod-created` when empty. |
+| argoEvents.eventSource.serviceAccount.create | bool | true | Create the EventSource ServiceAccount and its Pod-watch RBAC. |
+| argoEvents.eventSource.serviceAccount.name | string | "" | Name of the EventSource ServiceAccount. Defaults to `<fullname>-argo-eventsource` when empty. |
+| argoEvents.eventSource.watchNamespace | string | "" | Single namespace to watch for Pod events. When empty, the chart watches the union of the target namespaces of every enabled engine. |
+| argoEvents.job.generateNameSuffix | string | `"setup-"` | Suffix appended to the generateName of Sensor-created setup Jobs. |
+| argoEvents.sensor.serviceAccount.create | bool | true | Create the Sensor ServiceAccount and its Job-create RBAC. |
+| argoEvents.sensor.serviceAccount.name | string | "" | Name of the Sensor ServiceAccount. Defaults to `<fullname>-argo-sensor` when empty. |
+| argoEvents.sidecarInjectAnnotation | string | `"sidecar.opentelemetry.io/inject"` | Pod annotation key the OpenTelemetry Operator reads to inject a sidecar. The Sensors filter incoming Pod events on this key. |
+| argoEvents.triggerSetupJob | bool | true | Create each setup Job from an Argo Events Sensor when a target Pod appears, instead of from a Helm post-install/post-upgrade hook. Running setup after the operator has injected the sidecar avoids racing database setup against sidecar startup, and allows the release to live in a different namespace from the database. |
+| postgres.databases | list | `[{"host":"","name":"postgresql","namespace":"","port":5432,"pwd":"","sidecar-name":"postgres-dbm-sidecar","user":""}]` | PostgreSQL instances to monitor. Each entry produces its own sidecar collector, monitor secret, and setup Job. |
+| postgres.databases[0] | object | `{"host":"","name":"postgresql","namespace":"","port":5432,"pwd":"","sidecar-name":"postgres-dbm-sidecar","user":""}` | Name for this instance. Used as the prefix of the monitor secret and setup Job names, and set as the `opentelemetry-database-monitoring/database` label on every resource. |
+| postgres.databases[0].host | string | "" | Host the setup Job connects to, normally the PostgreSQL Service name. A value containing a dot is used as-is; otherwise, when the instance runs in another namespace, it is expanded to `<host>.<namespace>.svc.cluster.local`. |
+| postgres.databases[0].namespace | string | "" | Namespace where the annotated PostgreSQL Pod runs. Replicates the monitor secret into that namespace and sets the expected inject annotation to `<releaseNamespace>/<sidecar-name>` when it differs from the release namespace. Empty means the release namespace. |
+| postgres.databases[0].port | int | `5432` | Port the setup Job connects to. The sidecar's receiver port is fixed at 5432 in assets/pg-monitoring-config.yaml; override that asset to change the port the collector uses. |
+| postgres.databases[0].pwd | string | "" | Password for the administrative user. Interpolated into the setup Job spec, so it is readable by anyone who can read Jobs in the release namespace. It is not written to a secret. |
+| postgres.databases[0].sidecar-name | string | `"postgres-dbm-sidecar"` | Name of the OpenTelemetryCollector resource for this instance. This is the value the target Pod's `sidecar.opentelemetry.io/inject` annotation must carry for the operator to inject the sidecar. |
+| postgres.databases[0].user | string | "" | Administrative user the setup Job connects as. Needs to be a superuser, or a role with CREATEROLE and CREATEDB. |
+| postgres.enabled | bool | false | Deploy PostgreSQL monitoring: the injected sidecar collector, the monitor credentials secret, the setup ConfigMap, and the setup Job. |
+| postgres.image | string | `"ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0"` | Collector image for the injected sidecar. |

--- a/charts/opentelemetry-database-monitoring/README.md.gotmpl
+++ b/charts/opentelemetry-database-monitoring/README.md.gotmpl
@@ -4,9 +4,9 @@
 
 {{ template "chart.badgesSection" . }}
 
-A Helm chart that deploys OpenTelemetry-based deep monitoring for PostgreSQL using a sidecar collector pattern. It installs stored functions on the target database, creates a dedicated monitoring user, and runs an `OpenTelemetryCollector` sidecar that emits metrics via OTLP.
-
-When `argoEvents.enabled=true`, the chart also installs [Argo Events](https://argoproj.io/docs/events/) to run the database setup Job after the OTel Operator injects the sidecar into a target Pod.
+Database monitoring for the OpenTelemetry Collector. For each database instance you
+declare, the chart injects a Collector as a **sidecar into the database Pod**,
+provisions a least-privilege monitoring user, and exports metrics over OTLP.
 
 {{ template "chart.homepageLine" . }}
 
@@ -16,16 +16,30 @@ When `argoEvents.enabled=true`, the chart also installs [Argo Events](https://ar
 
 {{ template "chart.requirementsSection" . }}
 
+## Supported databases
+
+Every database is disabled by default. Enable the ones you need; they can run side
+by side in one release. Each has its own setup section below, which is the place to
+start — it covers the version requirements, the privileges the monitoring user
+gets, and the metrics collected.
+
+| Database | Values key | Setup |
+|----------|-----------|-------|
+| PostgreSQL | `postgres` | [PostgreSQL](#postgresql) |
+
+All databases export **metrics only**. See [Query collection](#query-collection)
+for how per-query data is collected and why.
+
 ## How it works
 
 ### Sidecar collector
 
 ```
 ┌───────────────────────────────────────────┐
-│  Your PostgreSQL Pod                      │
+│  Your database Pod                        │
 │                                           │
 │  ┌─────────────┐   ┌─────────────────┐    │
-│  │  PostgreSQL │   │  OTel Collector │    │
+│  │  database   │   │  OTel Collector │    │
 │  │  container  │◄──│    (sidecar)    │    │
 │  └─────────────┘   └────────┬────────┘    │
 │                              │ OTLP/gRPC  │
@@ -36,15 +50,30 @@ When `argoEvents.enabled=true`, the chart also installs [Argo Events](https://ar
                   or any OTLP endpoint)
 ```
 
-The chart creates a single shared **ConfigMap** (`postgresql-monitoring-setup`) that embeds `pg-monitoring-setup.sql` (the stored functions), and then for each database entry in `values.yaml`:
+The Collector reaches the database over the Pod's own network namespace, so that
+traffic never leaves the Pod. For each entry in an engine's `databases` list the
+chart creates:
 
-1. **Secret** — a `<name>-pg-monitor-credentials` Secret holding the auto-generated (or idempotently preserved) password for the `otel_monitor` user. When `postgres.databases[*].namespace` differs from the Helm release namespace, the same Secret is replicated into the target namespace so the injected sidecar can resolve `secretKeyRef` in the Pod's namespace.
-2. **Setup Job** — waits for PostgreSQL to be ready, runs the setup SQL on the `otel` database, and rotates the `otel_monitor` password to match the Secret. See [Argo Events setup](#argo-events-setup) below for when and how this Job is created.
-3. **OpenTelemetryCollector** (sidecar) — an `opentelemetry.io/v1beta1` CR in the **Helm release namespace** that configures the contrib collector with all receivers and exports metrics to `$K8S_NODE_IP:4317`.
+1. **Secret** — holds the auto-generated (or idempotently preserved) password for
+   the `otel_monitor` user. When the entry's `namespace` differs from the Helm
+   release namespace, the same Secret is replicated into the target namespace so
+   the injected sidecar can resolve `secretKeyRef` in the Pod's namespace.
+2. **Setup Job** — waits for the database to accept connections, runs the engine's
+   setup script, and rotates the `otel_monitor` password to match the Secret. See
+   [Argo Events setup](#argo-events-setup) for when and how this Job is created.
+3. **OpenTelemetryCollector** (sidecar) — an `opentelemetry.io/v1beta1` CR in the
+   **Helm release namespace** that configures the contrib Collector with the
+   engine's receivers and exports metrics to `$K8S_NODE_IP:4317`.
+
+Each engine also gets one shared **ConfigMap** carrying its setup script.
 
 ### Argo Events setup
 
-When `argoEvents.enabled=true` and `argoEvents.triggerSetupJob=true` (the default), the chart installs Argo Events and uses it to run the setup Job **after** the OTel Operator injects the sidecar into a target Pod. This avoids racing the database setup against sidecar startup and supports deploying DB monitoring in one namespace while Postgres runs in another.
+When `argoEvents.enabled=true` and `argoEvents.triggerSetupJob=true` (the default),
+the chart installs Argo Events and uses it to run the setup Job **after** the OTel
+Operator injects the sidecar into a target Pod. This avoids racing database setup
+against sidecar startup, and supports deploying monitoring in one namespace while
+the database runs in another.
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
@@ -54,7 +83,7 @@ When `argoEvents.enabled=true` and `argoEvents.triggerSetupJob=true` (the defaul
 │                  │                              │                       │
 │  OpenTelemetryCollector CR ◄─────────────────────┘ (same release ns)   │
 │  Monitor Secret (for Job)                                               │
-│  ConfigMap (setup SQL)                                                  │
+│  ConfigMap (setup script)                                               │
 │  Argo Events controller (argo-events subchart)                          │
 └─────────────────────────────────────────────────────────────────────────┘
          ▲                                    │
@@ -64,34 +93,48 @@ When `argoEvents.enabled=true` and `argoEvents.triggerSetupJob=true` (the defaul
 ┌─────────────────────────────────────────────────────────────────────────┐
 │  Target namespace (e.g. demo)                                           │
 │                                                                         │
-│  PostgreSQL Pod  +  injected OTel sidecar                               │
+│  database Pod  +  injected OTel sidecar                                 │
 │  Monitor Secret (replica for sidecar secretKeyRef)                      │
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-The flow for each `postgres.databases` entry:
+The flow for each database entry:
 
-1. **EventBus** — NATS-backed bus in the release namespace (`argoEvents.eventBusName`, default `default`).
-2. **EventSource** — watches Pod `ADD` events in the database target namespace(s). Uses `filter.afterStart: true`, so only Pods created **after** the EventSource starts trigger events (existing Pods are ignored).
-3. **Sensor** (one per database) — subscribes to the EventSource and filters on the `sidecar.opentelemetry.io/inject` annotation (`argoEvents.sidecarInjectAnnotation`). When the annotation matches the expected value, it creates the setup Job in the release namespace.
-4. **Setup Job** — same SQL setup as the Helm-hook path; connects to Postgres using cluster DNS (`<host>.<namespace>.svc.cluster.local`) when the database runs in another namespace.
+1. **EventBus** — NATS-backed bus in the release namespace
+   (`argoEvents.eventBusName`, default `default`).
+2. **EventSource** — watches Pod `ADD` events in the target namespace(s). Uses
+   `filter.afterStart: true`, so only Pods created **after** the EventSource starts
+   trigger events; existing Pods are ignored. It watches the union of the target
+   namespaces of every enabled database.
+3. **Sensor** (one per database entry) — subscribes to the EventSource and filters
+   on the `sidecar.opentelemetry.io/inject` annotation
+   (`argoEvents.sidecarInjectAnnotation`). When the annotation matches the expected
+   value, it creates the setup Job in the release namespace.
+4. **Setup Job** — the same setup as the Helm-hook path; connects using cluster DNS
+   (`<host>.<namespace>.svc.cluster.local`) when the database runs in another
+   namespace.
 
-When `argoEvents.enabled=false`, or `argoEvents.triggerSetupJob=false`, the setup Job is created directly as a Helm `post-install` / `post-upgrade` hook instead.
+When `argoEvents.enabled=false`, or `argoEvents.triggerSetupJob=false`, the setup
+Job is created directly as a Helm `post-install` / `post-upgrade` hook instead.
 
 #### Sidecar inject annotation
 
-The OTel Operator must inject the sidecar before the Sensor fires. Annotate the target Pod (or its controller template) with `sidecar.opentelemetry.io/inject`:
+The OTel Operator must inject the sidecar before the Sensor fires. Annotate the
+target Pod (or its controller template) with `sidecar.opentelemetry.io/inject`:
 
 | Scenario | Expected annotation value |
 |----------|---------------------------|
-| Postgres in the same namespace as the Helm release | `postgres-dbm-sidecar` (the `sidecar-name`) |
-| Postgres in a different namespace | `<releaseNamespace>/<sidecar-name>` (e.g. `observability/postgres-dbm-sidecar`) |
+| Database in the same namespace as the Helm release | the entry's `sidecar-name` |
+| Database in a different namespace | `<releaseNamespace>/<sidecar-name>` (e.g. `observability/postgres-dbm-sidecar`) |
 
-The Sensor filter is derived automatically from `postgres.databases[*].namespace` and `sidecar-name`. The `OpenTelemetryCollector` CR always lives in the release namespace; cross-namespace injection is driven by the annotation prefix.
+The Sensor filter is derived automatically from each entry's `namespace` and
+`sidecar-name`. The `OpenTelemetryCollector` CR always lives in the release
+namespace; cross-namespace injection is driven by the annotation prefix.
 
 #### Cross-namespace example
 
-Install DB monitoring in `observability`, target Postgres in `demo`:
+Install monitoring in `observability`, targeting a database in `demo`. The example
+uses PostgreSQL; the shape is identical for every engine.
 
 ```yaml
 # values.yaml for: helm install dbm … -n observability
@@ -111,19 +154,26 @@ argoEvents:
   triggerSetupJob: true
 ```
 
-On the Postgres Pod (in `demo`):
+On the database Pod (in `demo`):
 
 ```yaml
 podAnnotations:
   sidecar.opentelemetry.io/inject: "observability/postgres-dbm-sidecar"
 ```
 
-After install, restart the Postgres Pod so the EventSource emits a fresh `ADD` event:
+After install, restart the Pod so the EventSource emits a fresh `ADD` event:
 
 ```bash
 kubectl delete pod -n demo -l app.kubernetes.io/name=postgresql
 kubectl get jobs -n observability -l app.kubernetes.io/component=db-monitoring-setup -w
 ```
+
+#### Multiple databases
+
+Add more entries to an engine's `databases` list, or enable several engines at
+once. Every entry gets its own sidecar CR, monitor Secret, and setup Job, and each
+needs a distinct `sidecar-name`. The Argo Events plumbing (EventBus, EventSource,
+RBAC) is shared across all of them.
 
 #### Disabling Argo Events
 
@@ -133,16 +183,22 @@ argoEvents:
   triggerSetupJob: false  # use Helm hook Jobs even when argoEvents.enabled=true
 ```
 
-Argo Events CRDs are bundled under `crds/` and installed before other chart resources. The `argo-events` subchart is gated by `argoEvents.enabled`; its own CRD install is disabled (`argo-events.crds.install: false`) because this chart ships the CRDs.
+Argo Events CRDs are bundled under `crds/` and installed before other chart
+resources. The `argo-events` subchart is gated by `argoEvents.enabled`; its own CRD
+install is disabled (`argo-events.crds.install: false`) because this chart ships
+the CRDs.
 
 ## Prerequisites
 
 - Kubernetes 1.21+
-- [OpenTelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator) installed in the cluster (provides the `OpenTelemetryCollector` CRD and injects sidecars)
-- PostgreSQL 10+ (for `pg_stat_progress_vacuum`)
-- A superuser (or a role with `CREATEROLE` and `CREATEDB`) available to run the setup Job — credentials are passed via `postgres.databases[*].user` / `postgres.databases[*].pwd`
-- An `otel` database must exist on each target PostgreSQL instance before install (the Job connects to it: `psql … -d otel`)
-- When using Argo Events (`argoEvents.enabled=true`): Argo Events CRDs must be available (installed from this chart's `crds/` directory on first install)
+- [OpenTelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator)
+  installed in the cluster. It provides the `OpenTelemetryCollector` CRD and injects
+  the sidecars.
+- An OTLP endpoint reachable at `$K8S_NODE_IP:4317`, such as a DaemonSet Collector.
+- When using Argo Events (`argoEvents.enabled=true`): the Argo Events CRDs, which
+  are installed from this chart's `crds/` directory on first install.
+- Per-database version and privilege requirements are listed in each database's
+  setup section.
 
 ## Installation
 
@@ -150,91 +206,40 @@ Argo Events CRDs are bundled under `crds/` and installed before other chart reso
 helm repo add tsuga-charts https://tsuga-dev.github.io/helm-charts/
 helm repo update
 
-helm install pg-monitoring tsuga-charts/opentelemetry-database-monitoring \
+helm install db-monitoring tsuga-charts/opentelemetry-database-monitoring \
   --set postgres.enabled=true \
   --set postgres.databases[0].name=postgresql \
   --set postgres.databases[0].host=postgresql \
   --set postgres.databases[0].user=root \
-  --set postgres.databases[0].pwd=<superuser-password>
+  --set postgres.databases[0].pwd=<admin-password>
 ```
 
-With Argo Events enabled (default), install into the namespace where you want the sidecar CRs, EventBus, and setup Jobs to live. Set `postgres.databases[*].namespace` when Postgres runs elsewhere.
+Install into the namespace where you want the sidecar CRs, EventBus, and setup Jobs
+to live. Set the entry's `namespace` when the database runs elsewhere.
 
-## Examples
+## PostgreSQL
 
-### Single database (same namespace)
+Enable with `postgres.enabled=true`.
 
-```yaml
-postgres:
-  enabled: true
-  databases:
-    - name: postgresql
-      sidecar-name: postgres-dbm-sidecar
-      user: root
-      pwd: otel
-      port: 5432
-      host: postgresql
+### Requirements
 
-argoEvents:
-  enabled: true
-  triggerSetupJob: true
-```
+- PostgreSQL 10 or later, for `pg_stat_progress_vacuum`.
+- An `otel` database must already exist on the instance. The setup Job connects to
+  it directly (`psql … -d otel`).
+- The admin credentials in `postgres.databases[*].user` / `pwd` must be a superuser,
+  or a role with `CREATEROLE` and `CREATEDB`.
 
-Annotate the Postgres Pod with `sidecar.opentelemetry.io/inject: postgres-dbm-sidecar`.
-
-### Cross-namespace database
-
-```yaml
-postgres:
-  enabled: true
-  databases:
-    - name: postgresql
-      namespace: demo
-      sidecar-name: postgres-dbm-sidecar
-      user: root
-      pwd: otel
-      port: 5432
-      host: postgresql
-
-argoEvents:
-  enabled: true
-  triggerSetupJob: true
-```
-
-Annotate the Postgres Pod in `demo` with `sidecar.opentelemetry.io/inject: <releaseNamespace>/postgres-dbm-sidecar`.
-
-### Multiple databases
-
-Each entry produces an independent set of resources (Secret, Sensor, sidecar CR, and setup Job trigger).
-
-```yaml
-postgres:
-  enabled: true
-  databases:
-    - name: postgresql
-      namespace: demo
-      sidecar-name: postgres-dbm-sidecar
-      user: root
-      pwd: otel
-      port: 5432
-      host: postgresql
-    - name: postgresql2
-      namespace: staging
-      sidecar-name: postgres2-dbm-sidecar
-      user: root
-      pwd: otel
-      port: 5432
-      host: postgresql2
-```
-
-## Database setup
+### Setup
 
 The setup Job runs `assets/pg-monitoring-setup.sql` idempotently. It:
 
-1. Creates the `otel_monitor` user (if absent) and grants it `pg_monitor` + `SELECT` on `pg_stat_database`.
+1. Creates the `otel_monitor` user and grants it `pg_monitor` plus `SELECT` on
+   `pg_stat_database`.
 2. Enables the `pg_stat_statements` extension.
 3. Creates the `otel` schema and grants `USAGE` to `otel_monitor`.
-4. Installs the following stored functions (all `STABLE`, safe for repeated execution):
+4. Installs the stored functions below, all `STABLE` and safe to re-run.
+5. Grants `EXECUTE` on all `otel` functions to `otel_monitor`.
+6. Rotates the `otel_monitor` password to match the Secret.
 
 | Function | Description |
 |----------|-------------|
@@ -246,21 +251,13 @@ The setup Job runs `assets/pg-monitoring-setup.sql` idempotently. It:
 | `otel.pg_idle_in_transaction()` | Idle-in-transaction connection count and max age per database. |
 | `otel.pg_replication_slots()` | Replication slot lag in bytes per slot. |
 | `otel.pg_wal()` | WAL segment file count and total WAL directory size. |
-| `otel.pg_vacuum_progress()` | Active vacuum operations with phase and block progress (PG 10+). |
-| `otel.pg_top_queries()` | Top 20 queries by call count from `pg_stat_statements`. Query text truncated to 200 characters. |
+| `otel.pg_vacuum_progress()` | Active vacuum operations with phase and block progress. |
+| `otel.pg_top_queries()` | Top queries by call count from `pg_stat_statements`. |
 
-5. Grants `EXECUTE` on all `otel` functions to `otel_monitor`.
-6. Rotates the `otel_monitor` password to match the value in the Secret.
+### Metrics
 
-> **Note:** The Job connects to the `otel` database (`-d otel`). This database must exist before the chart is installed.
-
-## Metrics
-
-The sidecar collector runs two categories of receivers.
-
-### Built-in `postgresql` receiver
-
-Polls the PostgreSQL stats system views directly. Default collection interval.
+The `postgresql` receiver polls the PostgreSQL statistics views directly, with 20
+default-disabled metrics additionally enabled by this chart.
 
 | Metric | Unit | Description |
 |--------|------|-------------|
@@ -281,78 +278,152 @@ Polls the PostgreSQL stats system views directly. Default collection interval.
 | `postgresql.wal.age` | `s` | WAL archiver age |
 | `postgresql.wal.lag` | `s` | Replication WAL lag |
 
-### `sqlquery` receivers (stored functions)
+The `sqlquery` receivers read the stored functions installed above:
 
 | Receiver | Interval | Metrics |
 |----------|----------|---------|
 | `sqlquery/postgresql_top_queries` | default | `postgresql.query.calls`, `.rows`, `.exec_time`, `.plan_time`, `.blocks.shared.*`, `.blocks.temp.*` — attributed by `db.namespace`, `db.user.name`, `server.address`, `db.query.text`, `db.version` |
 | `sqlquery/pg_table_stats` | 5 min | `postgresql.table.vacuum.age`, `.autovacuum.age`, `.analyze.age`, `.autoanalyze.age`, `.autovacuum.count`, `.analyze.count`, `.autoanalyze.count`, `.rows.modified.since.analyze` |
 | `sqlquery/pg_bloat` | 1 hour | `postgresql.table.bloat.ratio`, `postgresql.table.bloat.bytes` |
-| `sqlquery/pg_connections` | 30 s | `postgresql.backends` (count), `postgresql.backends.age` (max state age) |
+| `sqlquery/pg_connections` | 30 s | `postgresql.backends`, `postgresql.backends.age` |
 | `sqlquery/pg_locks` | 30 s | `postgresql.lock.count`, `postgresql.lock.blocking_queries`, `postgresql.connection.idle_in_transaction`, `postgresql.connection.idle_in_transaction.age` |
 | `sqlquery/pg_replication` | 30 s | `postgresql.replication.slot.lag` |
 | `sqlquery/pg_wal` | 60 s | `postgresql.wal.file_count`, `postgresql.wal.bytes` |
 | `sqlquery/pg_vacuum_progress` | 60 s | `postgresql.vacuum.heap_blks_total`, `.heap_blks_scanned`, `.heap_blks_vacuumed`, `postgresql.vacuum.age` |
 
-All metrics are batched (max 5000 per batch) and exported via OTLP/gRPC to `$K8S_NODE_IP:4317`.
+### Example
+
+See `examples/pg-single-db/` and `examples/pg-multiple-db/`.
+
+```yaml
+postgres:
+  enabled: true
+  databases:
+    - name: postgresql
+      sidecar-name: postgres-dbm-sidecar
+      user: root
+      pwd: otel
+      port: 5432
+      host: postgresql
+```
+
+Annotate the PostgreSQL Pod with
+`sidecar.opentelemetry.io/inject: postgres-dbm-sidecar`.
+
+## Query collection
+
+Several database receivers can report per-query data through a native
+`top_query_collection` or `query_sample_collection` block. Those blocks emit **log
+records** — the `db.server.top_query` and `db.server.query_sample` events — and
+that logs signal is at **Development** stability. This chart exports metrics only,
+so where per-query data is available it is collected with the `sqlquery` receiver
+against a view or function installed by the setup script.
+
+| Database | Per-query metrics | Mechanism |
+|----------|------------------|-----------|
+| PostgreSQL | yes | `sqlquery` over `otel.pg_top_queries()` |
+
+The native blocks are functional, so this is a choice about signal type rather than
+a workaround. To use the native events instead, enable them on the receiver and add
+a `logs` pipeline by overriding the engine's asset config. Do not run both: they
+report the same data twice.
 
 ## Security notes
 
-- The superuser credentials (`user`/`pwd`) are used only by the setup Job and are not stored in any long-lived secret.
-- The sidecar uses the auto-generated `otel_monitor` password from the Secret. With Helm hook Jobs, the password is rotated on every `helm upgrade`. With Argo Events, rotation happens each time a new setup Job completes.
-- The Secret is created with `lookup` to preserve the existing password across upgrades — a new random 24-character password is only generated on first install.
-- The `otel_monitor` user holds `pg_monitor` (read-only system views) and `EXECUTE` on the `otel.*` functions. It has no write access to application data.
-- All SQL connections from the sidecar use `sslmode=disable`. Enable TLS by overriding `assets/pg-monitoring-config.yaml` if your PostgreSQL requires it.
+- The admin credentials (`user` / `pwd`) are used only by the setup Job. They are
+  interpolated into the Job spec, so they are readable by anyone who can read Jobs
+  in the release namespace, and are not written to a Secret.
+- The sidecar uses the auto-generated `otel_monitor` password from the Secret. With
+  Helm hook Jobs the password is rotated on every `helm upgrade`; with Argo Events,
+  rotation happens each time a new setup Job completes.
+- The Secret is created with `lookup` to preserve the existing password across
+  upgrades. A new random 24-character password is generated only on first install.
+- The `otel_monitor` user is read-only on every database and has no write access to
+  application data. The exact grants are listed in each database's setup section.
+- **Why TLS is off between the sidecar and the database.** The Collector runs as a
+  sidecar *inside the database Pod*, so it reaches the server over the Pod's own
+  network namespace and that traffic never leaves the Pod. That is the assumption
+  behind disabling TLS on the receivers and their `sqlquery` datasources. **If you
+  repoint these configs at a database outside the Pod, the assumption no longer
+  holds** — configure TLS first by overriding the engine's asset config.
+- The export hop to `$K8S_NODE_IP:4317` also runs without TLS. Unlike the database
+  hop this one does leave the Pod, so it relies on the node-local Collector being
+  trusted.
+- The Collector image is pinned to a concrete tag. An untagged image resolves to
+  `:latest`, which forces `imagePullPolicy: Always` and lets the Collector version
+  change under the configuration in `assets/`.
 
 ## Upgrading
 
-**Without Argo Events** (`argoEvents.enabled=false` or `argoEvents.triggerSetupJob=false`): the setup Job runs on both `post-install` and `post-upgrade` Helm hooks with a `before-hook-creation` deletion policy, so it re-runs on every `helm upgrade`.
+**Without Argo Events** (`argoEvents.enabled=false` or
+`argoEvents.triggerSetupJob=false`): the setup Job runs on both `post-install` and
+`post-upgrade` Helm hooks with a `before-hook-creation` deletion policy, so it
+re-runs on every `helm upgrade`.
 
-**With Argo Events** (default): the setup Job is created by a Sensor when a new target Pod is added with the correct inject annotation. Upgrading the chart updates EventSource/Sensor configuration but does not re-run setup on existing Pods. Restart the target Postgres Pod after upgrade if you need setup to run again.
+**With Argo Events** (default): the setup Job is created by a Sensor when a new
+target Pod is added with the correct inject annotation. Upgrading the chart updates
+EventSource and Sensor configuration but does not re-run setup on existing Pods.
+Restart the target Pod after upgrade if you need setup to run again.
 
-All SQL statements are idempotent and the password rotation uses the existing Secret value.
+All setup scripts are idempotent, and password rotation uses the existing Secret
+value.
 
 ## Troubleshooting
 
-**Setup Job never created (Argo Events enabled)**
+**Authentication errors in the sidecar right after a Pod starts**
 
-1. Confirm EventBus, EventSource, and Sensor exist in the **Helm release namespace**:
-   ```bash
-   kubectl get eventbus,eventsource,sensor -n <release-namespace>
-   ```
-2. Verify the Sensor filter matches the Pod annotation (same namespace → `sidecar-name`; cross-namespace → `<releaseNamespace>/<sidecar-name>`):
-   ```bash
-   kubectl get sensor -n <release-namespace> -o yaml | rg 'value:|eventName:'
-   kubectl get pod -n <target-namespace> <postgres-pod> -o jsonpath='{.metadata.annotations.sidecar\.opentelemetry\.io/inject}{"\n"}'
-   ```
-3. The EventSource ignores Pods that existed before it started (`afterStart: true`). Restart the Postgres Pod after install or upgrade:
-   ```bash
-   kubectl delete pod -n <target-namespace> -l app.kubernetes.io/name=postgresql
-   kubectl get jobs -n <release-namespace> -l app.kubernetes.io/component=db-monitoring-setup -w
-   ```
-4. Remove stale EventBus/EventSource/Sensor objects left over from an install in a different release namespace.
+Expected, and self-correcting. With Argo Events driving setup, the sequence is: the
+Pod starts, the operator injects the sidecar, the Sensor sees the Pod and creates
+the setup Job, and the Job creates the `otel_monitor` user. The sidecar therefore
+begins scraping a few seconds before that user exists, and logs one scrape failure
+per interval until it does.
 
-**Job fails immediately**
+Compare the error timestamp against the Job's completion time before treating it as
+a real failure:
 
-Check that the `otel` database exists and the superuser credentials are correct:
 ```bash
-kubectl logs -l app.kubernetes.io/component=db-monitoring-setup -n <release-namespace>
+kubectl -n <release-namespace> get job -l app.kubernetes.io/component=db-monitoring-setup \
+  -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.completionTime}{"\n"}{end}'
 ```
 
-**Sidecar init container fails with secret not found**
+Errors older than the completion time are the startup race. Errors newer than it
+are a real problem: check that the Job succeeded, and that the monitor Secret in
+the database's namespace matches the one in the release namespace.
 
-The monitor Secret must exist in the **Pod's namespace**. Set `postgres.databases[*].namespace` so the chart replicates the Secret into the target namespace.
+**Setup Job never created (Argo Events enabled)**
 
-**No metrics in the collector**
+The EventSource only reports Pods created after it starts (`filter.afterStart:
+true`). Restart the database Pod:
 
-Verify the `OpenTelemetryCollector` CR was injected as a sidecar into the target Pod. The OTel Operator must be running and the Pod must have the `sidecar.opentelemetry.io/inject` annotation (or the operator must be configured for namespace-wide injection).
+```bash
+kubectl delete pod -n <target-namespace> -l <your-database-selector>
+```
 
-**`pg_stat_statements` not available**
+Then confirm the annotation on the Pod matches the value the Sensor expects — see
+[Sidecar inject annotation](#sidecar-inject-annotation).
 
-The extension must be listed in `shared_preload_libraries` in `postgresql.conf` and PostgreSQL must be restarted before it can be created. Add `shared_preload_libraries = 'pg_stat_statements'` to your PostgreSQL configuration and restart the server before installing the chart.
+**Sidecar not injected**
 
-**Top queries missing**
+Check that the OpenTelemetry Operator is running, that the
+`OpenTelemetryCollector` CR exists in the release namespace, and that the Pod
+annotation carries the `<releaseNamespace>/` prefix when the database runs in
+another namespace:
 
-Queries run by the collector itself are excluded via the `/* otel-collector-ignore */` comment prefix. If `otel.pg_top_queries()` returns no rows, check that `pg_stat_statements.track` is not set to `none`.
+```bash
+kubectl get opentelemetrycollectors -A
+kubectl -n <target-namespace> get pod <pod> -o jsonpath='{.spec.initContainers[*].name}'
+```
+
+The operator injects the Collector as a native sidecar, so it appears under
+`initContainers` with `restartPolicy: Always` rather than under `containers`.
+
+**Setup Job failing**
+
+```bash
+kubectl -n <release-namespace> logs job/<db-name>-<engine>-monitoring-setup
+```
+
+The Job waits for the database to accept connections before running setup, so a Job
+stuck in that loop means the `host` and `port` in values do not reach the database.
 
 {{ template "chart.valuesSection" . }}

--- a/charts/opentelemetry-database-monitoring/assets/pg-monitoring-config.yaml
+++ b/charts/opentelemetry-database-monitoring/assets/pg-monitoring-config.yaml
@@ -1,4 +1,9 @@
 receivers:
+  # The collector runs as a sidecar inside the PostgreSQL Pod and reaches the
+  # server over the Pod's own network namespace, so this traffic does not leave
+  # the Pod. TLS is disabled here and every sqlquery datasource below sets
+  # sslmode=disable. Configure TLS before pointing this config at a PostgreSQL
+  # server outside the Pod.
   postgresql:
     endpoint: ${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME}:5432
     metrics:
@@ -398,7 +403,9 @@ processors:
     send_batch_max_size: 5000
     send_batch_size: 5000
 exporters:
-  otlp:
+  # otlp_grpc is the canonical exporter type. The shorter `otlp` spelling is a
+  # deprecated alias that logs a warning on every collector startup.
+  otlp_grpc:
     compression: gzip
     endpoint: ${env:K8S_NODE_IP}:4317
     tls:
@@ -407,7 +414,7 @@ service:
   pipelines:
     metrics:
       exporters:
-        - otlp
+        - otlp_grpc
       processors:
         - batch
       receivers:

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-eventbus.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-eventbus.yaml
@@ -5,7 +5,7 @@ kind: EventBus
 metadata:
   name: default
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-events-rbac.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-events-rbac.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-database-monitoring-argo-eventsource
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -17,7 +17,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-database-monitoring-argo-sensor
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -30,7 +30,7 @@ metadata:
   name: example-opentelemetry-database-monitoring-argo-eventsource
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -46,7 +46,7 @@ kind: Role
 metadata:
   name: example-opentelemetry-database-monitoring-argo-sensor
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -63,7 +63,7 @@ metadata:
   name: example-opentelemetry-database-monitoring-argo-eventsource
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -83,7 +83,7 @@ kind: RoleBinding
 metadata:
   name: example-opentelemetry-database-monitoring-argo-sensor
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-eventsource.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-eventsource.yaml
@@ -5,7 +5,7 @@ kind: EventSource
 metadata:
   name: example-opentelemetry-database-monitoring-pod-created
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-sensor.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/argo-sensor.yaml
@@ -5,7 +5,7 @@ kind: Sensor
 metadata:
   name: example-opentelemetry-database-monitoring-postgresql-setup
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -39,7 +39,7 @@ spec:
                 generateName: postgresql-postgresql-monitoring-setup-
                 namespace: default
                 labels:
-                  helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+                  helm.sh/chart: opentelemetry-database-monitoring-0.2.0
                   app.kubernetes.io/name: opentelemetry-database-monitoring
                   app.kubernetes.io/instance: example
                   app.kubernetes.io/version: "1.16.0"
@@ -91,7 +91,7 @@ kind: Sensor
 metadata:
   name: example-opentelemetry-database-monitoring-postgresql2-setup
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -125,7 +125,7 @@ spec:
                 generateName: postgresql2-postgresql-monitoring-setup-
                 namespace: default
                 labels:
-                  helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+                  helm.sh/chart: opentelemetry-database-monitoring-0.2.0
                   app.kubernetes.io/name: opentelemetry-database-monitoring
                   app.kubernetes.io/instance: example
                   app.kubernetes.io/version: "1.16.0"

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/configmap-pg-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/configmap-pg-monitoring.yaml
@@ -317,4 +317,3 @@ data:
     -- ---------------------------------------------------------------------------
     
     GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA otel TO otel_monitor;
-    

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/postgres-dbm-sidecar.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/postgres-dbm-sidecar.yaml
@@ -8,7 +8,7 @@ metadata:
     meta.helm.sh/release-name: "example"
     meta.helm.sh/release-namespace: "default"
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -16,7 +16,7 @@ metadata:
     opentelemetry-database-monitoring/database: postgresql
 spec:
   mode: sidecar
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
   env:
     - name: K8S_NODE_IP
       valueFrom:
@@ -29,6 +29,11 @@ spec:
           key: password
   config:
     receivers:
+      # The collector runs as a sidecar inside the PostgreSQL Pod and reaches the
+      # server over the Pod's own network namespace, so this traffic does not leave
+      # the Pod. TLS is disabled here and every sqlquery datasource below sets
+      # sslmode=disable. Configure TLS before pointing this config at a PostgreSQL
+      # server outside the Pod.
       postgresql:
         endpoint: ${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME}:5432
         metrics:
@@ -428,7 +433,9 @@ spec:
         send_batch_max_size: 5000
         send_batch_size: 5000
     exporters:
-      otlp:
+      # otlp_grpc is the canonical exporter type. The shorter `otlp` spelling is a
+      # deprecated alias that logs a warning on every collector startup.
+      otlp_grpc:
         compression: gzip
         endpoint: ${env:K8S_NODE_IP}:4317
         tls:
@@ -437,7 +444,7 @@ spec:
       pipelines:
         metrics:
           exporters:
-            - otlp
+            - otlp_grpc
           processors:
             - batch
           receivers:
@@ -460,7 +467,7 @@ metadata:
     meta.helm.sh/release-name: "example"
     meta.helm.sh/release-namespace: "default"
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -468,7 +475,7 @@ metadata:
     opentelemetry-database-monitoring/database: postgresql2
 spec:
   mode: sidecar
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
   env:
     - name: K8S_NODE_IP
       valueFrom:
@@ -481,6 +488,11 @@ spec:
           key: password
   config:
     receivers:
+      # The collector runs as a sidecar inside the PostgreSQL Pod and reaches the
+      # server over the Pod's own network namespace, so this traffic does not leave
+      # the Pod. TLS is disabled here and every sqlquery datasource below sets
+      # sslmode=disable. Configure TLS before pointing this config at a PostgreSQL
+      # server outside the Pod.
       postgresql:
         endpoint: ${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME}:5432
         metrics:
@@ -880,7 +892,9 @@ spec:
         send_batch_max_size: 5000
         send_batch_size: 5000
     exporters:
-      otlp:
+      # otlp_grpc is the canonical exporter type. The shorter `otlp` spelling is a
+      # deprecated alias that logs a warning on every collector startup.
+      otlp_grpc:
         compression: gzip
         endpoint: ${env:K8S_NODE_IP}:4317
         tls:
@@ -889,7 +903,7 @@ spec:
       pipelines:
         metrics:
           exporters:
-            - otlp
+            - otlp_grpc
           processors:
             - batch
           receivers:

--- a/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/secret-pg-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-multiple-db/rendered/secret-pg-monitoring.yaml
@@ -6,7 +6,7 @@ metadata:
   name: postgresql-pg-monitor-credentials
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -23,7 +23,7 @@ metadata:
   name: postgresql2-pg-monitor-credentials
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-eventbus.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-eventbus.yaml
@@ -5,7 +5,7 @@ kind: EventBus
 metadata:
   name: default
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-events-rbac.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-events-rbac.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-database-monitoring-argo-eventsource
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -17,7 +17,7 @@ kind: ServiceAccount
 metadata:
   name: example-opentelemetry-database-monitoring-argo-sensor
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -30,7 +30,7 @@ metadata:
   name: example-opentelemetry-database-monitoring-argo-eventsource
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -46,7 +46,7 @@ kind: Role
 metadata:
   name: example-opentelemetry-database-monitoring-argo-sensor
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -63,7 +63,7 @@ metadata:
   name: example-opentelemetry-database-monitoring-argo-eventsource
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -83,7 +83,7 @@ kind: RoleBinding
 metadata:
   name: example-opentelemetry-database-monitoring-argo-sensor
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-eventsource.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-eventsource.yaml
@@ -5,7 +5,7 @@ kind: EventSource
 metadata:
   name: example-opentelemetry-database-monitoring-pod-created
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-sensor.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/argo-sensor.yaml
@@ -5,7 +5,7 @@ kind: Sensor
 metadata:
   name: example-opentelemetry-database-monitoring-postgresql-setup
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -39,7 +39,7 @@ spec:
                 generateName: postgresql-postgresql-monitoring-setup-
                 namespace: default
                 labels:
-                  helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+                  helm.sh/chart: opentelemetry-database-monitoring-0.2.0
                   app.kubernetes.io/name: opentelemetry-database-monitoring
                   app.kubernetes.io/instance: example
                   app.kubernetes.io/version: "1.16.0"

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/configmap-pg-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/configmap-pg-monitoring.yaml
@@ -317,4 +317,3 @@ data:
     -- ---------------------------------------------------------------------------
     
     GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA otel TO otel_monitor;
-    

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/postgres-dbm-sidecar.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/postgres-dbm-sidecar.yaml
@@ -8,7 +8,7 @@ metadata:
     meta.helm.sh/release-name: "example"
     meta.helm.sh/release-namespace: "default"
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"
@@ -16,7 +16,7 @@ metadata:
     opentelemetry-database-monitoring/database: postgresql
 spec:
   mode: sidecar
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
   env:
     - name: K8S_NODE_IP
       valueFrom:
@@ -29,6 +29,11 @@ spec:
           key: password
   config:
     receivers:
+      # The collector runs as a sidecar inside the PostgreSQL Pod and reaches the
+      # server over the Pod's own network namespace, so this traffic does not leave
+      # the Pod. TLS is disabled here and every sqlquery datasource below sets
+      # sslmode=disable. Configure TLS before pointing this config at a PostgreSQL
+      # server outside the Pod.
       postgresql:
         endpoint: ${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME}:5432
         metrics:
@@ -428,7 +433,9 @@ spec:
         send_batch_max_size: 5000
         send_batch_size: 5000
     exporters:
-      otlp:
+      # otlp_grpc is the canonical exporter type. The shorter `otlp` spelling is a
+      # deprecated alias that logs a warning on every collector startup.
+      otlp_grpc:
         compression: gzip
         endpoint: ${env:K8S_NODE_IP}:4317
         tls:
@@ -437,7 +444,7 @@ spec:
       pipelines:
         metrics:
           exporters:
-            - otlp
+            - otlp_grpc
           processors:
             - batch
           receivers:

--- a/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/secret-pg-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/pg-single-db/rendered/secret-pg-monitoring.yaml
@@ -6,7 +6,7 @@ metadata:
   name: postgresql-pg-monitor-credentials
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-database-monitoring-0.1.2
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
     app.kubernetes.io/name: opentelemetry-database-monitoring
     app.kubernetes.io/instance: example
     app.kubernetes.io/version: "1.16.0"

--- a/charts/opentelemetry-database-monitoring/templates/NOTES.txt
+++ b/charts/opentelemetry-database-monitoring/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{- if include "opentelemetry-database-monitoring.anyEngineEnabled" . }}
 {{- if .Values.postgres.enabled }}
 PostgreSQL monitoring deployed for {{ len .Values.postgres.databases }} database(s).
 
@@ -7,12 +8,13 @@ PostgreSQL monitoring deployed for {{ len .Values.postgres.databases }} database
   Sidecar  : {{ index . "sidecar-name" }}
   Inject   : {{ include "opentelemetry-database-monitoring.sidecarInjectValue" (dict "root" $ "db" .) }}
 {{ end }}
+{{- end }}
 
 {{- if and .Values.argoEvents.enabled .Values.argoEvents.triggerSetupJob }}
 Argo Events will create setup Jobs when a new Pod is added with the inject annotation above.
-Existing Pods are ignored (afterStart filter). Restart the target Postgres Pod after install:
+Existing Pods are ignored (afterStart filter). Restart the target database Pod after install:
 
-  kubectl delete pod -n <target-namespace> -l app.kubernetes.io/name=postgresql
+  kubectl delete pod -n <target-namespace> -l <your-database-selector>
 
 Argo Events resources live in the release namespace ({{ .Release.Namespace }}).
 Remove stale EventBus/EventSource/Sensor objects from other namespaces if a previous install used a different release namespace.
@@ -25,10 +27,10 @@ Check that the setup Jobs completed successfully:
 {{- end }}
 
 If a Job failed, inspect its logs:
-  kubectl logs job/<db-name>-postgresql-monitoring-setup -n {{ .Release.Namespace }}
+  kubectl logs job/<db-name>-<engine>-monitoring-setup -n {{ .Release.Namespace }}
 
 Verify the OTel sidecars are running inside the target Pods:
   kubectl get opentelemetrycollectors -n {{ .Release.Namespace }}
 {{- else }}
-PostgreSQL monitoring is disabled. Set postgres.enabled=true to deploy.
+Database monitoring is disabled. Set postgres.enabled=true to deploy.
 {{- end }}

--- a/charts/opentelemetry-database-monitoring/templates/_helpers.tpl
+++ b/charts/opentelemetry-database-monitoring/templates/_helpers.tpl
@@ -48,14 +48,72 @@ app.kubernetes.io/name: {{ include "opentelemetry-database-monitoring.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 {{/*
-Namespace where the target Postgres pod (and injected sidecar) run.
+Namespace where the target database pod (and injected sidecar) run.
 */}}
 {{- define "opentelemetry-database-monitoring.databaseNamespace" -}}
 {{- default $.Release.Namespace (index . "namespace") -}}
 {{- end }}
 
 {{/*
-Monitor credentials secret name for a database entry.
+Space-separated list of the database engines this chart supports.
+
+Each name must match a top-level values key that has `enabled` and `databases`.
+The shared Argo Events plumbing is derived from this list, so adding an engine here
+is what brings it into the EventBus, EventSource and RBAC gating.
+*/}}
+{{- define "opentelemetry-database-monitoring.engines" -}}
+postgres
+{{- end }}
+
+{{/*
+True when at least one database engine is enabled.
+
+The Argo Events plumbing (EventBus, EventSource, RBAC) is shared across engines, so
+it is gated on the union rather than on any single engine.
+*/}}
+{{- define "opentelemetry-database-monitoring.anyEngineEnabled" -}}
+{{- $root := . -}}
+{{- $any := false -}}
+{{- range $engine := splitList " " (include "opentelemetry-database-monitoring.engines" $root) -}}
+{{- if (index $root.Values $engine).enabled -}}
+{{- $any = true -}}
+{{- end -}}
+{{- end -}}
+{{- if $any -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
+Comma-separated union of the namespaces the Argo EventSource must watch, across
+every enabled engine. Returned as a string because a template cannot return a list;
+callers do `splitList ","` on it.
+
+An explicit argoEvents.eventSource.watchNamespace overrides the union entirely.
+*/}}
+{{- define "opentelemetry-database-monitoring.watchNamespaces" -}}
+{{- $root := . -}}
+{{- $namespaces := list -}}
+{{- if $root.Values.argoEvents.eventSource.watchNamespace -}}
+{{- $namespaces = append $namespaces $root.Values.argoEvents.eventSource.watchNamespace -}}
+{{- else -}}
+{{- range $engine := splitList " " (include "opentelemetry-database-monitoring.engines" $root) -}}
+{{- $config := index $root.Values $engine -}}
+{{- if $config.enabled -}}
+{{- range $db := $config.databases -}}
+{{- $ns := include "opentelemetry-database-monitoring.databaseNamespace" (merge (dict) $db (dict "Release" $root.Release)) -}}
+{{- if not (has $ns $namespaces) -}}
+{{- $namespaces = append $namespaces $ns -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- join "," $namespaces -}}
+{{- end }}
+
+{{/*
+Monitor credentials secret name for a PostgreSQL database entry.
 */}}
 {{- define "opentelemetry-database-monitoring.monitorSecretName" -}}
 {{- printf "%s-pg-monitor-credentials" .name -}}
@@ -63,11 +121,16 @@ Monitor credentials secret name for a database entry.
 
 {{/*
 Resolve a stable monitor password, preferring an existing secret in the release or target namespace.
+
+Context:
+  .root       - root Helm context
+  .db         - database entry
+  .secretName - optional; defaults to the PostgreSQL monitor secret name
 */}}
 {{- define "opentelemetry-database-monitoring.monitorPassword" -}}
 {{- $root := .root -}}
 {{- $db := .db -}}
-{{- $secretName := include "opentelemetry-database-monitoring.monitorSecretName" $db -}}
+{{- $secretName := default (include "opentelemetry-database-monitoring.monitorSecretName" $db) .secretName -}}
 {{- $targetNamespace := include "opentelemetry-database-monitoring.databaseNamespace" (merge (dict) $db (dict "Release" $root.Release)) -}}
 {{- $password := randAlphaNum 24 -}}
 {{- $releaseSecret := lookup "v1" "Secret" $root.Release.Namespace $secretName -}}
@@ -83,13 +146,18 @@ Resolve a stable monitor password, preferring an existing secret in the release 
 {{- end }}
 
 {{/*
-Hostname used by setup Jobs to reach Postgres.
+Hostname used by setup Jobs to reach the database.
 Uses cluster DNS when the database runs in another namespace.
 */}}
 {{- define "opentelemetry-database-monitoring.databaseHost" -}}
 {{- $root := .root -}}
 {{- $db := .db -}}
-{{- $host := $db.host -}}
+{{/*
+default "" coerces an absent host to a string. A values override that replaces a
+databases[] entry without repeating `host` otherwise yields nil here, and the
+`contains` below fails the render with "invalid value; expected string".
+*/}}
+{{- $host := default "" $db.host -}}
 {{- if contains "." $host -}}
 {{- $host -}}
 {{- else -}}

--- a/charts/opentelemetry-database-monitoring/templates/argo-eventbus.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/argo-eventbus.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.postgres.enabled .Values.argoEvents.enabled .Values.argoEvents.eventBus.create }}
+{{- if and (include "opentelemetry-database-monitoring.anyEngineEnabled" .) .Values.argoEvents.enabled .Values.argoEvents.eventBus.create }}
 apiVersion: argoproj.io/v1alpha1
 kind: EventBus
 metadata:

--- a/charts/opentelemetry-database-monitoring/templates/argo-events-rbac.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/argo-events-rbac.yaml
@@ -1,18 +1,8 @@
-{{- if and .Values.postgres.enabled .Values.argoEvents.enabled }}
+{{- if and (include "opentelemetry-database-monitoring.anyEngineEnabled" .) .Values.argoEvents.enabled }}
 {{- $root := . }}
 {{- $eventSourceSa := default (printf "%s-argo-eventsource" (include "opentelemetry-database-monitoring.fullname" .)) .Values.argoEvents.eventSource.serviceAccount.name }}
 {{- $sensorSa := default (printf "%s-argo-sensor" (include "opentelemetry-database-monitoring.fullname" .)) .Values.argoEvents.sensor.serviceAccount.name }}
-{{- $watchNamespaces := list -}}
-{{- if .Values.argoEvents.eventSource.watchNamespace -}}
-{{- $watchNamespaces = append $watchNamespaces .Values.argoEvents.eventSource.watchNamespace -}}
-{{- else -}}
-{{- range $db := .Values.postgres.databases -}}
-{{- $ns := include "opentelemetry-database-monitoring.databaseNamespace" (merge (dict) $db (dict "Release" $root.Release)) -}}
-{{- if not (has $ns $watchNamespaces) -}}
-{{- $watchNamespaces = append $watchNamespaces $ns -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- $watchNamespaces := splitList "," (include "opentelemetry-database-monitoring.watchNamespaces" .) -}}
 
 {{- if .Values.argoEvents.eventSource.serviceAccount.create }}
 apiVersion: v1

--- a/charts/opentelemetry-database-monitoring/templates/argo-eventsource.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/argo-eventsource.yaml
@@ -1,17 +1,7 @@
-{{- if and .Values.postgres.enabled .Values.argoEvents.enabled }}
+{{- if and (include "opentelemetry-database-monitoring.anyEngineEnabled" .) .Values.argoEvents.enabled }}
 {{- $eventSourceName := default (printf "%s-pod-created" (include "opentelemetry-database-monitoring.fullname" .)) .Values.argoEvents.eventSource.name }}
 {{- $eventSourceSa := default (printf "%s-argo-eventsource" (include "opentelemetry-database-monitoring.fullname" .)) .Values.argoEvents.eventSource.serviceAccount.name }}
-{{- $watchNamespaces := list -}}
-{{- if .Values.argoEvents.eventSource.watchNamespace -}}
-{{- $watchNamespaces = append $watchNamespaces .Values.argoEvents.eventSource.watchNamespace -}}
-{{- else -}}
-{{- range $db := .Values.postgres.databases -}}
-{{- $ns := include "opentelemetry-database-monitoring.databaseNamespace" (merge (dict) $db (dict "Release" $.Release)) -}}
-{{- if not (has $ns $watchNamespaces) -}}
-{{- $watchNamespaces = append $watchNamespaces $ns -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- $watchNamespaces := splitList "," (include "opentelemetry-database-monitoring.watchNamespaces" .) -}}
 apiVersion: argoproj.io/v1alpha1
 kind: EventSource
 metadata:

--- a/charts/opentelemetry-database-monitoring/templates/argo-sensor.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/argo-sensor.yaml
@@ -1,9 +1,10 @@
-{{- if and .Values.postgres.enabled .Values.argoEvents.enabled .Values.argoEvents.triggerSetupJob }}
+{{- if and (include "opentelemetry-database-monitoring.anyEngineEnabled" .) .Values.argoEvents.enabled .Values.argoEvents.triggerSetupJob }}
 {{- $root := . }}
 {{- $eventSourceName := default (printf "%s-pod-created" (include "opentelemetry-database-monitoring.fullname" .)) .Values.argoEvents.eventSource.name }}
 {{- $sensorSa := default (printf "%s-argo-sensor" (include "opentelemetry-database-monitoring.fullname" .)) .Values.argoEvents.sensor.serviceAccount.name }}
 {{- $annotationKey := .Values.argoEvents.sidecarInjectAnnotation }}
 {{- $annotationPath := $annotationKey | replace "." "\\." | replace "/" "\\/" }}
+{{- if .Values.postgres.enabled }}
 {{- range $db := .Values.postgres.databases }}
 {{- $sidecarInjectValue := include "opentelemetry-database-monitoring.sidecarInjectValue" (dict "root" $root "db" $db) }}
 {{- $targetNamespace := include "opentelemetry-database-monitoring.databaseNamespace" (merge (dict) $db (dict "Release" $root.Release)) }}
@@ -41,5 +42,6 @@ spec:
           source:
             resource:
 {{ include "opentelemetry-database-monitoring.setupJob" (dict "root" $root "db" $db "useName" false "useGenerateName" true) | indent 14 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/opentelemetry-database-monitoring/templates/configmap-pg-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/configmap-pg-monitoring.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgres.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,3 +6,4 @@ metadata:
 data:
   monitoring-setup.sql: |
 {{ .Files.Get "assets/pg-monitoring-setup.sql" | indent 4 }}
+{{- end }}

--- a/charts/opentelemetry-database-monitoring/templates/postgres-dbm-sidecar.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/postgres-dbm-sidecar.yaml
@@ -14,7 +14,7 @@ metadata:
     opentelemetry-database-monitoring/database: {{ $db.name }}
 spec:
   mode: sidecar
-  image: {{ $root.Values.postgres.image | default "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib" }}
+  image: {{ $root.Values.postgres.image | default "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0" }}
   env:
     - name: K8S_NODE_IP
       valueFrom:

--- a/charts/opentelemetry-database-monitoring/tests/argo-events_test.yaml
+++ b/charts/opentelemetry-database-monitoring/tests/argo-events_test.yaml
@@ -1,0 +1,77 @@
+---
+suite: shared argo events plumbing
+templates:
+  - argo-sensor.yaml
+  - argo-eventsource.yaml
+  - argo-eventbus.yaml
+tests:
+  - it: should render no argo resources when every engine is disabled
+    set:
+      postgres.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render argo plumbing when an engine is enabled
+    template: argo-eventbus.yaml
+    set:
+      postgres.enabled: true
+    asserts:
+      - isKind:
+          of: EventBus
+
+  - it: should create one sensor per database entry
+    template: argo-sensor.yaml
+    set:
+      postgres.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchRegex:
+          path: metadata.name
+          pattern: "-postgresql-setup$"
+
+  - it: should watch the target namespaces of enabled engines
+    template: argo-eventsource.yaml
+    set:
+      postgres.enabled: true
+      postgres.databases:
+        - name: pg
+          namespace: pg-ns
+          sidecar-name: postgres-dbm-sidecar
+          user: root
+          pwd: otel
+          port: 5432
+          host: pg
+    asserts:
+      - exists:
+          path: spec.resource.target-pod-created-pg-ns
+
+  - it: should let an explicit watchNamespace override the engine union
+    template: argo-eventsource.yaml
+    set:
+      postgres.enabled: true
+      argoEvents.eventSource.watchNamespace: only-here
+      postgres.databases:
+        - name: pg
+          namespace: pg-ns
+          sidecar-name: postgres-dbm-sidecar
+          user: root
+          pwd: otel
+          port: 5432
+          host: pg
+    asserts:
+      - exists:
+          path: spec.resource.target-pod-created-only-here
+      - notExists:
+          path: spec.resource.target-pod-created-pg-ns
+
+  - it: should not create a Helm setup job when argo events drives it
+    templates:
+      - argo-sensor.yaml
+    set:
+      postgres.enabled: true
+      argoEvents.triggerSetupJob: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/opentelemetry-database-monitoring/tests/postgres_test.yaml
+++ b/charts/opentelemetry-database-monitoring/tests/postgres_test.yaml
@@ -1,0 +1,118 @@
+---
+suite: postgresql monitoring tests
+templates:
+  - postgres-dbm-sidecar.yaml
+  - secret-pg-monitoring.yaml
+  - configmap-pg-monitoring.yaml
+tests:
+  - it: should render nothing when postgres is disabled
+    set:
+      postgres.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create the sidecar collector with a pinned image
+    template: postgres-dbm-sidecar.yaml
+    set:
+      postgres.enabled: true
+    asserts:
+      - isKind:
+          of: OpenTelemetryCollector
+      - equal:
+          path: metadata.name
+          value: "postgres-dbm-sidecar"
+      - equal:
+          path: spec.mode
+          value: sidecar
+      # An untagged image resolves to :latest, which forces
+      # imagePullPolicy: Always and lets the collector version change under the
+      # receiver configuration in assets/.
+      - matchRegex:
+          path: spec.image
+          pattern: ":[0-9]+\\.[0-9]+\\.[0-9]+$"
+
+  - it: should export through the canonical otlp_grpc exporter type
+    template: postgres-dbm-sidecar.yaml
+    set:
+      postgres.enabled: true
+    asserts:
+      # `otlp` is a deprecated alias for the exporter and logs a warning on every
+      # collector startup.
+      - exists:
+          path: spec.config.exporters.otlp_grpc
+      - notExists:
+          path: spec.config.exporters.otlp
+      - contains:
+          path: spec.config.service.pipelines.metrics.exporters
+          content: otlp_grpc
+
+  - it: should wire the monitor password from the secret
+    template: postgres-dbm-sidecar.yaml
+    set:
+      postgres.enabled: true
+    asserts:
+      - equal:
+          path: spec.env[1].name
+          value: OTEL_MONITOR_PASSWORD
+      - equal:
+          path: spec.env[1].valueFrom.secretKeyRef.name
+          value: "postgresql-pg-monitor-credentials"
+
+  - it: should not render the setup configmap when postgres is disabled
+    template: configmap-pg-monitoring.yaml
+    set:
+      postgres.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render the setup configmap when postgres is enabled
+    template: configmap-pg-monitoring.yaml
+    set:
+      postgres.enabled: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: "postgresql-monitoring-setup"
+
+  - it: should replicate the secret into a cross-namespace target
+    template: secret-pg-monitoring.yaml
+    set:
+      postgres.enabled: true
+      postgres.databases:
+        - name: postgresql
+          namespace: databases
+          sidecar-name: postgres-dbm-sidecar
+          user: root
+          pwd: otel
+          port: 5432
+          host: postgresql
+    release:
+      namespace: "otel"
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.namespace
+          value: "otel"
+        documentIndex: 0
+      - equal:
+          path: metadata.namespace
+          value: "databases"
+        documentIndex: 1
+
+  - it: should render with a databases entry that omits host
+    template: secret-pg-monitoring.yaml
+    set:
+      postgres.enabled: true
+      # An entry without `host` used to fail the render with
+      # "invalid value; expected string".
+      postgres.databases:
+        - name: postgresql
+          sidecar-name: postgres-dbm-sidecar
+    asserts:
+      - isKind:
+          of: Secret

--- a/charts/opentelemetry-database-monitoring/values.yaml
+++ b/charts/opentelemetry-database-monitoring/values.yaml
@@ -1,47 +1,123 @@
 ---
+# =============================================================================
+# POSTGRESQL
+# =============================================================================
 postgres:
+  # -- Deploy PostgreSQL monitoring: the injected sidecar collector, the monitor
+  # credentials secret, the setup ConfigMap, and the setup Job.
+  # @default -- false
   enabled: false
-  image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib"
+  # Keep the tag. An untagged image resolves to :latest, which forces
+  # imagePullPolicy: Always and lets the collector version change under the
+  # receiver configuration in assets/pg-monitoring-config.yaml.
+  # -- Collector image for the injected sidecar.
+  image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0"
+  # -- PostgreSQL instances to monitor. Each entry produces its own sidecar
+  # collector, monitor secret, and setup Job.
   databases:
+      # -- Name for this instance. Used as the prefix of the monitor secret and
+      # setup Job names, and set as the
+      # `opentelemetry-database-monitoring/database` label on every resource.
     - name: postgresql
-      # Namespace where the annotated Postgres pod runs. Replicates the monitor secret there and
-      # sets the expected inject annotation to "<releaseNamespace>/<sidecar-name>" when different.
+      # -- Namespace where the annotated PostgreSQL Pod runs. Replicates the
+      # monitor secret into that namespace and sets the expected inject
+      # annotation to `<releaseNamespace>/<sidecar-name>` when it differs from
+      # the release namespace. Empty means the release namespace.
+      # @default -- ""
       namespace: ""
+      # -- Name of the OpenTelemetryCollector resource for this instance. This is
+      # the value the target Pod's `sidecar.opentelemetry.io/inject` annotation
+      # must carry for the operator to inject the sidecar.
       sidecar-name: postgres-dbm-sidecar
+      # -- Administrative user the setup Job connects as. Needs to be a superuser,
+      # or a role with CREATEROLE and CREATEDB.
+      # @default -- ""
       user: ""
+      # -- Password for the administrative user. Interpolated into the setup Job
+      # spec, so it is readable by anyone who can read Jobs in the release
+      # namespace. It is not written to a secret.
+      # @default -- ""
       pwd: ""
+      # -- Port the setup Job connects to. The sidecar's receiver port is fixed at
+      # 5432 in assets/pg-monitoring-config.yaml; override that asset to change
+      # the port the collector uses.
       port: 5432
+      # -- Host the setup Job connects to, normally the PostgreSQL Service name. A
+      # value containing a dot is used as-is; otherwise, when the instance runs in
+      # another namespace, it is expanded to `<host>.<namespace>.svc.cluster.local`.
+      # @default -- ""
       host: ""
 
-# Installs the Argo Events controller when argoEvents.enabled is true.
-# CRDs are shipped in this chart's crds/ directory (installed before other resources).
+# =============================================================================
+# ARGO EVENTS SUBCHART
+# =============================================================================
+# Installs the Argo Events controller. The CRDs are shipped in this chart's crds/
+# directory, which Helm installs before any other resource, so the subchart must
+# not install them again.
 argo-events:
+  # -- Install the bundled Argo Events controller subchart.
+  # @default -- true
   enabled: true
   crds:
+    # -- Let the Argo Events subchart install its own CRDs. Keep this false: the
+    # CRDs are shipped in this chart's crds/ directory.
+    # @default -- false
     install: false
 
+# =============================================================================
+# ARGO EVENTS WIRING
+# =============================================================================
 argoEvents:
-  # When true, watch for pods with sidecar.opentelemetry.io/inject and trigger setup jobs.
+  # -- Watch for Pods carrying the sidecar inject annotation and react to them.
+  # Also gates the EventBus, EventSource, Sensors, and their RBAC.
+  # @default -- true
   enabled: true
-  # When true, Argo Events sensors create setup jobs instead of Helm post-install hooks.
+  # -- Create each setup Job from an Argo Events Sensor when a target Pod appears,
+  # instead of from a Helm post-install/post-upgrade hook. Running setup after the
+  # operator has injected the sidecar avoids racing database setup against sidecar
+  # startup, and allows the release to live in a different namespace from the
+  # database.
+  # @default -- true
   triggerSetupJob: true
-  # Pod annotation key used by the OpenTelemetry Operator for sidecar injection.
+  # -- Pod annotation key the OpenTelemetry Operator reads to inject a sidecar.
+  # The Sensors filter incoming Pod events on this key.
   sidecarInjectAnnotation: sidecar.opentelemetry.io/inject
+  # -- Name of the EventBus the EventSource and Sensors connect to.
   eventBusName: default
   eventBus:
-    # Argo Events requires an EventBus in the namespace; the controller subchart does not create one.
+    # -- Create the EventBus. Argo Events requires one in the namespace and the
+    # controller subchart does not create it.
+    # @default -- true
     create: true
+    # -- Number of NATS replicas in the native EventBus.
     replicas: 1
+    # -- Authentication strategy for the native NATS EventBus.
     auth: none
   eventSource:
+    # -- Name of the EventSource. Defaults to `<fullname>-pod-created` when empty.
+    # @default -- ""
     name: ""
+    # -- Single namespace to watch for Pod events. When empty, the chart watches
+    # the union of the target namespaces of every enabled engine.
+    # @default -- ""
     watchNamespace: ""
     serviceAccount:
+      # -- Create the EventSource ServiceAccount and its Pod-watch RBAC.
+      # @default -- true
       create: true
+      # -- Name of the EventSource ServiceAccount. Defaults to
+      # `<fullname>-argo-eventsource` when empty.
+      # @default -- ""
       name: ""
   sensor:
     serviceAccount:
+      # -- Create the Sensor ServiceAccount and its Job-create RBAC.
+      # @default -- true
       create: true
+      # -- Name of the Sensor ServiceAccount. Defaults to
+      # `<fullname>-argo-sensor` when empty.
+      # @default -- ""
       name: ""
   job:
+    # -- Suffix appended to the generateName of Sensor-created setup Jobs.
     generateNameSuffix: "setup-"


### PR DESCRIPTION
Groundwork for adding MySQL, MongoDB and SQL Server. **No new engine here** — this
is the shared base the three engine PRs stack on.

## Fixes to the PostgreSQL path

- **Pin the collector image to `0.157.0`.** It was untagged, so it resolved to
  `:latest`, which forces `imagePullPolicy: Always` and lets the collector version
  change under the config in `assets/`.
- **Use the canonical `otlp_grpc` exporter type.** `otlp` is a deprecated alias that
  logged a warning on every collector startup. For *receivers* `otlp` is still
  canonical, so `opentelemetry-kube-stack` is unaffected.
- **Coerce an absent `databases[].host` to a string** in `databaseHost`. A values
  override that replaced an entry without repeating `host` failed the render with
  `invalid value; expected string`.
- **Gate `configmap-pg-monitoring.yaml` on `postgres.enabled`.** It rendered even
  with PostgreSQL disabled.
- Document the assumption behind disabling TLS between the sidecar and the database.

## Multi-engine scaffolding

- Add an `engines` list helper, and derive `anyEngineEnabled` and `watchNamespaces`
  from it. The shared Argo Events plumbing (EventBus, EventSource, RBAC) is now
  gated on the union of enabled engines and watches the union of their target
  namespaces, so adding an engine means adding one entry to that list rather than
  editing several templates.
- Let `monitorPassword` take an explicit secret name, so another engine can reuse
  the lookup logic instead of duplicating it.
- Guard the PostgreSQL sensor loop on `postgres.enabled`, so a release with
  PostgreSQL disabled emits no PostgreSQL sensors.

## Docs and tests

- **Restructure the README around a per-database setup section.** The shared sidecar
  and Argo Events material is now written engine-neutrally, and PostgreSQL has its
  own section covering requirements, setup, metrics and an example — the shape every
  engine follows.
- Rewrite `values.yaml` so every parameter carries a helm-docs description, matching
  the style used in `opentelemetry-kube-stack`.
- Add helm-unittest suites for the PostgreSQL path and the shared Argo Events
  plumbing, including regression cases for the two render bugs above.

## Verification

`helm lint` clean; **14 helm-unittest tests**; `make check-examples` 13 passed, exit
0. The rendered PostgreSQL output is unchanged apart from the image tag, the TLS
comment and the exporter rename — the helper refactor is behaviour-preserving, which
I confirmed by diffing the render against `main`.

## Stacked PRs

Review order is this PR first, then the three engines in any order:

- #148 MySQL
- #149 MongoDB
- #150 SQL Server

Each targets this branch, so its diff shows only that engine. They deliberately do
**not** bump `Chart.yaml`, to avoid a three-way conflict and 12 files of
`helm.sh/chart` label churn per PR; the version should be bumped once when they
land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
