### PR TITLE
Add MongoDB support to opentelemetry-database-monitoring

### DIFF
--- a/charts/opentelemetry-database-monitoring/README.md
+++ b/charts/opentelemetry-database-monitoring/README.md
@@ -23,6 +23,7 @@ gets, and the metrics collected.
 |----------|-----------|-------|
 | PostgreSQL | `postgres` | [PostgreSQL](#postgresql) |
 
+| MongoDB | `mongodb` | [MongoDB](#mongodb) |
 All databases export **metrics only**. See [Query collection](#query-collection)
 for how per-query data is collected and why.
 
@@ -306,6 +307,90 @@ postgres:
 Annotate the PostgreSQL Pod with
 `sidecar.opentelemetry.io/inject: postgres-dbm-sidecar`.
 
+## MongoDB
+
+Enable with `mongodb.enabled=true`.
+
+### Requirements
+
+- MongoDB 4.4 or later.
+- The admin credentials in `mongodb.databases[*].user` / `pwd` must hold the
+  `userAdmin` role on the `admin` database, or `root`.
+
+### Setup
+
+The setup Job runs `assets/mongodb-monitoring-setup.js` with `mongosh`,
+idempotently. It creates the `otel_monitor` user in the `admin` database with the
+built-in `clusterMonitor` role, which is the role MongoDB documents for a
+least-privilege monitoring user and the role the receiver requires to collect
+metrics. On re-run it updates the password in place, so a rotated monitor Secret
+converges instead of failing because the user already exists.
+
+There are no helper collections or views to install: the receiver reads the
+`serverStatus`, `dbStats`, and index stats commands directly. The generated password
+is passed to the script through `OTEL_MONITOR_PASSWORD` in the environment rather
+than on the command line, and the script exits non-zero if that variable is unset.
+
+### Metrics
+
+The `mongodb` receiver runs at a 30 s interval and reports 36 metrics: cache
+operations, collection, database, index and object counts, cursor counts and
+timeouts, connection count, data, index and storage sizes, memory usage, document
+and operation counts, operation time, global lock time, network I/O and request
+count, and session count, plus 15 default-disabled metrics enabled by this chart
+(active reads and writes, the per-second command, delete, getmore, insert, query and
+update rates, health, lock acquire count, operation latency, replicated operation
+count, page faults, uptime, and WiredTiger cache reads).
+
+Two settings are worth knowing about:
+
+- **`hosts`** takes a list of endpoint objects. This chart sets the single endpoint
+  of the Pod the sidecar runs in.
+- **`direct_connection: true`** makes each sidecar scrape only the `mongod` beside
+  it. With discovery enabled the receiver runs `replSetGetStatus` and connects out
+  to secondaries; because this chart injects one sidecar per Pod, every member is
+  already scraped by its own Collector, so discovery would report secondaries more
+  than once. `replSetGetStatus` is also not valid on a standalone server or through
+  `mongos`, where it logs a warning on each scrape. Set it to `false` by overriding
+  the asset config if you want one Collector to scrape a whole replica set.
+
+The following metrics are deliberately left disabled, each verified to report no
+data on MongoDB 7 with the WiredTiger storage engine:
+
+| Metric | Reason |
+|--------|--------|
+| `mongodb.extent.count` | Enabled upstream by default, but only reported by servers older than 4.4 using the mmapv1 storage engine. |
+| `mongodb.flushes.rate` | Fails the scrape with `could not find key for metric`. |
+| `mongodb.lock.acquire.time`, `.wait_count`, `mongodb.lock.deadlock.count` | Reported only while locks are contended. |
+| `mongodb.repl_*_per_sec` | Reported only by replica set members. |
+
+This receiver offers query samples as log records only, and has no top-query
+support, so there are no per-query metrics for MongoDB.
+
+### Topologies
+
+For a sharded cluster, annotate the `mongos` Pods. For a replica set, annotate each
+member Pod; every member then reports its own metrics, distinguished by the
+`server.address` resource attribute.
+
+### Example
+
+See `examples/mongodb-single-db/`.
+
+```yaml
+mongodb:
+  enabled: true
+  databases:
+    - name: mongodb
+      sidecar-name: mongodb-dbm-sidecar
+      user: root
+      pwd: otel
+      port: 27017
+      host: mongodb
+```
+
+Annotate the MongoDB Pod with `sidecar.opentelemetry.io/inject: mongodb-dbm-sidecar`.
+
 ## Query collection
 
 Several database receivers can report per-query data through a native
@@ -319,6 +404,7 @@ against a view or function installed by the setup script.
 |----------|------------------|-----------|
 | PostgreSQL | yes | `sqlquery` over `otel.pg_top_queries()` |
 
+| MongoDB | no | the receiver offers query samples as log records only, and has no top-query support |
 The native blocks are functional, so this is a choice about signal type rather than
 a workaround. To use the native events instead, enable them on the receiver and add
 a `logs` pipeline by overriding the engine's asset config. Do not run both: they
@@ -442,6 +528,17 @@ stuck in that loop means the `host` and `port` in values do not reach the databa
 | argoEvents.sensor.serviceAccount.name | string | "" | Name of the Sensor ServiceAccount. Defaults to `<fullname>-argo-sensor` when empty. |
 | argoEvents.sidecarInjectAnnotation | string | `"sidecar.opentelemetry.io/inject"` | Pod annotation key the OpenTelemetry Operator reads to inject a sidecar. The Sensors filter incoming Pod events on this key. |
 | argoEvents.triggerSetupJob | bool | true | Create each setup Job from an Argo Events Sensor when a target Pod appears, instead of from a Helm post-install/post-upgrade hook. Running setup after the operator has injected the sidecar avoids racing database setup against sidecar startup, and allows the release to live in a different namespace from the database. |
+| mongodb.databases | list | `[{"host":"","name":"mongodb","namespace":"","port":27017,"pwd":"","sidecar-name":"mongodb-dbm-sidecar","user":""}]` | MongoDB instances to monitor. Each entry produces its own sidecar collector, monitor secret, and setup Job. |
+| mongodb.databases[0] | object | `{"host":"","name":"mongodb","namespace":"","port":27017,"pwd":"","sidecar-name":"mongodb-dbm-sidecar","user":""}` | Name for this instance. Used as the prefix of the monitor secret and setup Job names, and set as the `opentelemetry-database-monitoring/database` label on every resource. |
+| mongodb.databases[0].host | string | "" | Host the setup Job connects to, normally the MongoDB Service name. A value containing a dot is used as-is; otherwise, when the instance runs in another namespace, it is expanded to `<host>.<namespace>.svc.cluster.local`. |
+| mongodb.databases[0].namespace | string | "" | Namespace where the annotated MongoDB Pod runs. Replicates the monitor secret into that namespace and sets the expected inject annotation to `<releaseNamespace>/<sidecar-name>` when it differs from the release namespace. Empty means the release namespace. |
+| mongodb.databases[0].port | int | `27017` | Port the setup Job connects to. The sidecar's receiver port is fixed at 27017 in assets/mongodb-monitoring-config.yaml; override that asset to change the port the collector uses. |
+| mongodb.databases[0].pwd | string | "" | Password for the administrative user. Interpolated into the setup Job spec, so it is readable by anyone who can read Jobs in the release namespace. It is not written to a secret. |
+| mongodb.databases[0].sidecar-name | string | `"mongodb-dbm-sidecar"` | Name of the OpenTelemetryCollector resource for this instance. This is the value the target Pod's `sidecar.opentelemetry.io/inject` annotation must carry for the operator to inject the sidecar. |
+| mongodb.databases[0].user | string | "" | Administrative user the setup Job authenticates as against the admin database. Needs the userAdmin role on admin, or root. |
+| mongodb.enabled | bool | false | Deploy MongoDB monitoring: the injected sidecar collector, the monitor credentials secret, the setup ConfigMap, and the setup Job. |
+| mongodb.image | string | `"ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0"` | Collector image for the injected sidecar. |
+| mongodb.setupImage | string | `"mongo:7"` | Image for the setup Job. Must provide the `mongosh` client on PATH. |
 | postgres.databases | list | `[{"host":"","name":"postgresql","namespace":"","port":5432,"pwd":"","sidecar-name":"postgres-dbm-sidecar","user":""}]` | PostgreSQL instances to monitor. Each entry produces its own sidecar collector, monitor secret, and setup Job. |
 | postgres.databases[0] | object | `{"host":"","name":"postgresql","namespace":"","port":5432,"pwd":"","sidecar-name":"postgres-dbm-sidecar","user":""}` | Name for this instance. Used as the prefix of the monitor secret and setup Job names, and set as the `opentelemetry-database-monitoring/database` label on every resource. |
 | postgres.databases[0].host | string | "" | Host the setup Job connects to, normally the PostgreSQL Service name. A value containing a dot is used as-is; otherwise, when the instance runs in another namespace, it is expanded to `<host>.<namespace>.svc.cluster.local`. |

--- a/charts/opentelemetry-database-monitoring/README.md.gotmpl
+++ b/charts/opentelemetry-database-monitoring/README.md.gotmpl
@@ -27,6 +27,7 @@ gets, and the metrics collected.
 |----------|-----------|-------|
 | PostgreSQL | `postgres` | [PostgreSQL](#postgresql) |
 
+| MongoDB | `mongodb` | [MongoDB](#mongodb) |
 All databases export **metrics only**. See [Query collection](#query-collection)
 for how per-query data is collected and why.
 
@@ -310,6 +311,90 @@ postgres:
 Annotate the PostgreSQL Pod with
 `sidecar.opentelemetry.io/inject: postgres-dbm-sidecar`.
 
+## MongoDB
+
+Enable with `mongodb.enabled=true`.
+
+### Requirements
+
+- MongoDB 4.4 or later.
+- The admin credentials in `mongodb.databases[*].user` / `pwd` must hold the
+  `userAdmin` role on the `admin` database, or `root`.
+
+### Setup
+
+The setup Job runs `assets/mongodb-monitoring-setup.js` with `mongosh`,
+idempotently. It creates the `otel_monitor` user in the `admin` database with the
+built-in `clusterMonitor` role, which is the role MongoDB documents for a
+least-privilege monitoring user and the role the receiver requires to collect
+metrics. On re-run it updates the password in place, so a rotated monitor Secret
+converges instead of failing because the user already exists.
+
+There are no helper collections or views to install: the receiver reads the
+`serverStatus`, `dbStats`, and index stats commands directly. The generated password
+is passed to the script through `OTEL_MONITOR_PASSWORD` in the environment rather
+than on the command line, and the script exits non-zero if that variable is unset.
+
+### Metrics
+
+The `mongodb` receiver runs at a 30 s interval and reports 36 metrics: cache
+operations, collection, database, index and object counts, cursor counts and
+timeouts, connection count, data, index and storage sizes, memory usage, document
+and operation counts, operation time, global lock time, network I/O and request
+count, and session count, plus 15 default-disabled metrics enabled by this chart
+(active reads and writes, the per-second command, delete, getmore, insert, query and
+update rates, health, lock acquire count, operation latency, replicated operation
+count, page faults, uptime, and WiredTiger cache reads).
+
+Two settings are worth knowing about:
+
+- **`hosts`** takes a list of endpoint objects. This chart sets the single endpoint
+  of the Pod the sidecar runs in.
+- **`direct_connection: true`** makes each sidecar scrape only the `mongod` beside
+  it. With discovery enabled the receiver runs `replSetGetStatus` and connects out
+  to secondaries; because this chart injects one sidecar per Pod, every member is
+  already scraped by its own Collector, so discovery would report secondaries more
+  than once. `replSetGetStatus` is also not valid on a standalone server or through
+  `mongos`, where it logs a warning on each scrape. Set it to `false` by overriding
+  the asset config if you want one Collector to scrape a whole replica set.
+
+The following metrics are deliberately left disabled, each verified to report no
+data on MongoDB 7 with the WiredTiger storage engine:
+
+| Metric | Reason |
+|--------|--------|
+| `mongodb.extent.count` | Enabled upstream by default, but only reported by servers older than 4.4 using the mmapv1 storage engine. |
+| `mongodb.flushes.rate` | Fails the scrape with `could not find key for metric`. |
+| `mongodb.lock.acquire.time`, `.wait_count`, `mongodb.lock.deadlock.count` | Reported only while locks are contended. |
+| `mongodb.repl_*_per_sec` | Reported only by replica set members. |
+
+This receiver offers query samples as log records only, and has no top-query
+support, so there are no per-query metrics for MongoDB.
+
+### Topologies
+
+For a sharded cluster, annotate the `mongos` Pods. For a replica set, annotate each
+member Pod; every member then reports its own metrics, distinguished by the
+`server.address` resource attribute.
+
+### Example
+
+See `examples/mongodb-single-db/`.
+
+```yaml
+mongodb:
+  enabled: true
+  databases:
+    - name: mongodb
+      sidecar-name: mongodb-dbm-sidecar
+      user: root
+      pwd: otel
+      port: 27017
+      host: mongodb
+```
+
+Annotate the MongoDB Pod with `sidecar.opentelemetry.io/inject: mongodb-dbm-sidecar`.
+
 ## Query collection
 
 Several database receivers can report per-query data through a native
@@ -323,6 +408,7 @@ against a view or function installed by the setup script.
 |----------|------------------|-----------|
 | PostgreSQL | yes | `sqlquery` over `otel.pg_top_queries()` |
 
+| MongoDB | no | the receiver offers query samples as log records only, and has no top-query support |
 The native blocks are functional, so this is a choice about signal type rather than
 a workaround. To use the native events instead, enable them on the receiver and add
 a `logs` pipeline by overriding the engine's asset config. Do not run both: they

--- a/charts/opentelemetry-database-monitoring/assets/mongodb-monitoring-config.yaml
+++ b/charts/opentelemetry-database-monitoring/assets/mongodb-monitoring-config.yaml
@@ -1,0 +1,92 @@
+receivers:
+  # The collector runs as a sidecar inside the MongoDB Pod and reaches mongod
+  # over the Pod's own network namespace, so this traffic does not leave the Pod
+  # and TLS is disabled. Configure TLS before pointing this config at a MongoDB
+  # server outside the Pod.
+  mongodb:
+    # hosts takes a list of endpoint objects.
+    hosts:
+      - endpoint: ${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME}:27017
+    username: otel_monitor
+    password: ${env:OTEL_MONITOR_PASSWORD}
+    # The monitor user is created in admin, which is not the default auth database.
+    auth_source: admin
+    # Connect only to the mongod in this Pod and skip secondary discovery.
+    #
+    # With direct_connection disabled, the receiver runs replSetGetStatus to
+    # enumerate secondaries and opens additional connections to them. Because
+    # this chart injects one sidecar per Pod, each member is already scraped by
+    # its own collector, so discovery would report every secondary more than
+    # once. replSetGetStatus is also not a valid command on a standalone server
+    # or through mongos, where it logs a warning on each scrape.
+    #
+    # Set to false to have a single collector scrape a whole replica set.
+    direct_connection: true
+    collection_interval: 30s
+    tls:
+      insecure: true
+    metrics:
+      mongodb.active.reads:
+        enabled: true
+      mongodb.active.writes:
+        enabled: true
+      mongodb.commands.rate:
+        enabled: true
+      mongodb.deletes.rate:
+        enabled: true
+      mongodb.getmores.rate:
+        enabled: true
+      mongodb.health:
+        enabled: true
+      mongodb.inserts.rate:
+        enabled: true
+      mongodb.lock.acquire.count:
+        enabled: true
+      mongodb.operation.latency.time:
+        enabled: true
+      mongodb.operation.repl.count:
+        enabled: true
+      mongodb.page_faults:
+        enabled: true
+      mongodb.queries.rate:
+        enabled: true
+      mongodb.updates.rate:
+        enabled: true
+      mongodb.uptime:
+        enabled: true
+      mongodb.wtcache.bytes.read:
+        enabled: true
+      # Disabled: mongodb.extent.count is enabled upstream by default, but the
+      # value is only reported by servers older than 4.4 using the mmapv1 storage
+      # engine. The receiver supports 4.4 and later, so this metric produces no
+      # data on any supported version.
+      mongodb.extent.count:
+        enabled: false
+      # The following metrics are left disabled. Each was verified to produce no
+      # data on MongoDB 7 with the WiredTiger storage engine:
+      #   mongodb.flushes.rate            fails the scrape with "could not find key for metric"
+      #   mongodb.lock.acquire.time       reported only while locks are contended
+      #   mongodb.lock.acquire.wait_count reported only while locks are contended
+      #   mongodb.lock.deadlock.count     reported only while locks are contended
+      #   mongodb.repl_*_per_sec          reported only by replica set members
+processors:
+  batch:
+    send_batch_max_size: 5000
+    send_batch_size: 5000
+exporters:
+  # otlp_grpc is the canonical exporter type. The shorter `otlp` spelling is a
+  # deprecated alias that logs a warning on every collector startup.
+  otlp_grpc:
+    compression: gzip
+    endpoint: ${env:K8S_NODE_IP}:4317
+    tls:
+      insecure: true
+service:
+  pipelines:
+    metrics:
+      exporters:
+        - otlp_grpc
+      processors:
+        - batch
+      receivers:
+        - mongodb

--- a/charts/opentelemetry-database-monitoring/assets/mongodb-monitoring-setup.js
+++ b/charts/opentelemetry-database-monitoring/assets/mongodb-monitoring-setup.js
@@ -1,0 +1,33 @@
+// MongoDB monitoring setup for OpenTelemetry
+// Run with mongosh as a user holding userAdmin (or root) on the admin database.
+// Safe to re-run (idempotent).
+//
+// This script provisions the least-privilege monitor user that the receiver
+// authenticates as. No helper collections or views are needed: the receiver
+// reads the serverStatus, dbStats, and index stats commands directly.
+//
+// The password is read from OTEL_MONITOR_PASSWORD in the environment, so it is
+// not written into this file or into the Job's command line.
+
+const monitorPassword = process.env.OTEL_MONITOR_PASSWORD;
+if (!monitorPassword) {
+  throw new Error("OTEL_MONITOR_PASSWORD is not set; refusing to create a user without a password");
+}
+
+const admin = db.getSiblingDB("admin");
+
+// clusterMonitor is the built-in role MongoDB documents for a least-privilege
+// monitoring user, and the role the receiver requires to collect metrics.
+const roles = [{ role: "clusterMonitor", db: "admin" }];
+
+const existing = admin.getUser("otel_monitor");
+if (existing === null) {
+  admin.createUser({ user: "otel_monitor", pwd: monitorPassword, roles: roles });
+  print("created user otel_monitor");
+} else {
+  // updateUser sets the password in place and re-asserts the roles. This makes a
+  // re-run after the monitor secret changes converge on the new password rather
+  // than fail because the user already exists.
+  admin.updateUser("otel_monitor", { pwd: monitorPassword, roles: roles });
+  print("updated user otel_monitor");
+}

--- a/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/argo-eventbus.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/argo-eventbus.yaml
@@ -1,0 +1,17 @@
+---
+# Source: opentelemetry-database-monitoring/templates/argo-eventbus.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: EventBus
+metadata:
+  name: default
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  nats:
+    native:
+      replicas: 1
+      auth: none

--- a/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/argo-events-rbac.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/argo-events-rbac.yaml
@@ -1,0 +1,97 @@
+---
+# Source: opentelemetry-database-monitoring/templates/argo-events-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-opentelemetry-database-monitoring-argo-eventsource
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: opentelemetry-database-monitoring/templates/argo-events-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-opentelemetry-database-monitoring-argo-sensor
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: opentelemetry-database-monitoring/templates/argo-events-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: example-opentelemetry-database-monitoring-argo-eventsource
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+# Source: opentelemetry-database-monitoring/templates/argo-events-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: example-opentelemetry-database-monitoring-argo-sensor
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create"]
+---
+# Source: opentelemetry-database-monitoring/templates/argo-events-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: example-opentelemetry-database-monitoring-argo-eventsource
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+subjects:
+  - kind: ServiceAccount
+    name: example-opentelemetry-database-monitoring-argo-eventsource
+    namespace: default
+roleRef:
+  kind: Role
+  name: example-opentelemetry-database-monitoring-argo-eventsource
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: opentelemetry-database-monitoring/templates/argo-events-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: example-opentelemetry-database-monitoring-argo-sensor
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+subjects:
+  - kind: ServiceAccount
+    name: example-opentelemetry-database-monitoring-argo-sensor
+roleRef:
+  kind: Role
+  name: example-opentelemetry-database-monitoring-argo-sensor
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/argo-events/argo-events-controller/config.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/argo-events/argo-events-controller/config.yaml
@@ -1,0 +1,86 @@
+---
+# Source: opentelemetry-database-monitoring/charts/argo-events/templates/argo-events-controller/config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-argo-events-controller-manager
+  namespace: "default"
+  labels:
+    helm.sh/chart: argo-events-2.4.22
+    app.kubernetes.io/name: argo-events-controller-manager
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-events
+data:
+  controller-config.yaml: |
+    eventBus:
+      nats:
+        versions:
+        - version: latest
+          natsStreamingImage: nats-streaming:latest
+          metricsExporterImage: natsio/prometheus-nats-exporter:latest
+        - version: 0.22.1
+          natsStreamingImage: nats-streaming:0.22.1
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.8.0
+      jetstream:
+        # Default JetStream settings, could be overridden by EventBus JetStream specs
+        settings: |
+          # https://docs.nats.io/running-a-nats-service/configuration#jetstream
+          # Only configure "max_memory_store" or "max_file_store", do not set "store_dir" as it has been hardcoded.
+          max_memory_store: -1
+          max_file_store: -1
+        # The default properties of the streams to be created in this JetStream service
+        streamConfig: |
+          maxMsgs: 1e+06
+          maxAge: 72h
+          maxBytes: 1GB
+          replicas: 3
+          duplicates: 300s
+          retention: 0
+          discard: 0
+        versions:
+        - version: latest
+          natsImage: nats:2.10.10
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
+          configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+          startCommand: /nats-server
+        - version: 2.8.1
+          natsImage: nats:2.8.1
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+        - version: 2.8.1-alpine
+          natsImage: nats:2.8.1-alpine
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: nats-server
+        - version: 2.8.2
+          natsImage: nats:2.8.2
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+        - version: 2.8.2-alpine
+          natsImage: nats:2.8.2-alpine
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: nats-server
+        - version: 2.9.1
+          natsImage: nats:2.9.1
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+        - version: 2.9.12
+          natsImage: nats:2.9.12
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+        - version: 2.9.16
+          natsImage: nats:2.9.16
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+        - version: 2.10.10
+          natsImage: nats:2.10.10
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
+          configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+          startCommand: /nats-server

--- a/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/argo-events/argo-events-controller/deployment.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/argo-events/argo-events-controller/deployment.yaml
@@ -1,0 +1,84 @@
+---
+# Source: opentelemetry-database-monitoring/charts/argo-events/templates/argo-events-controller/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-argo-events-controller-manager
+  namespace: "default"
+  labels:
+    helm.sh/chart: argo-events-2.4.22
+    app.kubernetes.io/name: argo-events-controller-manager
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-events
+    app.kubernetes.io/version: "v1.9.10"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argo-events-controller-manager
+      app.kubernetes.io/instance: example
+  revisionHistoryLimit: 5
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: e582d4d24cbef623004e1fa804eb237a2c123cfb72fb4fa0424a6d46d28bff50
+      labels:
+        helm.sh/chart: argo-events-2.4.22
+        app.kubernetes.io/name: argo-events-controller-manager
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: controller-manager
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: argo-events
+        app.kubernetes.io/version: "v1.9.10"
+    spec:
+      containers:
+      - name: controller-manager
+        image: quay.io/argoproj/argo-events:v1.9.10
+        imagePullPolicy: IfNotPresent
+        args:
+        - controller
+        - --leader-election=false
+        env:
+        - name: ARGO_EVENTS_IMAGE
+          value: quay.io/argoproj/argo-events:v1.9.10
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - name: config
+          mountPath: /etc/argo-events
+        ports:
+        - name: metrics
+          containerPort: 7777
+          protocol: TCP
+        - name: probe
+          containerPort: 8081
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            port: probe
+            path: /healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            port: probe
+            path: /readyz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 3
+      serviceAccountName: example-argo-events-controller-manager
+      volumes:
+      - name: config
+        configMap:
+          name: example-argo-events-controller-manager

--- a/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/argo-events/argo-events-controller/rbac.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/argo-events/argo-events-controller/rbac.yaml
@@ -1,0 +1,115 @@
+---
+# Source: opentelemetry-database-monitoring/charts/argo-events/templates/argo-events-controller/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: example-argo-events-controller-manager
+  labels:
+    helm.sh/chart: argo-events-2.4.22
+    app.kubernetes.io/name: argo-events-controller-manager
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-events
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - sensors
+  - sensors/finalizers
+  - sensors/status
+  - eventsources
+  - eventsources/finalizers
+  - eventsources/status
+  - eventbus
+  - eventbus/finalizers
+  - eventbus/status
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/exec
+  - configmaps
+  - services
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+---
+# Source: opentelemetry-database-monitoring/charts/argo-events/templates/argo-events-controller/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: example-argo-events-controller-manager
+  labels:
+    helm.sh/chart: argo-events-2.4.22
+    app.kubernetes.io/name: argo-events-controller-manager
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-events
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: example-argo-events-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: example-argo-events-controller-manager
+  namespace: "default"

--- a/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/argo-events/argo-events-controller/serviceaccount.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/argo-events/argo-events-controller/serviceaccount.yaml
@@ -1,0 +1,15 @@
+---
+# Source: opentelemetry-database-monitoring/charts/argo-events/templates/argo-events-controller/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: example-argo-events-controller-manager
+  namespace: "default"
+  labels:
+    helm.sh/chart: argo-events-2.4.22
+    app.kubernetes.io/name: argo-events-controller-manager
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-events

--- a/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/argo-events/argo-events-webhook/serviceaccount.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/argo-events/argo-events-webhook/serviceaccount.yaml
@@ -1,0 +1,15 @@
+---
+# Source: opentelemetry-database-monitoring/charts/argo-events/templates/argo-events-webhook/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: example-argo-events-events-webhook
+  namespace: "default"
+  labels:
+    helm.sh/chart: argo-events-2.4.22
+    app.kubernetes.io/name: argo-events-events-webhook
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: events-webhook
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-events

--- a/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/argo-eventsource.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/argo-eventsource.yaml
@@ -1,0 +1,26 @@
+---
+# Source: opentelemetry-database-monitoring/templates/argo-eventsource.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: EventSource
+metadata:
+  name: example-opentelemetry-database-monitoring-pod-created
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  eventBusName: default
+  template:
+    serviceAccountName: example-opentelemetry-database-monitoring-argo-eventsource
+  resource:
+    target-pod-created-default:
+      namespace: default
+      group: ""
+      version: v1
+      resource: pods
+      eventTypes:
+        - ADD
+      filter:
+        afterStart: true

--- a/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/argo-sensor.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/argo-sensor.yaml
@@ -1,0 +1,103 @@
+---
+# Source: opentelemetry-database-monitoring/templates/argo-sensor.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  
+  name: example-opentelemetry-database-monitoring-mongodb-mongodb-setup
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: argo-sensor
+    opentelemetry-database-monitoring/database: mongodb
+spec:
+  eventBusName: default
+  template:
+    serviceAccountName: example-opentelemetry-database-monitoring-argo-sensor
+  dependencies:
+    - name: target-pod-created-default
+      eventSourceName: example-opentelemetry-database-monitoring-pod-created
+      eventName: target-pod-created-default
+      filters:
+        data:
+          - path: body.metadata.annotations.sidecar\.opentelemetry\.io\/inject
+            type: string
+            value:
+              - "mongodb-dbm-sidecar"
+  triggers:
+    - template:
+        name: create-mongodb-mongodb-monitoring-setup-job
+        k8s:
+          operation: create
+          source:
+            resource:
+              apiVersion: batch/v1
+              kind: Job
+              metadata:
+                generateName: mongodb-mongodb-monitoring-setup-
+                namespace: default
+                labels:
+                  helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+                  app.kubernetes.io/name: opentelemetry-database-monitoring
+                  app.kubernetes.io/instance: example
+                  app.kubernetes.io/version: "1.16.0"
+                  app.kubernetes.io/managed-by: Helm
+                  app.kubernetes.io/component: db-monitoring-setup
+                  opentelemetry-database-monitoring/database: mongodb
+              spec:
+                backoffLimit: 3
+                template:
+                  metadata:
+                    labels:
+                      app.kubernetes.io/name: opentelemetry-database-monitoring
+                      app.kubernetes.io/instance: example
+                      app.kubernetes.io/component: db-monitoring-setup
+                      opentelemetry-database-monitoring/database: mongodb
+                  spec:
+                    restartPolicy: OnFailure
+                    containers:
+                      - name: setup
+                        image: mongo:7
+                        command:
+                          - /bin/sh
+                          - -c
+                          - |
+                            set -e
+                            until mongosh "mongodb://mongodb:27017/admin" \
+                              --username "$ADMIN_USER" --password "$ADMIN_PASSWORD" \
+                              --quiet --eval 'db.runCommand({ping:1})' > /dev/null 2>&1; do sleep 2; done
+                            # The script reads OTEL_MONITOR_PASSWORD from the environment, so the
+                            # generated password is never placed on the command line.
+                            mongosh "mongodb://mongodb:27017/admin" \
+                              --username "$ADMIN_USER" --password "$ADMIN_PASSWORD" \
+                              --quiet /scripts/monitoring-setup.js
+                            # Confirm the monitor user can authenticate and read serverStatus on the
+                            # endpoint the collector connects to. Failing here lets backoffLimit
+                            # retry rather than leaving a sidecar that cannot authenticate.
+                            mongosh "mongodb://mongodb:27017/admin" \
+                              --username otel_monitor --password "$OTEL_MONITOR_PASSWORD" \
+                              --authenticationDatabase admin --quiet \
+                              --eval 'if (db.getSiblingDB("admin").serverStatus().ok !== 1) { throw new Error("serverStatus not readable") }' > /dev/null
+                        env:
+                          - name: ADMIN_USER
+                            value: "root"
+                          # Passed as an env var so the admin password stays off the container's
+                          # process list. It is still visible in the Job spec, because it comes
+                          # from values.
+                          - name: ADMIN_PASSWORD
+                            value: "otel"
+                          - name: OTEL_MONITOR_PASSWORD
+                            valueFrom:
+                              secretKeyRef:
+                                name: mongodb-mongodb-monitor-credentials
+                                key: password
+                        volumeMounts:
+                          - name: monitoring-setup
+                            mountPath: /scripts
+                    volumes:
+                      - name: monitoring-setup
+                        configMap:
+                          name: mongodb-monitoring-setup

--- a/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/configmap-mongodb-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/configmap-mongodb-monitoring.yaml
@@ -1,0 +1,41 @@
+---
+# Source: opentelemetry-database-monitoring/templates/configmap-mongodb-monitoring.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mongodb-monitoring-setup
+data:
+  monitoring-setup.js: |
+    // MongoDB monitoring setup for OpenTelemetry
+    // Run with mongosh as a user holding userAdmin (or root) on the admin database.
+    // Safe to re-run (idempotent).
+    //
+    // This script provisions the least-privilege monitor user that the receiver
+    // authenticates as. No helper collections or views are needed: the receiver
+    // reads the serverStatus, dbStats, and index stats commands directly.
+    //
+    // The password is read from OTEL_MONITOR_PASSWORD in the environment, so it is
+    // not written into this file or into the Job's command line.
+    
+    const monitorPassword = process.env.OTEL_MONITOR_PASSWORD;
+    if (!monitorPassword) {
+      throw new Error("OTEL_MONITOR_PASSWORD is not set; refusing to create a user without a password");
+    }
+    
+    const admin = db.getSiblingDB("admin");
+    
+    // clusterMonitor is the built-in role MongoDB documents for a least-privilege
+    // monitoring user, and the role the receiver requires to collect metrics.
+    const roles = [{ role: "clusterMonitor", db: "admin" }];
+    
+    const existing = admin.getUser("otel_monitor");
+    if (existing === null) {
+      admin.createUser({ user: "otel_monitor", pwd: monitorPassword, roles: roles });
+      print("created user otel_monitor");
+    } else {
+      // updateUser sets the password in place and re-asserts the roles. This makes a
+      // re-run after the monitor secret changes converge on the new password rather
+      // than fail because the user already exists.
+      admin.updateUser("otel_monitor", { pwd: monitorPassword, roles: roles });
+      print("updated user otel_monitor");
+    }

--- a/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/mongodb-dbm-sidecar.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/mongodb-dbm-sidecar.yaml
@@ -1,0 +1,122 @@
+---
+# Source: opentelemetry-database-monitoring/templates/mongodb-dbm-sidecar.yaml
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: mongodb-dbm-sidecar
+  annotations:
+    meta.helm.sh/release-name: "example"
+    meta.helm.sh/release-namespace: "default"
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+    opentelemetry-database-monitoring/database: mongodb
+spec:
+  mode: sidecar
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
+  env:
+    - name: K8S_NODE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: OTEL_MONITOR_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: mongodb-mongodb-monitor-credentials
+          key: password
+  config:
+    receivers:
+      # The collector runs as a sidecar inside the MongoDB Pod and reaches mongod
+      # over the Pod's own network namespace, so this traffic does not leave the Pod
+      # and TLS is disabled. Configure TLS before pointing this config at a MongoDB
+      # server outside the Pod.
+      mongodb:
+        # hosts takes a list of endpoint objects.
+        hosts:
+          - endpoint: ${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME}:27017
+        username: otel_monitor
+        password: ${env:OTEL_MONITOR_PASSWORD}
+        # The monitor user is created in admin, which is not the default auth database.
+        auth_source: admin
+        # Connect only to the mongod in this Pod and skip secondary discovery.
+        #
+        # With direct_connection disabled, the receiver runs replSetGetStatus to
+        # enumerate secondaries and opens additional connections to them. Because
+        # this chart injects one sidecar per Pod, each member is already scraped by
+        # its own collector, so discovery would report every secondary more than
+        # once. replSetGetStatus is also not a valid command on a standalone server
+        # or through mongos, where it logs a warning on each scrape.
+        #
+        # Set to false to have a single collector scrape a whole replica set.
+        direct_connection: true
+        collection_interval: 30s
+        tls:
+          insecure: true
+        metrics:
+          mongodb.active.reads:
+            enabled: true
+          mongodb.active.writes:
+            enabled: true
+          mongodb.commands.rate:
+            enabled: true
+          mongodb.deletes.rate:
+            enabled: true
+          mongodb.getmores.rate:
+            enabled: true
+          mongodb.health:
+            enabled: true
+          mongodb.inserts.rate:
+            enabled: true
+          mongodb.lock.acquire.count:
+            enabled: true
+          mongodb.operation.latency.time:
+            enabled: true
+          mongodb.operation.repl.count:
+            enabled: true
+          mongodb.page_faults:
+            enabled: true
+          mongodb.queries.rate:
+            enabled: true
+          mongodb.updates.rate:
+            enabled: true
+          mongodb.uptime:
+            enabled: true
+          mongodb.wtcache.bytes.read:
+            enabled: true
+          # Disabled: mongodb.extent.count is enabled upstream by default, but the
+          # value is only reported by servers older than 4.4 using the mmapv1 storage
+          # engine. The receiver supports 4.4 and later, so this metric produces no
+          # data on any supported version.
+          mongodb.extent.count:
+            enabled: false
+          # The following metrics are left disabled. Each was verified to produce no
+          # data on MongoDB 7 with the WiredTiger storage engine:
+          #   mongodb.flushes.rate            fails the scrape with "could not find key for metric"
+          #   mongodb.lock.acquire.time       reported only while locks are contended
+          #   mongodb.lock.acquire.wait_count reported only while locks are contended
+          #   mongodb.lock.deadlock.count     reported only while locks are contended
+          #   mongodb.repl_*_per_sec          reported only by replica set members
+    processors:
+      batch:
+        send_batch_max_size: 5000
+        send_batch_size: 5000
+    exporters:
+      # otlp_grpc is the canonical exporter type. The shorter `otlp` spelling is a
+      # deprecated alias that logs a warning on every collector startup.
+      otlp_grpc:
+        compression: gzip
+        endpoint: ${env:K8S_NODE_IP}:4317
+        tls:
+          insecure: true
+    service:
+      pipelines:
+        metrics:
+          exporters:
+            - otlp_grpc
+          processors:
+            - batch
+          receivers:
+            - mongodb

--- a/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/secret-mongodb-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/rendered/secret-mongodb-monitoring.yaml
@@ -1,0 +1,17 @@
+---
+# Source: opentelemetry-database-monitoring/templates/secret-mongodb-monitoring.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mongodb-mongodb-monitor-credentials
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+    opentelemetry-database-monitoring/database: mongodb
+type: Opaque
+data:
+  password: "<your-password>"

--- a/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/values.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/mongodb-single-db/values.yaml
@@ -1,0 +1,10 @@
+---
+mongodb:
+  enabled: true
+  databases:
+    - name: mongodb
+      sidecar-name: mongodb-dbm-sidecar
+      user: root
+      pwd: otel
+      port: 27017
+      host: mongodb

--- a/charts/opentelemetry-database-monitoring/templates/NOTES.txt
+++ b/charts/opentelemetry-database-monitoring/templates/NOTES.txt
@@ -10,6 +10,16 @@ PostgreSQL monitoring deployed for {{ len .Values.postgres.databases }} database
 {{ end }}
 {{- end }}
 
+{{- if .Values.mongodb.enabled }}
+MongoDB monitoring deployed for {{ len .Values.mongodb.databases }} database(s).
+
+{{- range .Values.mongodb.databases }}
+  Database : {{ .name }} ({{ .host }}:{{ .port }})
+  Secret   : {{ .name }}-mongodb-monitor-credentials
+  Sidecar  : {{ index . "sidecar-name" }}
+  Inject   : {{ include "opentelemetry-database-monitoring.sidecarInjectValue" (dict "root" $ "db" .) }}
+{{ end }}
+{{- end }}
 {{- if and .Values.argoEvents.enabled .Values.argoEvents.triggerSetupJob }}
 Argo Events will create setup Jobs when a new Pod is added with the inject annotation above.
 Existing Pods are ignored (afterStart filter). Restart the target database Pod after install:

--- a/charts/opentelemetry-database-monitoring/templates/_helpers.tpl
+++ b/charts/opentelemetry-database-monitoring/templates/_helpers.tpl
@@ -62,7 +62,7 @@ The shared Argo Events plumbing is derived from this list, so adding an engine h
 is what brings it into the EventBus, EventSource and RBAC gating.
 */}}
 {{- define "opentelemetry-database-monitoring.engines" -}}
-postgres
+postgres mongodb
 {{- end }}
 
 {{/*
@@ -117,6 +117,15 @@ Monitor credentials secret name for a PostgreSQL database entry.
 */}}
 {{- define "opentelemetry-database-monitoring.monitorSecretName" -}}
 {{- printf "%s-pg-monitor-credentials" .name -}}
+{{- end }}
+
+{{/*
+Monitor credentials secret name for a MongoDB database entry.
+Kept separate per engine so two engines can never collide on a secret name
+when both are enabled with the same database entry name.
+*/}}
+{{- define "opentelemetry-database-monitoring.mongodbMonitorSecretName" -}}
+{{- printf "%s-mongodb-monitor-credentials" .name -}}
 {{- end }}
 
 {{/*

--- a/charts/opentelemetry-database-monitoring/templates/_job.tpl
+++ b/charts/opentelemetry-database-monitoring/templates/_job.tpl
@@ -62,3 +62,93 @@ spec:
           configMap:
             name: postgresql-monitoring-setup
 {{- end }}
+
+{{/*
+Render the MongoDB monitoring setup Job.
+
+Context:
+  .root             - root Helm context
+  .db               - database entry from mongodb.databases
+  .useName          - bool: use metadata.name
+  .useGenerateName  - bool: use metadata.generateName
+  .helmHook         - bool: add Helm post-install/post-upgrade hook annotations.
+                      Set when Helm owns the Job; leave unset when the Argo
+                      Events sensor creates it, which is not a Helm operation.
+*/}}
+{{- define "opentelemetry-database-monitoring.mongodbSetupJob" -}}
+{{- $root := .root -}}
+{{- $db := .db -}}
+{{- $dbHost := include "opentelemetry-database-monitoring.databaseHost" (dict "root" $root "db" $db) -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  {{- if .useGenerateName }}
+  generateName: {{ $db.name }}-mongodb-monitoring-setup-
+  {{- else }}
+  name: {{ $db.name }}-mongodb-monitoring-setup
+  {{- end }}
+  {{- if .helmHook }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    {{- include "opentelemetry-database-monitoring.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: db-monitoring-setup
+    opentelemetry-database-monitoring/database: {{ $db.name }}
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "opentelemetry-database-monitoring.selectorLabels" $root | nindent 8 }}
+        app.kubernetes.io/component: db-monitoring-setup
+        opentelemetry-database-monitoring/database: {{ $db.name }}
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: setup
+          image: {{ $root.Values.mongodb.setupImage | default "mongo:7" }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              until mongosh "mongodb://{{ $dbHost }}:{{ $db.port }}/admin" \
+                --username "$ADMIN_USER" --password "$ADMIN_PASSWORD" \
+                --quiet --eval 'db.runCommand({ping:1})' > /dev/null 2>&1; do sleep 2; done
+              # The script reads OTEL_MONITOR_PASSWORD from the environment, so the
+              # generated password is never placed on the command line.
+              mongosh "mongodb://{{ $dbHost }}:{{ $db.port }}/admin" \
+                --username "$ADMIN_USER" --password "$ADMIN_PASSWORD" \
+                --quiet /scripts/monitoring-setup.js
+              # Confirm the monitor user can authenticate and read serverStatus on the
+              # endpoint the collector connects to. Failing here lets backoffLimit
+              # retry rather than leaving a sidecar that cannot authenticate.
+              mongosh "mongodb://{{ $dbHost }}:{{ $db.port }}/admin" \
+                --username otel_monitor --password "$OTEL_MONITOR_PASSWORD" \
+                --authenticationDatabase admin --quiet \
+                --eval 'if (db.getSiblingDB("admin").serverStatus().ok !== 1) { throw new Error("serverStatus not readable") }' > /dev/null
+          env:
+            - name: ADMIN_USER
+              value: {{ $db.user | quote }}
+            # Passed as an env var so the admin password stays off the container's
+            # process list. It is still visible in the Job spec, because it comes
+            # from values.
+            - name: ADMIN_PASSWORD
+              value: {{ $db.pwd | quote }}
+            - name: OTEL_MONITOR_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opentelemetry-database-monitoring.mongodbMonitorSecretName" $db }}
+                  key: password
+          volumeMounts:
+            - name: monitoring-setup
+              mountPath: /scripts
+      volumes:
+        - name: monitoring-setup
+          configMap:
+            name: mongodb-monitoring-setup
+{{- end }}

--- a/charts/opentelemetry-database-monitoring/templates/argo-sensor.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/argo-sensor.yaml
@@ -44,4 +44,45 @@ spec:
 {{ include "opentelemetry-database-monitoring.setupJob" (dict "root" $root "db" $db "useName" false "useGenerateName" true) | indent 14 }}
 {{- end }}
 {{- end }}
+{{- if .Values.mongodb.enabled }}
+{{- range $db := .Values.mongodb.databases }}
+{{- $sidecarInjectValue := include "opentelemetry-database-monitoring.sidecarInjectValue" (dict "root" $root "db" $db) }}
+{{- $targetNamespace := include "opentelemetry-database-monitoring.databaseNamespace" (merge (dict) $db (dict "Release" $root.Release)) }}
+{{- $eventName := printf "target-pod-created-%s" (include "opentelemetry-database-monitoring.argoResourceSuffix" $targetNamespace) }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  {{/* -mongodb- keeps this from colliding with another engine's entry of the same name. */}}
+  name: {{ include "opentelemetry-database-monitoring.fullname" $root }}-{{ $db.name }}-mongodb-setup
+  labels:
+    {{- include "opentelemetry-database-monitoring.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: argo-sensor
+    opentelemetry-database-monitoring/database: {{ $db.name }}
+spec:
+  {{- with $root.Values.argoEvents.eventBusName }}
+  eventBusName: {{ . }}
+  {{- end }}
+  template:
+    serviceAccountName: {{ $sensorSa }}
+  dependencies:
+    - name: {{ $eventName }}
+      eventSourceName: {{ $eventSourceName }}
+      eventName: {{ $eventName }}
+      filters:
+        data:
+          - path: body.metadata.annotations.{{ $annotationPath }}
+            type: string
+            value:
+              - {{ $sidecarInjectValue | quote }}
+  triggers:
+    - template:
+        name: create-{{ $db.name }}-mongodb-monitoring-setup-job
+        k8s:
+          operation: create
+          source:
+            resource:
+{{ include "opentelemetry-database-monitoring.mongodbSetupJob" (dict "root" $root "db" $db "useName" false "useGenerateName" true) | indent 14 }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/opentelemetry-database-monitoring/templates/configmap-mongodb-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/configmap-mongodb-monitoring.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.mongodb.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mongodb-monitoring-setup
+data:
+  monitoring-setup.js: |
+{{ .Files.Get "assets/mongodb-monitoring-setup.js" | indent 4 }}
+{{- end }}

--- a/charts/opentelemetry-database-monitoring/templates/job-mongodb-monitoring-setup.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/job-mongodb-monitoring-setup.yaml
@@ -1,0 +1,7 @@
+{{- if and .Values.mongodb.enabled (not (and .Values.argoEvents.enabled .Values.argoEvents.triggerSetupJob)) }}
+{{- $root := . }}
+{{- range $db := .Values.mongodb.databases }}
+---
+{{ include "opentelemetry-database-monitoring.mongodbSetupJob" (dict "root" $root "db" $db "useName" true "useGenerateName" false "helmHook" true) }}
+{{- end }}
+{{- end }}

--- a/charts/opentelemetry-database-monitoring/templates/mongodb-dbm-sidecar.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/mongodb-dbm-sidecar.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.mongodb.enabled}}
+{{- $root := . }}
+{{- range $db := .Values.mongodb.databases }}
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: {{ index $db "sidecar-name" }}
+  annotations:
+    meta.helm.sh/release-name: {{ $root.Release.Name | quote }}
+    meta.helm.sh/release-namespace: {{ $root.Release.Namespace | quote }}
+  labels:
+    {{- include "opentelemetry-database-monitoring.labels" $root | nindent 4 }}
+    opentelemetry-database-monitoring/database: {{ $db.name }}
+spec:
+  mode: sidecar
+  image: {{ $root.Values.mongodb.image | default "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0" }}
+  env:
+    - name: K8S_NODE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: OTEL_MONITOR_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "opentelemetry-database-monitoring.mongodbMonitorSecretName" $db }}
+          key: password
+  config:
+{{ $root.Files.Get "assets/mongodb-monitoring-config.yaml" | trimPrefix "---" | trim | indent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/opentelemetry-database-monitoring/templates/secret-mongodb-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/secret-mongodb-monitoring.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.mongodb.enabled }}
+{{- $root := . }}
+{{- range $db := .Values.mongodb.databases }}
+{{- $secretName := include "opentelemetry-database-monitoring.mongodbMonitorSecretName" $db }}
+{{- $targetNamespace := include "opentelemetry-database-monitoring.databaseNamespace" (merge (dict) $db (dict "Release" $root.Release)) }}
+{{- $password := include "opentelemetry-database-monitoring.monitorPassword" (dict "root" $root "db" $db "secretName" $secretName) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    {{- include "opentelemetry-database-monitoring.labels" $root | nindent 4 }}
+    opentelemetry-database-monitoring/database: {{ $db.name }}
+type: Opaque
+data:
+  password: {{ $password | b64enc | quote }}
+{{- if ne $targetNamespace $root.Release.Namespace }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ $targetNamespace }}
+  labels:
+    {{- include "opentelemetry-database-monitoring.labels" $root | nindent 4 }}
+    opentelemetry-database-monitoring/database: {{ $db.name }}
+type: Opaque
+data:
+  password: {{ $password | b64enc | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/opentelemetry-database-monitoring/tests/mongodb_test.yaml
+++ b/charts/opentelemetry-database-monitoring/tests/mongodb_test.yaml
@@ -1,0 +1,175 @@
+---
+suite: mongodb monitoring tests
+templates:
+  - mongodb-dbm-sidecar.yaml
+  - secret-mongodb-monitoring.yaml
+  - configmap-mongodb-monitoring.yaml
+  - job-mongodb-monitoring-setup.yaml
+tests:
+  - it: should render nothing when mongodb is disabled
+    set:
+      mongodb.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create the sidecar collector with a pinned image
+    template: mongodb-dbm-sidecar.yaml
+    set:
+      mongodb.enabled: true
+    release:
+      name: "test-release"
+    asserts:
+      - isKind:
+          of: OpenTelemetryCollector
+      - equal:
+          path: metadata.name
+          value: "mongodb-dbm-sidecar"
+      - equal:
+          path: spec.mode
+          value: sidecar
+      # An untagged image resolves to :latest and lets the collector version
+      # change under the receiver configuration.
+      - matchRegex:
+          path: spec.image
+          pattern: ":[0-9]+\\.[0-9]+\\.[0-9]+$"
+
+  - it: should wire the monitor password from the mongodb secret
+    template: mongodb-dbm-sidecar.yaml
+    set:
+      mongodb.enabled: true
+    asserts:
+      - equal:
+          path: spec.env[1].name
+          value: OTEL_MONITOR_PASSWORD
+      - equal:
+          path: spec.env[1].valueFrom.secretKeyRef.name
+          value: "mongodb-mongodb-monitor-credentials"
+
+  - it: should configure the receiver with a hosts list and admin auth source
+    template: mongodb-dbm-sidecar.yaml
+    set:
+      mongodb.enabled: true
+    asserts:
+      # hosts is a list of endpoint objects for this receiver.
+      - matchRegex:
+          path: spec.config.receivers.mongodb.hosts[0].endpoint
+          pattern: ":27017$"
+      # The monitor user is created in admin, which is not the default auth database.
+      - equal:
+          path: spec.config.receivers.mongodb.auth_source
+          value: admin
+      # Each Pod's sidecar scrapes only its own mongod; secondary discovery would
+      # report every member more than once.
+      - equal:
+          path: spec.config.receivers.mongodb.direct_connection
+          value: true
+      - equal:
+          path: spec.config.receivers.mongodb.tls.insecure
+          value: true
+
+  - it: should export metrics only and disable metrics with no data on supported versions
+    template: mongodb-dbm-sidecar.yaml
+    set:
+      mongodb.enabled: true
+    asserts:
+      - contains:
+          path: spec.config.service.pipelines.metrics.receivers
+          content: mongodb
+      # The receiver's query sample support emits log records; this chart exports
+      # metrics only.
+      - notExists:
+          path: spec.config.service.pipelines.logs
+      # Only reported by servers older than 4.4 using the mmapv1 storage engine.
+      - equal:
+          path: spec.config.receivers.mongodb.metrics["mongodb.extent.count"].enabled
+          value: false
+      # Fails the scrape with "could not find key for metric" on WiredTiger.
+      - notExists:
+          path: spec.config.receivers.mongodb.metrics["mongodb.flushes.rate"]
+
+  - it: should create the monitor secret in the release namespace
+    template: secret-mongodb-monitoring.yaml
+    set:
+      mongodb.enabled: true
+    release:
+      namespace: "otel"
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: "mongodb-mongodb-monitor-credentials"
+      - equal:
+          path: metadata.namespace
+          value: "otel"
+      - exists:
+          path: data.password
+
+  - it: should replicate the secret into a cross-namespace target
+    template: secret-mongodb-monitoring.yaml
+    set:
+      mongodb.enabled: true
+      mongodb.databases:
+        - name: mongodb
+          namespace: databases
+          sidecar-name: mongodb-dbm-sidecar
+          user: root
+          pwd: otel
+          port: 27017
+          host: mongodb
+    release:
+      namespace: "otel"
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.namespace
+          value: "otel"
+        documentIndex: 0
+      - equal:
+          path: metadata.namespace
+          value: "databases"
+        documentIndex: 1
+
+  - it: should mount the setup script as javascript, not sql
+    template: configmap-mongodb-monitoring.yaml
+    set:
+      mongodb.enabled: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: "mongodb-monitoring-setup"
+      - exists:
+          path: data["monitoring-setup.js"]
+      - matchRegex:
+          path: data["monitoring-setup.js"]
+          pattern: "clusterMonitor"
+
+  - it: should create a Helm-hooked setup job when argo events is disabled
+    template: job-mongodb-monitoring-setup.yaml
+    set:
+      mongodb.enabled: true
+      argoEvents.enabled: false
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.name
+          value: "mongodb-mongodb-monitoring-setup"
+      # Without the hook annotations, an upgrade fails on the Job's immutable fields.
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: "post-install,post-upgrade"
+
+  - it: should not create a Helm setup job when argo events drives it
+    template: job-mongodb-monitoring-setup.yaml
+    set:
+      mongodb.enabled: true
+      argoEvents.enabled: true
+      argoEvents.triggerSetupJob: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/opentelemetry-database-monitoring/values.schema.json
+++ b/charts/opentelemetry-database-monitoring/values.schema.json
@@ -95,6 +95,49 @@
                 }
             }
         },
+        "mongodb": {
+            "type": "object",
+            "properties": {
+                "databases": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "host": {
+                                "type": "string"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "type": "string"
+                            },
+                            "port": {
+                                "type": "integer"
+                            },
+                            "pwd": {
+                                "type": "string"
+                            },
+                            "sidecar-name": {
+                                "type": "string"
+                            },
+                            "user": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "image": {
+                    "type": "string"
+                },
+                "setupImage": {
+                    "type": "string"
+                }
+            }
+        },
         "postgres": {
             "type": "object",
             "properties": {

--- a/charts/opentelemetry-database-monitoring/values.yaml
+++ b/charts/opentelemetry-database-monitoring/values.yaml
@@ -49,6 +49,57 @@ postgres:
       host: ""
 
 # =============================================================================
+# MONGODB
+# =============================================================================
+mongodb:
+  # -- Deploy MongoDB monitoring: the injected sidecar collector, the monitor
+  # credentials secret, the setup ConfigMap, and the setup Job.
+  # @default -- false
+  enabled: false
+  # Keep the tag. An untagged image resolves to :latest, which forces
+  # imagePullPolicy: Always and lets the collector version change under the
+  # receiver configuration in assets/mongodb-monitoring-config.yaml.
+  # -- Collector image for the injected sidecar.
+  image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0"
+  # -- Image for the setup Job. Must provide the `mongosh` client on PATH.
+  setupImage: "mongo:7"
+  # -- MongoDB instances to monitor. Each entry produces its own sidecar
+  # collector, monitor secret, and setup Job.
+  databases:
+      # -- Name for this instance. Used as the prefix of the monitor secret and
+      # setup Job names, and set as the
+      # `opentelemetry-database-monitoring/database` label on every resource.
+    - name: mongodb
+      # -- Namespace where the annotated MongoDB Pod runs. Replicates the monitor
+      # secret into that namespace and sets the expected inject annotation to
+      # `<releaseNamespace>/<sidecar-name>` when it differs from the release
+      # namespace. Empty means the release namespace.
+      # @default -- ""
+      namespace: ""
+      # -- Name of the OpenTelemetryCollector resource for this instance. This is
+      # the value the target Pod's `sidecar.opentelemetry.io/inject` annotation
+      # must carry for the operator to inject the sidecar.
+      sidecar-name: mongodb-dbm-sidecar
+      # -- Administrative user the setup Job authenticates as against the admin
+      # database. Needs the userAdmin role on admin, or root.
+      # @default -- ""
+      user: ""
+      # -- Password for the administrative user. Interpolated into the setup Job
+      # spec, so it is readable by anyone who can read Jobs in the release
+      # namespace. It is not written to a secret.
+      # @default -- ""
+      pwd: ""
+      # -- Port the setup Job connects to. The sidecar's receiver port is fixed at
+      # 27017 in assets/mongodb-monitoring-config.yaml; override that asset to
+      # change the port the collector uses.
+      port: 27017
+      # -- Host the setup Job connects to, normally the MongoDB Service name. A
+      # value containing a dot is used as-is; otherwise, when the instance runs in
+      # another namespace, it is expanded to `<host>.<namespace>.svc.cluster.local`.
+      # @default -- ""
+      host: ""
+
+# =============================================================================
 # ARGO EVENTS SUBCHART
 # =============================================================================
 # Installs the Argo Events controller. The CRDs are shipped in this chart's crds/


### PR DESCRIPTION
Stacked on #147, which carries the shared scaffolding. **Base is `dbm/base`, so this
diff shows only MongoDB.**

## What this adds

A `mongodb:` engine block: a sidecar `OpenTelemetryCollector`, a monitor credentials
secret, a setup ConfigMap and Job, an Argo Events sensor, an example with rendered
output, and a helm-unittest suite. Disabled by default. Requires MongoDB 4.4+.

## Setup differs from the SQL engines

Setup runs a **`mongosh` script, not SQL**. It creates the `otel_monitor` user in the
`admin` database with the built-in `clusterMonitor` role — the role MongoDB documents
for a least-privilege monitoring user and the one the receiver requires — and updates
the password in place on re-run so a rotated secret converges instead of failing on a
duplicate user.

There are no helper collections or views: the receiver reads the `serverStatus`,
`dbStats` and index stats commands directly. The generated password is read from
`OTEL_MONITOR_PASSWORD` in the environment rather than the command line, and the
script exits non-zero if it is unset.

## Metrics

The `mongodb` receiver runs at 30 s with 15 default-disabled metrics additionally
enabled, for **36 metrics**.

Two settings worth attention in review:

- **`hosts`** takes a list of endpoint objects, not a single `endpoint`.
- **`direct_connection: true`** makes each sidecar scrape only the `mongod` beside it.
  With discovery enabled the receiver runs `replSetGetStatus` and connects out to
  secondaries; because this chart injects one sidecar per Pod, every member already
  has its own collector, so discovery would report secondaries more than once.
  `replSetGetStatus` is also not valid on a standalone server or through `mongos`,
  where it warns on each scrape.

Five metrics are deliberately disabled, each verified to report no data on MongoDB 7
with WiredTiger:

| Metric | Reason |
|--------|--------|
| `mongodb.flushes.rate` | Fails the scrape with `could not find key for metric` |
| `mongodb.extent.count` | Enabled upstream by default, but only exists on pre-4.4 mmapv1 |
| `mongodb.lock.acquire.time`, `.wait_count`, `deadlock.count` | Need lock contention |
| `mongodb.repl_*_per_sec` | Replica set members only |

This receiver has **no top-query support** and offers query samples as log records
only, so there are no per-query metrics for MongoDB. That is a genuine gap versus the
SQL engines, not an omission here.

## Testing

- `helm lint` clean; **24 helm-unittest tests**; `make check-examples` exit 0.
- Verified against **real MongoDB 7.0.39** on collector `0.157.0`, with the collector
  sharing the database container's network namespace.
- **Verified end to end in a Kubernetes cluster**: the operator injected the sidecar
  on the pinned image, the monitor secret replicated cross-namespace, the Argo sensor
  fired on Pod ADD and its setup Job completed, and 36 MongoDB metrics arrived at a
  node-local collector.

One thing that surfaced only in-cluster: the sidecar starts scraping a few seconds
before the setup Job creates the monitor user, so it logs one auth failure per
interval until setup lands. That is inherent to Argo Events triggering setup after
Pod start, and is documented in the README's Troubleshooting section (added in #147)
with the command to tell it apart from a real failure.

## Note on Chart.yaml

Deliberately not bumped, to avoid a three-way conflict with the sibling engine PRs
and 12 files of `helm.sh/chart` label churn. Bump once when these land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
