### PR TITLE
Add MySQL support to opentelemetry-database-monitoring

### DIFF
--- a/charts/opentelemetry-database-monitoring/README.md
+++ b/charts/opentelemetry-database-monitoring/README.md
@@ -23,6 +23,7 @@ gets, and the metrics collected.
 |----------|-----------|-------|
 | PostgreSQL | `postgres` | [PostgreSQL](#postgresql) |
 
+| MySQL | `mysql` | [MySQL](#mysql) |
 All databases export **metrics only**. See [Query collection](#query-collection)
 for how per-query data is collected and why.
 
@@ -306,6 +307,91 @@ postgres:
 Annotate the PostgreSQL Pod with
 `sidecar.opentelemetry.io/inject: postgres-dbm-sidecar`.
 
+## MySQL
+
+Enable with `mysql.enabled=true`.
+
+### Requirements
+
+- MySQL 8.0 or later. Query plans on top queries require 8.0+; MariaDB does not
+  expose the statement text the top-query view reads.
+- `performance_schema` must be enabled, which is the default on MySQL 8. The
+  `statements_digest` consumer must also be enabled, which is likewise the default.
+- The admin credentials in `mysql.databases[*].user` / `pwd` must have `CREATE USER`
+  and `GRANT OPTION`.
+
+### Setup
+
+The setup Job runs `assets/mysql-monitoring-setup.sql` idempotently. It:
+
+1. Creates `otel_monitor'@'%'` and grants it `PROCESS` and `REPLICATION CLIENT` on
+   `*.*`, plus `SELECT` on `performance_schema.*`.
+2. Creates the `otel` database.
+3. Installs the views below, then grants `SELECT` on `otel.*`.
+4. Rotates the `otel_monitor` password to match the Secret.
+
+The views are declared `SQL SECURITY DEFINER`, so the monitor user reads them with
+the definer's rights. This keeps the monitor role limited to the two grants above
+rather than requiring direct access to every underlying table.
+
+| View | Description |
+|------|-------------|
+| `otel.mysql_top_queries` | Top 50 statement digests by total execution time, from `performance_schema.events_statements_summary_by_digest`. Normalized digest text truncated to 1024 characters. |
+| `otel.mysql_locks` | Current InnoDB locks by table, type, mode, and granted status, from `performance_schema.data_locks`. |
+| `otel.mysql_connections` | Connection count and max age per schema per command state, from `information_schema.PROCESSLIST`. |
+
+`mysql_top_queries` excludes system schemas and `otel` itself, so that
+server-internal statements and the Collector's own queries do not occupy the
+top-N. It also bounds the window on `LAST_SEEN`, because
+`events_statements_summary_by_digest` accumulates from server start; without that
+bound the highest all-time totals would be reported on every scrape instead of
+current load.
+
+`mysql_locks` reads a live view of locks held right now, not a cumulative counter,
+so a row disappearing means the lock was released.
+
+### Metrics
+
+The `mysql` receiver runs at a 30 s interval and reports 45 metrics: buffer pool
+pages and operations, handlers, index and table I/O waits, locks, row locks, row
+operations, sorts, threads, temporary resources, and uptime, plus 22
+default-disabled metrics enabled by this chart (commands, connection counts and
+errors, joins, max used connections, page size, query counts, slow query count,
+replica lag, statement events, table size/rows/average row length, table lock
+waits, `table_open_cache`, and client network I/O).
+
+| Receiver | Interval | Metrics |
+|----------|----------|---------|
+| `sqlquery/mysql_top_queries` | 60 s | `mysql.query.calls`, `.exec_time`, `.lock_time`, `.rows.sent`, `.rows.examined`, `.rows.affected`, `.errors`, `.no_index_used`, `.full_scans`, `.tmp_disk_tables` — attributed by `db.namespace`, `db.query.hash`, `db.query.text` |
+| `sqlquery/mysql_locks` | 30 s | `mysql.lock.count` — attributed by `db.namespace`, `db.collection.name`, `db.mysql.lock.type`, `.mode`, `.status` |
+| `sqlquery/mysql_connections` | 30 s | `mysql.connection.state.count`, `mysql.connection.state.age` |
+
+`mysql.replica.sql_delay` and `mysql.replica.time_behind_source` are enabled but
+only report data on a replica.
+
+Keep `tls: insecure: true` written out in full if you override the asset config.
+The receiver defaults `insecure` to `true` only when the `tls` key is absent; once
+`tls` is present, `insecure` takes its zero value of `false` and the receiver
+requires TLS.
+
+### Example
+
+See `examples/mysql-single-db/`.
+
+```yaml
+mysql:
+  enabled: true
+  databases:
+    - name: mysql
+      sidecar-name: mysql-dbm-sidecar
+      user: root
+      pwd: otel
+      port: 3306
+      host: mysql
+```
+
+Annotate the MySQL Pod with `sidecar.opentelemetry.io/inject: mysql-dbm-sidecar`.
+
 ## Query collection
 
 Several database receivers can report per-query data through a native
@@ -319,6 +405,7 @@ against a view or function installed by the setup script.
 |----------|------------------|-----------|
 | PostgreSQL | yes | `sqlquery` over `otel.pg_top_queries()` |
 
+| MySQL | yes | `sqlquery` over `otel.mysql_top_queries` |
 The native blocks are functional, so this is a choice about signal type rather than
 a workaround. To use the native events instead, enable them on the receiver and add
 a `logs` pipeline by overriding the engine's asset config. Do not run both: they
@@ -442,6 +529,17 @@ stuck in that loop means the `host` and `port` in values do not reach the databa
 | argoEvents.sensor.serviceAccount.name | string | "" | Name of the Sensor ServiceAccount. Defaults to `<fullname>-argo-sensor` when empty. |
 | argoEvents.sidecarInjectAnnotation | string | `"sidecar.opentelemetry.io/inject"` | Pod annotation key the OpenTelemetry Operator reads to inject a sidecar. The Sensors filter incoming Pod events on this key. |
 | argoEvents.triggerSetupJob | bool | true | Create each setup Job from an Argo Events Sensor when a target Pod appears, instead of from a Helm post-install/post-upgrade hook. Running setup after the operator has injected the sidecar avoids racing database setup against sidecar startup, and allows the release to live in a different namespace from the database. |
+| mysql.databases | list | `[{"host":"","name":"mysql","namespace":"","port":3306,"pwd":"","sidecar-name":"mysql-dbm-sidecar","user":""}]` | MySQL instances to monitor. Each entry produces its own sidecar collector, monitor secret, and setup Job. |
+| mysql.databases[0] | object | `{"host":"","name":"mysql","namespace":"","port":3306,"pwd":"","sidecar-name":"mysql-dbm-sidecar","user":""}` | Name for this instance. Used as the prefix of the monitor secret and setup Job names, and set as the `opentelemetry-database-monitoring/database` label on every resource. |
+| mysql.databases[0].host | string | "" | Host the setup Job connects to, normally the MySQL Service name. A value containing a dot is used as-is; otherwise, when the instance runs in another namespace, it is expanded to `<host>.<namespace>.svc.cluster.local`. |
+| mysql.databases[0].namespace | string | "" | Namespace where the annotated MySQL Pod runs. Replicates the monitor secret into that namespace and sets the expected inject annotation to `<releaseNamespace>/<sidecar-name>` when it differs from the release namespace. Empty means the release namespace. |
+| mysql.databases[0].port | int | `3306` | Port the setup Job connects to. The sidecar's receiver port is fixed at 3306 in assets/mysql-monitoring-config.yaml; override that asset to change the port the collector uses. |
+| mysql.databases[0].pwd | string | "" | Password for the administrative user. Interpolated into the setup Job spec, so it is readable by anyone who can read Jobs in the release namespace. It is not written to a secret. |
+| mysql.databases[0].sidecar-name | string | `"mysql-dbm-sidecar"` | Name of the OpenTelemetryCollector resource for this instance. This is the value the target Pod's `sidecar.opentelemetry.io/inject` annotation must carry for the operator to inject the sidecar. |
+| mysql.databases[0].user | string | "" | Administrative user the setup Job connects as. Needs CREATE USER and GRANT OPTION. |
+| mysql.enabled | bool | false | Deploy MySQL monitoring: the injected sidecar collector, the monitor credentials secret, the setup ConfigMap, and the setup Job. |
+| mysql.image | string | `"ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0"` | Collector image for the injected sidecar. |
+| mysql.setupImage | string | `"mysql:8.4"` | Image for the setup Job. Must provide the `mysql` and `mysqladmin` clients on PATH. |
 | postgres.databases | list | `[{"host":"","name":"postgresql","namespace":"","port":5432,"pwd":"","sidecar-name":"postgres-dbm-sidecar","user":""}]` | PostgreSQL instances to monitor. Each entry produces its own sidecar collector, monitor secret, and setup Job. |
 | postgres.databases[0] | object | `{"host":"","name":"postgresql","namespace":"","port":5432,"pwd":"","sidecar-name":"postgres-dbm-sidecar","user":""}` | Name for this instance. Used as the prefix of the monitor secret and setup Job names, and set as the `opentelemetry-database-monitoring/database` label on every resource. |
 | postgres.databases[0].host | string | "" | Host the setup Job connects to, normally the PostgreSQL Service name. A value containing a dot is used as-is; otherwise, when the instance runs in another namespace, it is expanded to `<host>.<namespace>.svc.cluster.local`. |

--- a/charts/opentelemetry-database-monitoring/README.md.gotmpl
+++ b/charts/opentelemetry-database-monitoring/README.md.gotmpl
@@ -27,6 +27,7 @@ gets, and the metrics collected.
 |----------|-----------|-------|
 | PostgreSQL | `postgres` | [PostgreSQL](#postgresql) |
 
+| MySQL | `mysql` | [MySQL](#mysql) |
 All databases export **metrics only**. See [Query collection](#query-collection)
 for how per-query data is collected and why.
 
@@ -310,6 +311,91 @@ postgres:
 Annotate the PostgreSQL Pod with
 `sidecar.opentelemetry.io/inject: postgres-dbm-sidecar`.
 
+## MySQL
+
+Enable with `mysql.enabled=true`.
+
+### Requirements
+
+- MySQL 8.0 or later. Query plans on top queries require 8.0+; MariaDB does not
+  expose the statement text the top-query view reads.
+- `performance_schema` must be enabled, which is the default on MySQL 8. The
+  `statements_digest` consumer must also be enabled, which is likewise the default.
+- The admin credentials in `mysql.databases[*].user` / `pwd` must have `CREATE USER`
+  and `GRANT OPTION`.
+
+### Setup
+
+The setup Job runs `assets/mysql-monitoring-setup.sql` idempotently. It:
+
+1. Creates `otel_monitor'@'%'` and grants it `PROCESS` and `REPLICATION CLIENT` on
+   `*.*`, plus `SELECT` on `performance_schema.*`.
+2. Creates the `otel` database.
+3. Installs the views below, then grants `SELECT` on `otel.*`.
+4. Rotates the `otel_monitor` password to match the Secret.
+
+The views are declared `SQL SECURITY DEFINER`, so the monitor user reads them with
+the definer's rights. This keeps the monitor role limited to the two grants above
+rather than requiring direct access to every underlying table.
+
+| View | Description |
+|------|-------------|
+| `otel.mysql_top_queries` | Top 50 statement digests by total execution time, from `performance_schema.events_statements_summary_by_digest`. Normalized digest text truncated to 1024 characters. |
+| `otel.mysql_locks` | Current InnoDB locks by table, type, mode, and granted status, from `performance_schema.data_locks`. |
+| `otel.mysql_connections` | Connection count and max age per schema per command state, from `information_schema.PROCESSLIST`. |
+
+`mysql_top_queries` excludes system schemas and `otel` itself, so that
+server-internal statements and the Collector's own queries do not occupy the
+top-N. It also bounds the window on `LAST_SEEN`, because
+`events_statements_summary_by_digest` accumulates from server start; without that
+bound the highest all-time totals would be reported on every scrape instead of
+current load.
+
+`mysql_locks` reads a live view of locks held right now, not a cumulative counter,
+so a row disappearing means the lock was released.
+
+### Metrics
+
+The `mysql` receiver runs at a 30 s interval and reports 45 metrics: buffer pool
+pages and operations, handlers, index and table I/O waits, locks, row locks, row
+operations, sorts, threads, temporary resources, and uptime, plus 22
+default-disabled metrics enabled by this chart (commands, connection counts and
+errors, joins, max used connections, page size, query counts, slow query count,
+replica lag, statement events, table size/rows/average row length, table lock
+waits, `table_open_cache`, and client network I/O).
+
+| Receiver | Interval | Metrics |
+|----------|----------|---------|
+| `sqlquery/mysql_top_queries` | 60 s | `mysql.query.calls`, `.exec_time`, `.lock_time`, `.rows.sent`, `.rows.examined`, `.rows.affected`, `.errors`, `.no_index_used`, `.full_scans`, `.tmp_disk_tables` — attributed by `db.namespace`, `db.query.hash`, `db.query.text` |
+| `sqlquery/mysql_locks` | 30 s | `mysql.lock.count` — attributed by `db.namespace`, `db.collection.name`, `db.mysql.lock.type`, `.mode`, `.status` |
+| `sqlquery/mysql_connections` | 30 s | `mysql.connection.state.count`, `mysql.connection.state.age` |
+
+`mysql.replica.sql_delay` and `mysql.replica.time_behind_source` are enabled but
+only report data on a replica.
+
+Keep `tls: insecure: true` written out in full if you override the asset config.
+The receiver defaults `insecure` to `true` only when the `tls` key is absent; once
+`tls` is present, `insecure` takes its zero value of `false` and the receiver
+requires TLS.
+
+### Example
+
+See `examples/mysql-single-db/`.
+
+```yaml
+mysql:
+  enabled: true
+  databases:
+    - name: mysql
+      sidecar-name: mysql-dbm-sidecar
+      user: root
+      pwd: otel
+      port: 3306
+      host: mysql
+```
+
+Annotate the MySQL Pod with `sidecar.opentelemetry.io/inject: mysql-dbm-sidecar`.
+
 ## Query collection
 
 Several database receivers can report per-query data through a native
@@ -323,6 +409,7 @@ against a view or function installed by the setup script.
 |----------|------------------|-----------|
 | PostgreSQL | yes | `sqlquery` over `otel.pg_top_queries()` |
 
+| MySQL | yes | `sqlquery` over `otel.mysql_top_queries` |
 The native blocks are functional, so this is a choice about signal type rather than
 a workaround. To use the native events instead, enable them on the receiver and add
 a `logs` pipeline by overriding the engine's asset config. Do not run both: they

--- a/charts/opentelemetry-database-monitoring/assets/mysql-monitoring-config.yaml
+++ b/charts/opentelemetry-database-monitoring/assets/mysql-monitoring-config.yaml
@@ -1,0 +1,227 @@
+receivers:
+  # The collector runs as a sidecar inside the MySQL Pod and reaches mysqld over
+  # the Pod's own network namespace, so this traffic does not leave the Pod. TLS
+  # is disabled here and every sqlquery datasource below sets tls=false.
+  # Configure TLS before pointing this config at a MySQL server outside the Pod.
+  #
+  # Keep `tls: insecure: true` written out in full. The receiver defaults
+  # insecure to true only when the `tls` key is absent; once `tls` is present,
+  # insecure takes its zero value of false and the receiver requires TLS.
+  mysql:
+    endpoint: ${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME}:3306
+    username: otel_monitor
+    password: ${env:OTEL_MONITOR_PASSWORD}
+    collection_interval: 30s
+    tls:
+      insecure: true
+    metrics:
+      mysql.client.network.io:
+        enabled: true
+      mysql.commands:
+        enabled: true
+      mysql.connection.count:
+        enabled: true
+      mysql.connection.errors:
+        enabled: true
+      mysql.joins:
+        enabled: true
+      mysql.max_used_connections:
+        enabled: true
+      mysql.page_size:
+        enabled: true
+      mysql.query.client.count:
+        enabled: true
+      mysql.query.count:
+        enabled: true
+      mysql.query.slow.count:
+        enabled: true
+      mysql.replica.sql_delay:
+        enabled: true
+      mysql.replica.time_behind_source:
+        enabled: true
+      mysql.statement_event.count:
+        enabled: true
+      mysql.statement_event.wait.time:
+        enabled: true
+      mysql.table.average_row_length:
+        enabled: true
+      mysql.table.lock_wait.read.count:
+        enabled: true
+      mysql.table.lock_wait.read.time:
+        enabled: true
+      mysql.table.lock_wait.write.count:
+        enabled: true
+      mysql.table.lock_wait.write.time:
+        enabled: true
+      mysql.table.rows:
+        enabled: true
+      mysql.table.size:
+        enabled: true
+      mysql.table_open_cache:
+        enabled: true
+  # Top queries are collected as metrics through sqlquery. The receiver's native
+  # top_query_collection block reports the same data as log records through the
+  # db.server.top_query event, at Development stability; this chart exports
+  # metrics only. See the chart README.
+  sqlquery/mysql_top_queries:
+    collection_interval: 60s
+    datasource: otel_monitor:${env:OTEL_MONITOR_PASSWORD}@tcp(${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME}:3306)/otel?tls=false
+    driver: mysql
+    queries:
+      - sql: SELECT * FROM otel.mysql_top_queries
+        metrics:
+          - attribute_columns:
+              - db.namespace
+              - db.query.hash
+              - db.query.text
+            data_type: gauge
+            metric_name: mysql.query.calls
+            unit: "{query}"
+            value_column: calls
+            value_type: int
+          - attribute_columns:
+              - db.namespace
+              - db.query.hash
+              - db.query.text
+            data_type: gauge
+            metric_name: mysql.query.exec_time
+            unit: ms
+            value_column: total_exec_time_ms
+            value_type: double
+          - attribute_columns:
+              - db.namespace
+              - db.query.hash
+              - db.query.text
+            data_type: gauge
+            metric_name: mysql.query.lock_time
+            unit: ms
+            value_column: total_lock_time_ms
+            value_type: double
+          - attribute_columns:
+              - db.namespace
+              - db.query.hash
+              - db.query.text
+            data_type: gauge
+            metric_name: mysql.query.rows.sent
+            unit: "{row}"
+            value_column: rows_sent
+            value_type: int
+          - attribute_columns:
+              - db.namespace
+              - db.query.hash
+              - db.query.text
+            data_type: gauge
+            metric_name: mysql.query.rows.examined
+            unit: "{row}"
+            value_column: rows_examined
+            value_type: int
+          - attribute_columns:
+              - db.namespace
+              - db.query.hash
+              - db.query.text
+            data_type: gauge
+            metric_name: mysql.query.rows.affected
+            unit: "{row}"
+            value_column: rows_affected
+            value_type: int
+          - attribute_columns:
+              - db.namespace
+              - db.query.hash
+              - db.query.text
+            data_type: gauge
+            metric_name: mysql.query.errors
+            unit: "{error}"
+            value_column: query_errors
+            value_type: int
+          - attribute_columns:
+              - db.namespace
+              - db.query.hash
+              - db.query.text
+            data_type: gauge
+            metric_name: mysql.query.no_index_used
+            unit: "{query}"
+            value_column: no_index_used
+            value_type: int
+          - attribute_columns:
+              - db.namespace
+              - db.query.hash
+              - db.query.text
+            data_type: gauge
+            metric_name: mysql.query.full_scans
+            unit: "{query}"
+            value_column: full_scans
+            value_type: int
+          - attribute_columns:
+              - db.namespace
+              - db.query.hash
+              - db.query.text
+            data_type: gauge
+            metric_name: mysql.query.tmp_disk_tables
+            unit: "{table}"
+            value_column: tmp_disk_tables
+            value_type: int
+  sqlquery/mysql_locks:
+    collection_interval: 30s
+    datasource: otel_monitor:${env:OTEL_MONITOR_PASSWORD}@tcp(${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME}:3306)/otel?tls=false
+    driver: mysql
+    queries:
+      - sql: SELECT * FROM otel.mysql_locks
+        metrics:
+          - attribute_columns:
+              - db.namespace
+              - db.collection.name
+              - db.mysql.lock.type
+              - db.mysql.lock.mode
+              - db.mysql.lock.status
+            data_type: gauge
+            metric_name: mysql.lock.count
+            unit: "{lock}"
+            value_column: lock_count
+            value_type: int
+  sqlquery/mysql_connections:
+    collection_interval: 30s
+    datasource: otel_monitor:${env:OTEL_MONITOR_PASSWORD}@tcp(${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME}:3306)/otel?tls=false
+    driver: mysql
+    queries:
+      - sql: SELECT * FROM otel.mysql_connections
+        metrics:
+          - attribute_columns:
+              - db.namespace
+              - db.client.connection.state
+            data_type: gauge
+            metric_name: mysql.connection.state.count
+            unit: "{connection}"
+            value_column: connection_count
+            value_type: int
+          - attribute_columns:
+              - db.namespace
+              - db.client.connection.state
+            data_type: gauge
+            metric_name: mysql.connection.state.age
+            unit: s
+            value_column: max_state_age_seconds
+            value_type: int
+processors:
+  batch:
+    send_batch_max_size: 5000
+    send_batch_size: 5000
+exporters:
+  # otlp_grpc is the canonical exporter type. The shorter `otlp` spelling is a
+  # deprecated alias that logs a warning on every collector startup.
+  otlp_grpc:
+    compression: gzip
+    endpoint: ${env:K8S_NODE_IP}:4317
+    tls:
+      insecure: true
+service:
+  pipelines:
+    metrics:
+      exporters:
+        - otlp_grpc
+      processors:
+        - batch
+      receivers:
+        - mysql
+        - sqlquery/mysql_top_queries
+        - sqlquery/mysql_locks
+        - sqlquery/mysql_connections

--- a/charts/opentelemetry-database-monitoring/assets/mysql-monitoring-setup.sql
+++ b/charts/opentelemetry-database-monitoring/assets/mysql-monitoring-setup.sql
@@ -1,0 +1,104 @@
+-- MySQL monitoring setup for OpenTelemetry
+-- Run this as a user with CREATE USER and GRANT OPTION (e.g. root).
+-- Safe to re-run (all statements are idempotent).
+
+-- ---------------------------------------------------------------------------
+-- 1. Monitoring user
+--
+-- The password is a placeholder: the setup Job rewrites it with the generated
+-- value from the monitor secret immediately after running this script, so the
+-- literal below never survives setup.
+-- ---------------------------------------------------------------------------
+
+CREATE USER IF NOT EXISTS 'otel_monitor'@'%' IDENTIFIED BY 'your-password';
+
+-- Server-level metrics come from SHOW GLOBAL STATUS / SHOW REPLICA STATUS.
+GRANT PROCESS, REPLICATION CLIENT ON *.* TO 'otel_monitor'@'%';
+
+-- Table, index and statement-event metrics read performance_schema directly.
+GRANT SELECT ON performance_schema.* TO 'otel_monitor'@'%';
+
+-- mysql.table.rows / .size / .average_row_length read information_schema.tables,
+-- which every user can already read, so no extra grant is needed for those.
+
+-- ---------------------------------------------------------------------------
+-- 2. Monitoring schema
+-- ---------------------------------------------------------------------------
+
+CREATE DATABASE IF NOT EXISTS otel;
+
+-- ---------------------------------------------------------------------------
+-- 3. Monitoring views
+--
+-- Attribute columns use OTel semconv names where defined:
+--   db.namespace     → schema name        (stable semconv)
+--   db.query.text    → normalized digest  (stable semconv)
+--   db.query.hash    → statement digest   (experimental)
+--
+-- The views are declared SQL SECURITY DEFINER, so the monitor user reads them
+-- with the definer's rights. This keeps the monitor role limited to the two
+-- grants above instead of requiring direct access to every underlying table.
+-- ---------------------------------------------------------------------------
+
+-- Top queries by total execution time, from the statement digest summary.
+--
+-- The WHERE clause carries three filters that the metric depends on:
+--   * System schemas are excluded so that server-internal statements do not
+--     occupy the top-N.
+--   * The `otel` schema is excluded because these views are themselves queried
+--     once per collection interval and would otherwise be reported as top
+--     queries.
+--   * LAST_SEEN bounds the window to recent activity.
+--     events_statements_summary_by_digest accumulates from server start, so an
+--     unbounded query reports the highest all-time totals on every scrape and
+--     stops reflecting current load. 300s covers the 60s collection interval.
+CREATE OR REPLACE SQL SECURITY DEFINER VIEW otel.mysql_top_queries AS
+SELECT
+    COALESCE(d.SCHEMA_NAME, '')             AS `db.namespace`,
+    d.DIGEST                                AS `db.query.hash`,
+    LEFT(COALESCE(d.DIGEST_TEXT, ''), 1024) AS `db.query.text`,
+    d.COUNT_STAR                            AS calls,
+    d.SUM_ROWS_SENT                         AS rows_sent,
+    d.SUM_ROWS_EXAMINED                     AS rows_examined,
+    d.SUM_ROWS_AFFECTED                     AS rows_affected,
+    d.SUM_ERRORS                            AS query_errors,
+    d.SUM_NO_INDEX_USED                     AS no_index_used,
+    d.SUM_SELECT_SCAN                       AS full_scans,
+    d.SUM_CREATED_TMP_DISK_TABLES           AS tmp_disk_tables,
+    d.SUM_TIMER_WAIT / 1000000000.0         AS total_exec_time_ms,
+    d.SUM_LOCK_TIME  / 1000000000.0         AS total_lock_time_ms
+FROM performance_schema.events_statements_summary_by_digest d
+WHERE d.DIGEST IS NOT NULL
+  AND d.SCHEMA_NAME IS NOT NULL
+  AND d.SCHEMA_NAME NOT IN ('performance_schema', 'information_schema', 'mysql', 'sys', 'otel')
+  AND d.LAST_SEEN > DATE_SUB(NOW(), INTERVAL 300 SECOND)
+ORDER BY d.SUM_TIMER_WAIT DESC
+LIMIT 50;
+
+-- Current InnoDB locks, split by type and whether they are granted.
+-- data_locks is a live view of locks held right now, not a cumulative counter,
+-- so a row disappearing simply means the lock was released.
+CREATE OR REPLACE SQL SECURITY DEFINER VIEW otel.mysql_locks AS
+SELECT
+    COALESCE(w.OBJECT_SCHEMA, '')   AS `db.namespace`,
+    COALESCE(w.OBJECT_NAME, '')     AS `db.collection.name`,
+    COALESCE(w.LOCK_TYPE, '')       AS `db.mysql.lock.type`,
+    COALESCE(w.LOCK_MODE, '')       AS `db.mysql.lock.mode`,
+    COALESCE(w.LOCK_STATUS, '')     AS `db.mysql.lock.status`,
+    COUNT(*)                        AS lock_count
+FROM performance_schema.data_locks w
+WHERE w.OBJECT_SCHEMA IS NOT NULL
+  AND w.OBJECT_SCHEMA NOT IN ('performance_schema', 'information_schema', 'mysql', 'sys', 'otel')
+GROUP BY w.OBJECT_SCHEMA, w.OBJECT_NAME, w.LOCK_TYPE, w.LOCK_MODE, w.LOCK_STATUS;
+
+-- Connection counts and the age of the longest-running connection per state.
+CREATE OR REPLACE SQL SECURITY DEFINER VIEW otel.mysql_connections AS
+SELECT
+    COALESCE(p.DB, '')                AS `db.namespace`,
+    COALESCE(p.COMMAND, 'unknown')    AS `db.client.connection.state`,
+    COUNT(*)                          AS connection_count,
+    COALESCE(MAX(p.TIME), 0)          AS max_state_age_seconds
+FROM information_schema.PROCESSLIST p
+GROUP BY p.DB, p.COMMAND;
+
+GRANT SELECT ON otel.* TO 'otel_monitor'@'%';

--- a/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/argo-eventbus.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/argo-eventbus.yaml
@@ -1,0 +1,17 @@
+---
+# Source: opentelemetry-database-monitoring/templates/argo-eventbus.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: EventBus
+metadata:
+  name: default
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  nats:
+    native:
+      replicas: 1
+      auth: none

--- a/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/argo-events-rbac.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/argo-events-rbac.yaml
@@ -1,0 +1,97 @@
+---
+# Source: opentelemetry-database-monitoring/templates/argo-events-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-opentelemetry-database-monitoring-argo-eventsource
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: opentelemetry-database-monitoring/templates/argo-events-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-opentelemetry-database-monitoring-argo-sensor
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: opentelemetry-database-monitoring/templates/argo-events-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: example-opentelemetry-database-monitoring-argo-eventsource
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+# Source: opentelemetry-database-monitoring/templates/argo-events-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: example-opentelemetry-database-monitoring-argo-sensor
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create"]
+---
+# Source: opentelemetry-database-monitoring/templates/argo-events-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: example-opentelemetry-database-monitoring-argo-eventsource
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+subjects:
+  - kind: ServiceAccount
+    name: example-opentelemetry-database-monitoring-argo-eventsource
+    namespace: default
+roleRef:
+  kind: Role
+  name: example-opentelemetry-database-monitoring-argo-eventsource
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: opentelemetry-database-monitoring/templates/argo-events-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: example-opentelemetry-database-monitoring-argo-sensor
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+subjects:
+  - kind: ServiceAccount
+    name: example-opentelemetry-database-monitoring-argo-sensor
+roleRef:
+  kind: Role
+  name: example-opentelemetry-database-monitoring-argo-sensor
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/argo-events/argo-events-controller/config.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/argo-events/argo-events-controller/config.yaml
@@ -1,0 +1,86 @@
+---
+# Source: opentelemetry-database-monitoring/charts/argo-events/templates/argo-events-controller/config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-argo-events-controller-manager
+  namespace: "default"
+  labels:
+    helm.sh/chart: argo-events-2.4.22
+    app.kubernetes.io/name: argo-events-controller-manager
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-events
+data:
+  controller-config.yaml: |
+    eventBus:
+      nats:
+        versions:
+        - version: latest
+          natsStreamingImage: nats-streaming:latest
+          metricsExporterImage: natsio/prometheus-nats-exporter:latest
+        - version: 0.22.1
+          natsStreamingImage: nats-streaming:0.22.1
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.8.0
+      jetstream:
+        # Default JetStream settings, could be overridden by EventBus JetStream specs
+        settings: |
+          # https://docs.nats.io/running-a-nats-service/configuration#jetstream
+          # Only configure "max_memory_store" or "max_file_store", do not set "store_dir" as it has been hardcoded.
+          max_memory_store: -1
+          max_file_store: -1
+        # The default properties of the streams to be created in this JetStream service
+        streamConfig: |
+          maxMsgs: 1e+06
+          maxAge: 72h
+          maxBytes: 1GB
+          replicas: 3
+          duplicates: 300s
+          retention: 0
+          discard: 0
+        versions:
+        - version: latest
+          natsImage: nats:2.10.10
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
+          configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+          startCommand: /nats-server
+        - version: 2.8.1
+          natsImage: nats:2.8.1
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+        - version: 2.8.1-alpine
+          natsImage: nats:2.8.1-alpine
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: nats-server
+        - version: 2.8.2
+          natsImage: nats:2.8.2
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+        - version: 2.8.2-alpine
+          natsImage: nats:2.8.2-alpine
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: nats-server
+        - version: 2.9.1
+          natsImage: nats:2.9.1
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+        - version: 2.9.12
+          natsImage: nats:2.9.12
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+        - version: 2.9.16
+          natsImage: nats:2.9.16
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+        - version: 2.10.10
+          natsImage: nats:2.10.10
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
+          configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+          startCommand: /nats-server

--- a/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/argo-events/argo-events-controller/deployment.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/argo-events/argo-events-controller/deployment.yaml
@@ -1,0 +1,84 @@
+---
+# Source: opentelemetry-database-monitoring/charts/argo-events/templates/argo-events-controller/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-argo-events-controller-manager
+  namespace: "default"
+  labels:
+    helm.sh/chart: argo-events-2.4.22
+    app.kubernetes.io/name: argo-events-controller-manager
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-events
+    app.kubernetes.io/version: "v1.9.10"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argo-events-controller-manager
+      app.kubernetes.io/instance: example
+  revisionHistoryLimit: 5
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: e582d4d24cbef623004e1fa804eb237a2c123cfb72fb4fa0424a6d46d28bff50
+      labels:
+        helm.sh/chart: argo-events-2.4.22
+        app.kubernetes.io/name: argo-events-controller-manager
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: controller-manager
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: argo-events
+        app.kubernetes.io/version: "v1.9.10"
+    spec:
+      containers:
+      - name: controller-manager
+        image: quay.io/argoproj/argo-events:v1.9.10
+        imagePullPolicy: IfNotPresent
+        args:
+        - controller
+        - --leader-election=false
+        env:
+        - name: ARGO_EVENTS_IMAGE
+          value: quay.io/argoproj/argo-events:v1.9.10
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - name: config
+          mountPath: /etc/argo-events
+        ports:
+        - name: metrics
+          containerPort: 7777
+          protocol: TCP
+        - name: probe
+          containerPort: 8081
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            port: probe
+            path: /healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            port: probe
+            path: /readyz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 3
+      serviceAccountName: example-argo-events-controller-manager
+      volumes:
+      - name: config
+        configMap:
+          name: example-argo-events-controller-manager

--- a/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/argo-events/argo-events-controller/rbac.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/argo-events/argo-events-controller/rbac.yaml
@@ -1,0 +1,115 @@
+---
+# Source: opentelemetry-database-monitoring/charts/argo-events/templates/argo-events-controller/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: example-argo-events-controller-manager
+  labels:
+    helm.sh/chart: argo-events-2.4.22
+    app.kubernetes.io/name: argo-events-controller-manager
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-events
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - sensors
+  - sensors/finalizers
+  - sensors/status
+  - eventsources
+  - eventsources/finalizers
+  - eventsources/status
+  - eventbus
+  - eventbus/finalizers
+  - eventbus/status
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/exec
+  - configmaps
+  - services
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+---
+# Source: opentelemetry-database-monitoring/charts/argo-events/templates/argo-events-controller/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: example-argo-events-controller-manager
+  labels:
+    helm.sh/chart: argo-events-2.4.22
+    app.kubernetes.io/name: argo-events-controller-manager
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-events
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: example-argo-events-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: example-argo-events-controller-manager
+  namespace: "default"

--- a/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/argo-events/argo-events-controller/serviceaccount.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/argo-events/argo-events-controller/serviceaccount.yaml
@@ -1,0 +1,15 @@
+---
+# Source: opentelemetry-database-monitoring/charts/argo-events/templates/argo-events-controller/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: example-argo-events-controller-manager
+  namespace: "default"
+  labels:
+    helm.sh/chart: argo-events-2.4.22
+    app.kubernetes.io/name: argo-events-controller-manager
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-events

--- a/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/argo-events/argo-events-webhook/serviceaccount.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/argo-events/argo-events-webhook/serviceaccount.yaml
@@ -1,0 +1,15 @@
+---
+# Source: opentelemetry-database-monitoring/charts/argo-events/templates/argo-events-webhook/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: example-argo-events-events-webhook
+  namespace: "default"
+  labels:
+    helm.sh/chart: argo-events-2.4.22
+    app.kubernetes.io/name: argo-events-events-webhook
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: events-webhook
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-events

--- a/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/argo-eventsource.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/argo-eventsource.yaml
@@ -1,0 +1,26 @@
+---
+# Source: opentelemetry-database-monitoring/templates/argo-eventsource.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: EventSource
+metadata:
+  name: example-opentelemetry-database-monitoring-pod-created
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  eventBusName: default
+  template:
+    serviceAccountName: example-opentelemetry-database-monitoring-argo-eventsource
+  resource:
+    target-pod-created-default:
+      namespace: default
+      group: ""
+      version: v1
+      resource: pods
+      eventTypes:
+        - ADD
+      filter:
+        afterStart: true

--- a/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/argo-sensor.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/argo-sensor.yaml
@@ -1,0 +1,94 @@
+---
+# Source: opentelemetry-database-monitoring/templates/argo-sensor.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  
+  name: example-opentelemetry-database-monitoring-mysql-mysql-setup
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: argo-sensor
+    opentelemetry-database-monitoring/database: mysql
+spec:
+  eventBusName: default
+  template:
+    serviceAccountName: example-opentelemetry-database-monitoring-argo-sensor
+  dependencies:
+    - name: target-pod-created-default
+      eventSourceName: example-opentelemetry-database-monitoring-pod-created
+      eventName: target-pod-created-default
+      filters:
+        data:
+          - path: body.metadata.annotations.sidecar\.opentelemetry\.io\/inject
+            type: string
+            value:
+              - "mysql-dbm-sidecar"
+  triggers:
+    - template:
+        name: create-mysql-mysql-monitoring-setup-job
+        k8s:
+          operation: create
+          source:
+            resource:
+              apiVersion: batch/v1
+              kind: Job
+              metadata:
+                generateName: mysql-mysql-monitoring-setup-
+                namespace: default
+                labels:
+                  helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+                  app.kubernetes.io/name: opentelemetry-database-monitoring
+                  app.kubernetes.io/instance: example
+                  app.kubernetes.io/version: "1.16.0"
+                  app.kubernetes.io/managed-by: Helm
+                  app.kubernetes.io/component: db-monitoring-setup
+                  opentelemetry-database-monitoring/database: mysql
+              spec:
+                backoffLimit: 3
+                template:
+                  metadata:
+                    labels:
+                      app.kubernetes.io/name: opentelemetry-database-monitoring
+                      app.kubernetes.io/instance: example
+                      app.kubernetes.io/component: db-monitoring-setup
+                      opentelemetry-database-monitoring/database: mysql
+                  spec:
+                    restartPolicy: OnFailure
+                    containers:
+                      - name: setup
+                        image: mysql:8.4
+                        command:
+                          - /bin/sh
+                          - -c
+                          - |
+                            set -e
+                            until mysqladmin ping -h mysql -P 3306 -u root --silent; do sleep 2; done
+                            mysql -h mysql -P 3306 -u root < /scripts/monitoring-setup.sql
+                            mysql -h mysql -P 3306 -u root \
+                              -e "ALTER USER 'otel_monitor'@'%' IDENTIFIED BY '$OTEL_MONITOR_PASSWORD'"
+                            # Confirm the monitoring role is actually usable on the endpoint we reached,
+                            # and that it can read the views the collector scrapes. Fail (and let
+                            # backoffLimit retry) if the setup did not land where the collector connects.
+                            MYSQL_PWD="$OTEL_MONITOR_PASSWORD" mysql -h mysql -P 3306 -u otel_monitor \
+                              -e "SELECT 1 FROM otel.mysql_top_queries LIMIT 0" > /dev/null
+                        env:
+                          # MYSQL_PWD keeps the admin password out of the container's process list.
+                          # It is still visible in the Job spec, because it comes from values.
+                          - name: MYSQL_PWD
+                            value: "otel"
+                          - name: OTEL_MONITOR_PASSWORD
+                            valueFrom:
+                              secretKeyRef:
+                                name: mysql-mysql-monitor-credentials
+                                key: password
+                        volumeMounts:
+                          - name: monitoring-setup
+                            mountPath: /scripts
+                    volumes:
+                      - name: monitoring-setup
+                        configMap:
+                          name: mysql-monitoring-setup

--- a/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/configmap-mysql-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/configmap-mysql-monitoring.yaml
@@ -1,0 +1,112 @@
+---
+# Source: opentelemetry-database-monitoring/templates/configmap-mysql-monitoring.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mysql-monitoring-setup
+data:
+  monitoring-setup.sql: |
+    -- MySQL monitoring setup for OpenTelemetry
+    -- Run this as a user with CREATE USER and GRANT OPTION (e.g. root).
+    -- Safe to re-run (all statements are idempotent).
+    
+    -- ---------------------------------------------------------------------------
+    -- 1. Monitoring user
+    --
+    -- The password is a placeholder: the setup Job rewrites it with the generated
+    -- value from the monitor secret immediately after running this script, so the
+    -- literal below never survives setup.
+    -- ---------------------------------------------------------------------------
+    
+    CREATE USER IF NOT EXISTS 'otel_monitor'@'%' IDENTIFIED BY 'your-password';
+    
+    -- Server-level metrics come from SHOW GLOBAL STATUS / SHOW REPLICA STATUS.
+    GRANT PROCESS, REPLICATION CLIENT ON *.* TO 'otel_monitor'@'%';
+    
+    -- Table, index and statement-event metrics read performance_schema directly.
+    GRANT SELECT ON performance_schema.* TO 'otel_monitor'@'%';
+    
+    -- mysql.table.rows / .size / .average_row_length read information_schema.tables,
+    -- which every user can already read, so no extra grant is needed for those.
+    
+    -- ---------------------------------------------------------------------------
+    -- 2. Monitoring schema
+    -- ---------------------------------------------------------------------------
+    
+    CREATE DATABASE IF NOT EXISTS otel;
+    
+    -- ---------------------------------------------------------------------------
+    -- 3. Monitoring views
+    --
+    -- Attribute columns use OTel semconv names where defined:
+    --   db.namespace     → schema name        (stable semconv)
+    --   db.query.text    → normalized digest  (stable semconv)
+    --   db.query.hash    → statement digest   (experimental)
+    --
+    -- The views are declared SQL SECURITY DEFINER, so the monitor user reads them
+    -- with the definer's rights. This keeps the monitor role limited to the two
+    -- grants above instead of requiring direct access to every underlying table.
+    -- ---------------------------------------------------------------------------
+    
+    -- Top queries by total execution time, from the statement digest summary.
+    --
+    -- The WHERE clause carries three filters that the metric depends on:
+    --   * System schemas are excluded so that server-internal statements do not
+    --     occupy the top-N.
+    --   * The `otel` schema is excluded because these views are themselves queried
+    --     once per collection interval and would otherwise be reported as top
+    --     queries.
+    --   * LAST_SEEN bounds the window to recent activity.
+    --     events_statements_summary_by_digest accumulates from server start, so an
+    --     unbounded query reports the highest all-time totals on every scrape and
+    --     stops reflecting current load. 300s covers the 60s collection interval.
+    CREATE OR REPLACE SQL SECURITY DEFINER VIEW otel.mysql_top_queries AS
+    SELECT
+        COALESCE(d.SCHEMA_NAME, '')             AS `db.namespace`,
+        d.DIGEST                                AS `db.query.hash`,
+        LEFT(COALESCE(d.DIGEST_TEXT, ''), 1024) AS `db.query.text`,
+        d.COUNT_STAR                            AS calls,
+        d.SUM_ROWS_SENT                         AS rows_sent,
+        d.SUM_ROWS_EXAMINED                     AS rows_examined,
+        d.SUM_ROWS_AFFECTED                     AS rows_affected,
+        d.SUM_ERRORS                            AS query_errors,
+        d.SUM_NO_INDEX_USED                     AS no_index_used,
+        d.SUM_SELECT_SCAN                       AS full_scans,
+        d.SUM_CREATED_TMP_DISK_TABLES           AS tmp_disk_tables,
+        d.SUM_TIMER_WAIT / 1000000000.0         AS total_exec_time_ms,
+        d.SUM_LOCK_TIME  / 1000000000.0         AS total_lock_time_ms
+    FROM performance_schema.events_statements_summary_by_digest d
+    WHERE d.DIGEST IS NOT NULL
+      AND d.SCHEMA_NAME IS NOT NULL
+      AND d.SCHEMA_NAME NOT IN ('performance_schema', 'information_schema', 'mysql', 'sys', 'otel')
+      AND d.LAST_SEEN > DATE_SUB(NOW(), INTERVAL 300 SECOND)
+    ORDER BY d.SUM_TIMER_WAIT DESC
+    LIMIT 50;
+    
+    -- Current InnoDB locks, split by type and whether they are granted.
+    -- data_locks is a live view of locks held right now, not a cumulative counter,
+    -- so a row disappearing simply means the lock was released.
+    CREATE OR REPLACE SQL SECURITY DEFINER VIEW otel.mysql_locks AS
+    SELECT
+        COALESCE(w.OBJECT_SCHEMA, '')   AS `db.namespace`,
+        COALESCE(w.OBJECT_NAME, '')     AS `db.collection.name`,
+        COALESCE(w.LOCK_TYPE, '')       AS `db.mysql.lock.type`,
+        COALESCE(w.LOCK_MODE, '')       AS `db.mysql.lock.mode`,
+        COALESCE(w.LOCK_STATUS, '')     AS `db.mysql.lock.status`,
+        COUNT(*)                        AS lock_count
+    FROM performance_schema.data_locks w
+    WHERE w.OBJECT_SCHEMA IS NOT NULL
+      AND w.OBJECT_SCHEMA NOT IN ('performance_schema', 'information_schema', 'mysql', 'sys', 'otel')
+    GROUP BY w.OBJECT_SCHEMA, w.OBJECT_NAME, w.LOCK_TYPE, w.LOCK_MODE, w.LOCK_STATUS;
+    
+    -- Connection counts and the age of the longest-running connection per state.
+    CREATE OR REPLACE SQL SECURITY DEFINER VIEW otel.mysql_connections AS
+    SELECT
+        COALESCE(p.DB, '')                AS `db.namespace`,
+        COALESCE(p.COMMAND, 'unknown')    AS `db.client.connection.state`,
+        COUNT(*)                          AS connection_count,
+        COALESCE(MAX(p.TIME), 0)          AS max_state_age_seconds
+    FROM information_schema.PROCESSLIST p
+    GROUP BY p.DB, p.COMMAND;
+    
+    GRANT SELECT ON otel.* TO 'otel_monitor'@'%';

--- a/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/mysql-dbm-sidecar.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/mysql-dbm-sidecar.yaml
@@ -1,0 +1,257 @@
+---
+# Source: opentelemetry-database-monitoring/templates/mysql-dbm-sidecar.yaml
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: mysql-dbm-sidecar
+  annotations:
+    meta.helm.sh/release-name: "example"
+    meta.helm.sh/release-namespace: "default"
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+    opentelemetry-database-monitoring/database: mysql
+spec:
+  mode: sidecar
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
+  env:
+    - name: K8S_NODE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: OTEL_MONITOR_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: mysql-mysql-monitor-credentials
+          key: password
+  config:
+    receivers:
+      # The collector runs as a sidecar inside the MySQL Pod and reaches mysqld over
+      # the Pod's own network namespace, so this traffic does not leave the Pod. TLS
+      # is disabled here and every sqlquery datasource below sets tls=false.
+      # Configure TLS before pointing this config at a MySQL server outside the Pod.
+      #
+      # Keep `tls: insecure: true` written out in full. The receiver defaults
+      # insecure to true only when the `tls` key is absent; once `tls` is present,
+      # insecure takes its zero value of false and the receiver requires TLS.
+      mysql:
+        endpoint: ${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME}:3306
+        username: otel_monitor
+        password: ${env:OTEL_MONITOR_PASSWORD}
+        collection_interval: 30s
+        tls:
+          insecure: true
+        metrics:
+          mysql.client.network.io:
+            enabled: true
+          mysql.commands:
+            enabled: true
+          mysql.connection.count:
+            enabled: true
+          mysql.connection.errors:
+            enabled: true
+          mysql.joins:
+            enabled: true
+          mysql.max_used_connections:
+            enabled: true
+          mysql.page_size:
+            enabled: true
+          mysql.query.client.count:
+            enabled: true
+          mysql.query.count:
+            enabled: true
+          mysql.query.slow.count:
+            enabled: true
+          mysql.replica.sql_delay:
+            enabled: true
+          mysql.replica.time_behind_source:
+            enabled: true
+          mysql.statement_event.count:
+            enabled: true
+          mysql.statement_event.wait.time:
+            enabled: true
+          mysql.table.average_row_length:
+            enabled: true
+          mysql.table.lock_wait.read.count:
+            enabled: true
+          mysql.table.lock_wait.read.time:
+            enabled: true
+          mysql.table.lock_wait.write.count:
+            enabled: true
+          mysql.table.lock_wait.write.time:
+            enabled: true
+          mysql.table.rows:
+            enabled: true
+          mysql.table.size:
+            enabled: true
+          mysql.table_open_cache:
+            enabled: true
+      # Top queries are collected as metrics through sqlquery. The receiver's native
+      # top_query_collection block reports the same data as log records through the
+      # db.server.top_query event, at Development stability; this chart exports
+      # metrics only. See the chart README.
+      sqlquery/mysql_top_queries:
+        collection_interval: 60s
+        datasource: otel_monitor:${env:OTEL_MONITOR_PASSWORD}@tcp(${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME}:3306)/otel?tls=false
+        driver: mysql
+        queries:
+          - sql: SELECT * FROM otel.mysql_top_queries
+            metrics:
+              - attribute_columns:
+                  - db.namespace
+                  - db.query.hash
+                  - db.query.text
+                data_type: gauge
+                metric_name: mysql.query.calls
+                unit: "{query}"
+                value_column: calls
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.query.hash
+                  - db.query.text
+                data_type: gauge
+                metric_name: mysql.query.exec_time
+                unit: ms
+                value_column: total_exec_time_ms
+                value_type: double
+              - attribute_columns:
+                  - db.namespace
+                  - db.query.hash
+                  - db.query.text
+                data_type: gauge
+                metric_name: mysql.query.lock_time
+                unit: ms
+                value_column: total_lock_time_ms
+                value_type: double
+              - attribute_columns:
+                  - db.namespace
+                  - db.query.hash
+                  - db.query.text
+                data_type: gauge
+                metric_name: mysql.query.rows.sent
+                unit: "{row}"
+                value_column: rows_sent
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.query.hash
+                  - db.query.text
+                data_type: gauge
+                metric_name: mysql.query.rows.examined
+                unit: "{row}"
+                value_column: rows_examined
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.query.hash
+                  - db.query.text
+                data_type: gauge
+                metric_name: mysql.query.rows.affected
+                unit: "{row}"
+                value_column: rows_affected
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.query.hash
+                  - db.query.text
+                data_type: gauge
+                metric_name: mysql.query.errors
+                unit: "{error}"
+                value_column: query_errors
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.query.hash
+                  - db.query.text
+                data_type: gauge
+                metric_name: mysql.query.no_index_used
+                unit: "{query}"
+                value_column: no_index_used
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.query.hash
+                  - db.query.text
+                data_type: gauge
+                metric_name: mysql.query.full_scans
+                unit: "{query}"
+                value_column: full_scans
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.query.hash
+                  - db.query.text
+                data_type: gauge
+                metric_name: mysql.query.tmp_disk_tables
+                unit: "{table}"
+                value_column: tmp_disk_tables
+                value_type: int
+      sqlquery/mysql_locks:
+        collection_interval: 30s
+        datasource: otel_monitor:${env:OTEL_MONITOR_PASSWORD}@tcp(${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME}:3306)/otel?tls=false
+        driver: mysql
+        queries:
+          - sql: SELECT * FROM otel.mysql_locks
+            metrics:
+              - attribute_columns:
+                  - db.namespace
+                  - db.collection.name
+                  - db.mysql.lock.type
+                  - db.mysql.lock.mode
+                  - db.mysql.lock.status
+                data_type: gauge
+                metric_name: mysql.lock.count
+                unit: "{lock}"
+                value_column: lock_count
+                value_type: int
+      sqlquery/mysql_connections:
+        collection_interval: 30s
+        datasource: otel_monitor:${env:OTEL_MONITOR_PASSWORD}@tcp(${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME}:3306)/otel?tls=false
+        driver: mysql
+        queries:
+          - sql: SELECT * FROM otel.mysql_connections
+            metrics:
+              - attribute_columns:
+                  - db.namespace
+                  - db.client.connection.state
+                data_type: gauge
+                metric_name: mysql.connection.state.count
+                unit: "{connection}"
+                value_column: connection_count
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.client.connection.state
+                data_type: gauge
+                metric_name: mysql.connection.state.age
+                unit: s
+                value_column: max_state_age_seconds
+                value_type: int
+    processors:
+      batch:
+        send_batch_max_size: 5000
+        send_batch_size: 5000
+    exporters:
+      # otlp_grpc is the canonical exporter type. The shorter `otlp` spelling is a
+      # deprecated alias that logs a warning on every collector startup.
+      otlp_grpc:
+        compression: gzip
+        endpoint: ${env:K8S_NODE_IP}:4317
+        tls:
+          insecure: true
+    service:
+      pipelines:
+        metrics:
+          exporters:
+            - otlp_grpc
+          processors:
+            - batch
+          receivers:
+            - mysql
+            - sqlquery/mysql_top_queries
+            - sqlquery/mysql_locks
+            - sqlquery/mysql_connections

--- a/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/secret-mysql-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mysql-single-db/rendered/secret-mysql-monitoring.yaml
@@ -1,0 +1,17 @@
+---
+# Source: opentelemetry-database-monitoring/templates/secret-mysql-monitoring.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-mysql-monitor-credentials
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+    opentelemetry-database-monitoring/database: mysql
+type: Opaque
+data:
+  password: "<your-password>"

--- a/charts/opentelemetry-database-monitoring/examples/mysql-single-db/values.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mysql-single-db/values.yaml
@@ -1,0 +1,10 @@
+---
+mysql:
+  enabled: true
+  databases:
+    - name: mysql
+      sidecar-name: mysql-dbm-sidecar
+      user: root
+      pwd: otel
+      port: 3306
+      host: mysql

--- a/charts/opentelemetry-database-monitoring/templates/NOTES.txt
+++ b/charts/opentelemetry-database-monitoring/templates/NOTES.txt
@@ -10,6 +10,16 @@ PostgreSQL monitoring deployed for {{ len .Values.postgres.databases }} database
 {{ end }}
 {{- end }}
 
+{{- if .Values.mysql.enabled }}
+MySQL monitoring deployed for {{ len .Values.mysql.databases }} database(s).
+
+{{- range .Values.mysql.databases }}
+  Database : {{ .name }} ({{ .host }}:{{ .port }})
+  Secret   : {{ .name }}-mysql-monitor-credentials
+  Sidecar  : {{ index . "sidecar-name" }}
+  Inject   : {{ include "opentelemetry-database-monitoring.sidecarInjectValue" (dict "root" $ "db" .) }}
+{{ end }}
+{{- end }}
 {{- if and .Values.argoEvents.enabled .Values.argoEvents.triggerSetupJob }}
 Argo Events will create setup Jobs when a new Pod is added with the inject annotation above.
 Existing Pods are ignored (afterStart filter). Restart the target database Pod after install:

--- a/charts/opentelemetry-database-monitoring/templates/_helpers.tpl
+++ b/charts/opentelemetry-database-monitoring/templates/_helpers.tpl
@@ -62,7 +62,7 @@ The shared Argo Events plumbing is derived from this list, so adding an engine h
 is what brings it into the EventBus, EventSource and RBAC gating.
 */}}
 {{- define "opentelemetry-database-monitoring.engines" -}}
-postgres
+postgres mysql
 {{- end }}
 
 {{/*
@@ -117,6 +117,15 @@ Monitor credentials secret name for a PostgreSQL database entry.
 */}}
 {{- define "opentelemetry-database-monitoring.monitorSecretName" -}}
 {{- printf "%s-pg-monitor-credentials" .name -}}
+{{- end }}
+
+{{/*
+Monitor credentials secret name for a MySQL database entry.
+Kept separate per engine so two engines can never collide on a secret name
+when both are enabled with the same database entry name.
+*/}}
+{{- define "opentelemetry-database-monitoring.mysqlMonitorSecretName" -}}
+{{- printf "%s-mysql-monitor-credentials" .name -}}
 {{- end }}
 
 {{/*

--- a/charts/opentelemetry-database-monitoring/templates/_job.tpl
+++ b/charts/opentelemetry-database-monitoring/templates/_job.tpl
@@ -62,3 +62,84 @@ spec:
           configMap:
             name: postgresql-monitoring-setup
 {{- end }}
+
+{{/*
+Render the MySQL monitoring setup Job.
+
+Context:
+  .root             - root Helm context
+  .db               - database entry from mysql.databases
+  .useName          - bool: use metadata.name
+  .useGenerateName  - bool: use metadata.generateName
+  .helmHook         - bool: add Helm post-install/post-upgrade hook annotations.
+                      Set when Helm owns the Job; leave unset when the Argo
+                      Events sensor creates it, which is not a Helm operation.
+*/}}
+{{- define "opentelemetry-database-monitoring.mysqlSetupJob" -}}
+{{- $root := .root -}}
+{{- $db := .db -}}
+{{- $dbHost := include "opentelemetry-database-monitoring.databaseHost" (dict "root" $root "db" $db) -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  {{- if .useGenerateName }}
+  generateName: {{ $db.name }}-mysql-monitoring-setup-
+  {{- else }}
+  name: {{ $db.name }}-mysql-monitoring-setup
+  {{- end }}
+  {{- if .helmHook }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    {{- include "opentelemetry-database-monitoring.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: db-monitoring-setup
+    opentelemetry-database-monitoring/database: {{ $db.name }}
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "opentelemetry-database-monitoring.selectorLabels" $root | nindent 8 }}
+        app.kubernetes.io/component: db-monitoring-setup
+        opentelemetry-database-monitoring/database: {{ $db.name }}
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: setup
+          image: {{ $root.Values.mysql.setupImage | default "mysql:8.4" }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              until mysqladmin ping -h {{ $dbHost }} -P {{ $db.port }} -u {{ $db.user }} --silent; do sleep 2; done
+              mysql -h {{ $dbHost }} -P {{ $db.port }} -u {{ $db.user }} < /scripts/monitoring-setup.sql
+              mysql -h {{ $dbHost }} -P {{ $db.port }} -u {{ $db.user }} \
+                -e "ALTER USER 'otel_monitor'@'%' IDENTIFIED BY '$OTEL_MONITOR_PASSWORD'"
+              # Confirm the monitoring role is actually usable on the endpoint we reached,
+              # and that it can read the views the collector scrapes. Fail (and let
+              # backoffLimit retry) if the setup did not land where the collector connects.
+              MYSQL_PWD="$OTEL_MONITOR_PASSWORD" mysql -h {{ $dbHost }} -P {{ $db.port }} -u otel_monitor \
+                -e "SELECT 1 FROM otel.mysql_top_queries LIMIT 0" > /dev/null
+          env:
+            # MYSQL_PWD keeps the admin password out of the container's process list.
+            # It is still visible in the Job spec, because it comes from values.
+            - name: MYSQL_PWD
+              value: {{ $db.pwd | quote }}
+            - name: OTEL_MONITOR_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opentelemetry-database-monitoring.mysqlMonitorSecretName" $db }}
+                  key: password
+          volumeMounts:
+            - name: monitoring-setup
+              mountPath: /scripts
+      volumes:
+        - name: monitoring-setup
+          configMap:
+            name: mysql-monitoring-setup
+{{- end }}

--- a/charts/opentelemetry-database-monitoring/templates/argo-sensor.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/argo-sensor.yaml
@@ -44,4 +44,45 @@ spec:
 {{ include "opentelemetry-database-monitoring.setupJob" (dict "root" $root "db" $db "useName" false "useGenerateName" true) | indent 14 }}
 {{- end }}
 {{- end }}
+{{- if .Values.mysql.enabled }}
+{{- range $db := .Values.mysql.databases }}
+{{- $sidecarInjectValue := include "opentelemetry-database-monitoring.sidecarInjectValue" (dict "root" $root "db" $db) }}
+{{- $targetNamespace := include "opentelemetry-database-monitoring.databaseNamespace" (merge (dict) $db (dict "Release" $root.Release)) }}
+{{- $eventName := printf "target-pod-created-%s" (include "opentelemetry-database-monitoring.argoResourceSuffix" $targetNamespace) }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  {{/* -mysql- keeps this from colliding with a postgres entry of the same name. */}}
+  name: {{ include "opentelemetry-database-monitoring.fullname" $root }}-{{ $db.name }}-mysql-setup
+  labels:
+    {{- include "opentelemetry-database-monitoring.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: argo-sensor
+    opentelemetry-database-monitoring/database: {{ $db.name }}
+spec:
+  {{- with $root.Values.argoEvents.eventBusName }}
+  eventBusName: {{ . }}
+  {{- end }}
+  template:
+    serviceAccountName: {{ $sensorSa }}
+  dependencies:
+    - name: {{ $eventName }}
+      eventSourceName: {{ $eventSourceName }}
+      eventName: {{ $eventName }}
+      filters:
+        data:
+          - path: body.metadata.annotations.{{ $annotationPath }}
+            type: string
+            value:
+              - {{ $sidecarInjectValue | quote }}
+  triggers:
+    - template:
+        name: create-{{ $db.name }}-mysql-monitoring-setup-job
+        k8s:
+          operation: create
+          source:
+            resource:
+{{ include "opentelemetry-database-monitoring.mysqlSetupJob" (dict "root" $root "db" $db "useName" false "useGenerateName" true) | indent 14 }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/opentelemetry-database-monitoring/templates/configmap-mysql-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/configmap-mysql-monitoring.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.mysql.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mysql-monitoring-setup
+data:
+  monitoring-setup.sql: |
+{{ .Files.Get "assets/mysql-monitoring-setup.sql" | indent 4 }}
+{{- end }}

--- a/charts/opentelemetry-database-monitoring/templates/job-mysql-monitoring-setup.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/job-mysql-monitoring-setup.yaml
@@ -1,0 +1,7 @@
+{{- if and .Values.mysql.enabled (not (and .Values.argoEvents.enabled .Values.argoEvents.triggerSetupJob)) }}
+{{- $root := . }}
+{{- range $db := .Values.mysql.databases }}
+---
+{{ include "opentelemetry-database-monitoring.mysqlSetupJob" (dict "root" $root "db" $db "useName" true "useGenerateName" false "helmHook" true) }}
+{{- end }}
+{{- end }}

--- a/charts/opentelemetry-database-monitoring/templates/mysql-dbm-sidecar.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/mysql-dbm-sidecar.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.mysql.enabled}}
+{{- $root := . }}
+{{- range $db := .Values.mysql.databases }}
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: {{ index $db "sidecar-name" }}
+  annotations:
+    meta.helm.sh/release-name: {{ $root.Release.Name | quote }}
+    meta.helm.sh/release-namespace: {{ $root.Release.Namespace | quote }}
+  labels:
+    {{- include "opentelemetry-database-monitoring.labels" $root | nindent 4 }}
+    opentelemetry-database-monitoring/database: {{ $db.name }}
+spec:
+  mode: sidecar
+  image: {{ $root.Values.mysql.image | default "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0" }}
+  env:
+    - name: K8S_NODE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: OTEL_MONITOR_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "opentelemetry-database-monitoring.mysqlMonitorSecretName" $db }}
+          key: password
+  config:
+{{ $root.Files.Get "assets/mysql-monitoring-config.yaml" | trimPrefix "---" | trim | indent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/opentelemetry-database-monitoring/templates/secret-mysql-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/secret-mysql-monitoring.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.mysql.enabled }}
+{{- $root := . }}
+{{- range $db := .Values.mysql.databases }}
+{{- $secretName := include "opentelemetry-database-monitoring.mysqlMonitorSecretName" $db }}
+{{- $targetNamespace := include "opentelemetry-database-monitoring.databaseNamespace" (merge (dict) $db (dict "Release" $root.Release)) }}
+{{- $password := include "opentelemetry-database-monitoring.monitorPassword" (dict "root" $root "db" $db "secretName" $secretName) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    {{- include "opentelemetry-database-monitoring.labels" $root | nindent 4 }}
+    opentelemetry-database-monitoring/database: {{ $db.name }}
+type: Opaque
+data:
+  password: {{ $password | b64enc | quote }}
+{{- if ne $targetNamespace $root.Release.Namespace }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ $targetNamespace }}
+  labels:
+    {{- include "opentelemetry-database-monitoring.labels" $root | nindent 4 }}
+    opentelemetry-database-monitoring/database: {{ $db.name }}
+type: Opaque
+data:
+  password: {{ $password | b64enc | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/opentelemetry-database-monitoring/tests/mysql_test.yaml
+++ b/charts/opentelemetry-database-monitoring/tests/mysql_test.yaml
@@ -1,0 +1,164 @@
+---
+suite: mysql monitoring tests
+templates:
+  - mysql-dbm-sidecar.yaml
+  - secret-mysql-monitoring.yaml
+  - configmap-mysql-monitoring.yaml
+  - job-mysql-monitoring-setup.yaml
+tests:
+  - it: should render nothing when mysql is disabled
+    set:
+      mysql.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create the sidecar collector with a pinned image
+    template: mysql-dbm-sidecar.yaml
+    set:
+      mysql.enabled: true
+    release:
+      name: "test-release"
+    asserts:
+      - isKind:
+          of: OpenTelemetryCollector
+      - equal:
+          path: metadata.name
+          value: "mysql-dbm-sidecar"
+      - equal:
+          path: spec.mode
+          value: sidecar
+      # An untagged image resolves to :latest and silently moves the collector
+      # version out from under this config.
+      - matchRegex:
+          path: spec.image
+          pattern: ":[0-9]+\\.[0-9]+\\.[0-9]+$"
+
+  - it: should wire the monitor password from the mysql secret
+    template: mysql-dbm-sidecar.yaml
+    set:
+      mysql.enabled: true
+    asserts:
+      - equal:
+          path: spec.env[1].name
+          value: OTEL_MONITOR_PASSWORD
+      - equal:
+          path: spec.env[1].valueFrom.secretKeyRef.name
+          value: "mysql-mysql-monitor-credentials"
+
+  - it: should use the canonical mysql receiver type and keep tls explicit
+    template: mysql-dbm-sidecar.yaml
+    set:
+      mysql.enabled: true
+    asserts:
+      # `mysql` is the canonical component type; a near-miss fails the collector
+      # at startup with `unknown type`.
+      - matchRegex:
+          path: spec.config.receivers.mysql.endpoint
+          pattern: ":3306$"
+      # mysqlreceiver only defaults to insecure when `tls` is absent entirely.
+      # Once `tls` is present, omitting `insecure` makes it demand TLS.
+      - equal:
+          path: spec.config.receivers.mysql.tls.insecure
+          value: true
+
+  - it: should collect top queries as metrics through sqlquery
+    template: mysql-dbm-sidecar.yaml
+    set:
+      mysql.enabled: true
+    asserts:
+      - equal:
+          path: spec.config.receivers["sqlquery/mysql_top_queries"].driver
+          value: mysql
+      - contains:
+          path: spec.config.service.pipelines.metrics.receivers
+          content: "sqlquery/mysql_top_queries"
+      # The native top_query_collection block emits log records, not metrics.
+      # This chart's contract is metrics, so there must be no logs pipeline.
+      - notExists:
+          path: spec.config.service.pipelines.logs
+
+  - it: should create the monitor secret in the release namespace
+    template: secret-mysql-monitoring.yaml
+    set:
+      mysql.enabled: true
+    release:
+      name: "test-release"
+      namespace: "otel"
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: "mysql-mysql-monitor-credentials"
+      - equal:
+          path: metadata.namespace
+          value: "otel"
+      - exists:
+          path: data.password
+
+  - it: should replicate the secret into a cross-namespace target
+    template: secret-mysql-monitoring.yaml
+    set:
+      mysql.enabled: true
+      mysql.databases:
+        - name: mysql
+          namespace: databases
+          sidecar-name: mysql-dbm-sidecar
+          user: root
+          pwd: otel
+          port: 3306
+          host: mysql
+    release:
+      namespace: "otel"
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.namespace
+          value: "otel"
+        documentIndex: 0
+      - equal:
+          path: metadata.namespace
+          value: "databases"
+        documentIndex: 1
+
+  - it: should mount the setup SQL through a configmap
+    template: configmap-mysql-monitoring.yaml
+    set:
+      mysql.enabled: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: "mysql-monitoring-setup"
+      - matchRegex:
+          path: data["monitoring-setup.sql"]
+          pattern: "otel\\.mysql_top_queries"
+
+  - it: should create a Helm-hooked setup job when argo events is disabled
+    template: job-mysql-monitoring-setup.yaml
+    set:
+      mysql.enabled: true
+      argoEvents.enabled: false
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.name
+          value: "mysql-mysql-monitoring-setup"
+      # Without the hook annotations, an upgrade fails on the Job's immutable fields.
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: "post-install,post-upgrade"
+
+  - it: should not create a Helm setup job when argo events drives it
+    template: job-mysql-monitoring-setup.yaml
+    set:
+      mysql.enabled: true
+      argoEvents.enabled: true
+      argoEvents.triggerSetupJob: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/opentelemetry-database-monitoring/values.schema.json
+++ b/charts/opentelemetry-database-monitoring/values.schema.json
@@ -95,6 +95,49 @@
                 }
             }
         },
+        "mysql": {
+            "type": "object",
+            "properties": {
+                "databases": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "host": {
+                                "type": "string"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "type": "string"
+                            },
+                            "port": {
+                                "type": "integer"
+                            },
+                            "pwd": {
+                                "type": "string"
+                            },
+                            "sidecar-name": {
+                                "type": "string"
+                            },
+                            "user": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "image": {
+                    "type": "string"
+                },
+                "setupImage": {
+                    "type": "string"
+                }
+            }
+        },
         "postgres": {
             "type": "object",
             "properties": {

--- a/charts/opentelemetry-database-monitoring/values.yaml
+++ b/charts/opentelemetry-database-monitoring/values.yaml
@@ -49,6 +49,58 @@ postgres:
       host: ""
 
 # =============================================================================
+# MYSQL
+# =============================================================================
+mysql:
+  # -- Deploy MySQL monitoring: the injected sidecar collector, the monitor
+  # credentials secret, the setup ConfigMap, and the setup Job.
+  # @default -- false
+  enabled: false
+  # Keep the tag. An untagged image resolves to :latest, which forces
+  # imagePullPolicy: Always and lets the collector version change under the
+  # receiver configuration in assets/mysql-monitoring-config.yaml.
+  # -- Collector image for the injected sidecar.
+  image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0"
+  # -- Image for the setup Job. Must provide the `mysql` and `mysqladmin`
+  # clients on PATH.
+  setupImage: "mysql:8.4"
+  # -- MySQL instances to monitor. Each entry produces its own sidecar collector,
+  # monitor secret, and setup Job.
+  databases:
+      # -- Name for this instance. Used as the prefix of the monitor secret and
+      # setup Job names, and set as the
+      # `opentelemetry-database-monitoring/database` label on every resource.
+    - name: mysql
+      # -- Namespace where the annotated MySQL Pod runs. Replicates the monitor
+      # secret into that namespace and sets the expected inject annotation to
+      # `<releaseNamespace>/<sidecar-name>` when it differs from the release
+      # namespace. Empty means the release namespace.
+      # @default -- ""
+      namespace: ""
+      # -- Name of the OpenTelemetryCollector resource for this instance. This is
+      # the value the target Pod's `sidecar.opentelemetry.io/inject` annotation
+      # must carry for the operator to inject the sidecar.
+      sidecar-name: mysql-dbm-sidecar
+      # -- Administrative user the setup Job connects as. Needs CREATE USER and
+      # GRANT OPTION.
+      # @default -- ""
+      user: ""
+      # -- Password for the administrative user. Interpolated into the setup Job
+      # spec, so it is readable by anyone who can read Jobs in the release
+      # namespace. It is not written to a secret.
+      # @default -- ""
+      pwd: ""
+      # -- Port the setup Job connects to. The sidecar's receiver port is fixed at
+      # 3306 in assets/mysql-monitoring-config.yaml; override that asset to change
+      # the port the collector uses.
+      port: 3306
+      # -- Host the setup Job connects to, normally the MySQL Service name. A value
+      # containing a dot is used as-is; otherwise, when the instance runs in
+      # another namespace, it is expanded to `<host>.<namespace>.svc.cluster.local`.
+      # @default -- ""
+      host: ""
+
+# =============================================================================
 # ARGO EVENTS SUBCHART
 # =============================================================================
 # Installs the Argo Events controller. The CRDs are shipped in this chart's crds/


### PR DESCRIPTION
Stacked on #147, which carries the shared scaffolding. **Base is `dbm/base`, so this
diff shows only MySQL.**

## What this adds

A `mysql:` engine block following the same shape as `postgres:`: a sidecar
`OpenTelemetryCollector`, a monitor credentials secret, a setup ConfigMap and Job, an
Argo Events sensor, an example with rendered output, and a helm-unittest suite.
Disabled by default.

## Setup

The setup SQL creates a read-only `otel_monitor` user (`PROCESS`,
`REPLICATION CLIENT`, `SELECT` on `performance_schema`) and installs three
`SQL SECURITY DEFINER` views in an `otel` database, so the monitor role reads them
with the definer's rights and never needs direct access to the underlying tables.

| View | Purpose |
|------|---------|
| `otel.mysql_top_queries` | Top 50 statement digests by total execution time |
| `otel.mysql_locks` | Current InnoDB locks by table, type, mode, status |
| `otel.mysql_connections` | Connection count and max age per schema and state |

Two filters in the top-queries view are load-bearing, and worth a look during review:

- System schemas **and** the `otel` schema are excluded. Without that, the
  collector's own queries — which run once per collection interval — occupy the
  top-N. I hit exactly this while testing.
- `LAST_SEEN` bounds the window. `events_statements_summary_by_digest` accumulates
  from server start, so an unbounded query reports the highest all-time totals on
  every scrape and stops reflecting current load.

## Metrics

The `mysql` receiver runs at 30 s with 22 default-disabled metrics additionally
enabled, for **45 metrics**. Top queries, locks and connection states are collected
as metrics with `sqlquery` over the views above.

The receiver's native `top_query_collection` block reports the same data as **log
records** (the `db.server.top_query` event) at Development stability, and this chart
exports metrics only — see the Query collection section of the README.

`mysql.replica.sql_delay` and `mysql.replica.time_behind_source` are enabled but
only report data on a replica.

## Testing

- `helm lint` clean; **24 helm-unittest tests**; `make check-examples` exit 0.
- Verified against **real MySQL 8.4.11** on collector `0.157.0`, with the collector
  sharing the database container's network namespace so the topology matches the
  sidecar case. The config under test was extracted from the committed rendered
  example rather than hand-written.
- The lock view was verified under **real lock contention** (a held row lock), not
  from an empty result.

## Note on Chart.yaml

Deliberately not bumped, to avoid a three-way conflict with the sibling engine PRs
and 12 files of `helm.sh/chart` label churn. Bump once when these land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
