### PR TITLE
Add Microsoft SQL Server support to opentelemetry-database-monitoring

### DIFF
--- a/charts/opentelemetry-database-monitoring/README.md
+++ b/charts/opentelemetry-database-monitoring/README.md
@@ -23,6 +23,7 @@ gets, and the metrics collected.
 |----------|-----------|-------|
 | PostgreSQL | `postgres` | [PostgreSQL](#postgresql) |
 
+| Microsoft SQL Server | `sqlserver` | [Microsoft SQL Server](#microsoft-sql-server) |
 All databases export **metrics only**. See [Query collection](#query-collection)
 for how per-query data is collected and why.
 
@@ -306,6 +307,97 @@ postgres:
 Annotate the PostgreSQL Pod with
 `sidecar.opentelemetry.io/inject: postgres-dbm-sidecar`.
 
+## Microsoft SQL Server
+
+Enable with `sqlserver.enabled=true`.
+
+### Requirements
+
+- SQL Server 2016 or later. The top-query view reads `total_grant_kb`, which was
+  added in 2016.
+- The admin credentials in `sqlserver.databases[*].user` / `pwd` must be `sysadmin`,
+  or hold `CREATE LOGIN` plus `GRANT OPTION` on the server-state permissions the
+  setup SQL grants.
+
+### Setup
+
+The setup Job runs `assets/sqlserver-monitoring-setup.sql` with `sqlcmd`,
+idempotently. It:
+
+1. Creates the `otel_monitor` login.
+2. Grants permission to read the server-state DMVs. **SQL Server 2022 (major version
+   16) introduced `VIEW SERVER PERFORMANCE STATE`** as the granular replacement for
+   `VIEW SERVER STATE`. The new name does not exist on earlier versions, so the
+   script selects the grant from the server's major version.
+3. Grants `VIEW ANY DATABASE`, plus `CONNECT ANY DATABASE` and `VIEW ANY DEFINITION`
+   which the per-index physical stats metrics (`sqlserver.index.*`) require.
+4. Creates the `otel` database and the views below, and grants the monitor login
+   `SELECT` on them.
+5. Rotates the `otel_monitor` password to match the Secret.
+
+| View | Description |
+|------|-------------|
+| `dbo.sqlserver_top_queries` | Top 50 cached plans by total elapsed time, from `sys.dm_exec_query_stats`, with calls, CPU and elapsed time, logical and physical reads, logical writes, and rows returned. |
+| `dbo.sqlserver_blocking` | Sessions currently blocked on another session, counted per database and wait type, with the longest wait. |
+
+`sqlserver_top_queries` resolves the database from `sys.dm_exec_plan_attributes`
+rather than from `sys.dm_exec_sql_text`, which reports a NULL `dbid` for ad-hoc
+batches and would leave `db.namespace` empty for them. It excludes system databases,
+because the Collector's own DMV queries execute in the `master` context, and bounds
+the window on `last_execution_time`, because `sys.dm_exec_query_stats` accumulates
+for as long as a plan stays cached.
+
+### Metrics
+
+`server`, `port`, `username`, and `password` must all be set together to enable the
+receiver's **direct-connection mode**, which reads the dynamic management views.
+This chart always sets all four. Without them the receiver collects Windows
+performance counters instead, which are only available when the Collector itself
+runs on Windows.
+
+| Receiver | Interval | Metrics |
+|----------|----------|---------|
+| `sqlserver` | 30 s | 78 metrics — the 71 DMV-backed optional metrics enabled by this chart (database I/O, latency and operations, tempdb space and version store, index fragmentation, size and page counts, locks, latches, memory areas and grants, OS waits, page lookups and allocation, plan and recompilation rates, resource pool disk throttling, tasks and workers, blocked processes, deadlock and error rates, cursors, logins and logouts) plus the 7 default-enabled ones that report data in this mode |
+| `sqlquery/sqlserver_top_queries` | 60 s | `sqlserver.query.calls`, `.cpu_time`, `.elapsed_time`, `.logical_reads`, `.physical_reads`, `.logical_writes`, `.rows` — attributed by `db.namespace`, `db.query.hash`, `db.query.text` |
+| `sqlquery/sqlserver_blocking` | 30 s | `sqlserver.blocking.session.count`, `sqlserver.blocking.wait_time.max` — attributed by `db.namespace`, `db.mssql.wait.type` |
+
+**13 of the receiver's 20 default-enabled metrics report no data in
+direct-connection mode**, because they are Windows performance counters:
+`lock.wait_time.avg`, `page.checkpoint.flush.rate`, `page.lazy_write.rate`,
+`page.operation.rate`, `page.split.rate`, `transaction.rate`,
+`transaction.write.rate`, and the six `transaction_log.*` metrics. They are left at
+their upstream defaults rather than force-disabled, so a Windows deployment still
+collects them. `sqlserver.page.compression.rate` is the one optional metric this
+chart leaves disabled, having reported no data on SQL Server 2022 on Linux.
+
+### TLS
+
+This receiver exposes **no TLS settings**. Encryption is whatever the underlying
+`go-mssqldb` driver negotiates by default, and the only way to control it is the
+`datasource` connection string, which cannot be combined with
+`server`/`port`/`username`/`password`. To reach a SQL Server outside the Pod,
+override the asset config and replace those four settings with a single `datasource`
+that sets the encryption parameters explicitly.
+
+### Example
+
+See `examples/sqlserver-single-db/`.
+
+```yaml
+sqlserver:
+  enabled: true
+  databases:
+    - name: sqlserver
+      sidecar-name: sqlserver-dbm-sidecar
+      user: sa
+      pwd: otel
+      port: 1433
+      host: sqlserver
+```
+
+Annotate the SQL Server Pod with
+`sidecar.opentelemetry.io/inject: sqlserver-dbm-sidecar`.
+
 ## Query collection
 
 Several database receivers can report per-query data through a native
@@ -319,6 +411,7 @@ against a view or function installed by the setup script.
 |----------|------------------|-----------|
 | PostgreSQL | yes | `sqlquery` over `otel.pg_top_queries()` |
 
+| Microsoft SQL Server | yes | `sqlquery` over `otel.dbo.sqlserver_top_queries` |
 The native blocks are functional, so this is a choice about signal type rather than
 a workaround. To use the native events instead, enable them on the receiver and add
 a `logs` pipeline by overriding the engine's asset config. Do not run both: they
@@ -452,3 +545,14 @@ stuck in that loop means the `host` and `port` in values do not reach the databa
 | postgres.databases[0].user | string | "" | Administrative user the setup Job connects as. Needs to be a superuser, or a role with CREATEROLE and CREATEDB. |
 | postgres.enabled | bool | false | Deploy PostgreSQL monitoring: the injected sidecar collector, the monitor credentials secret, the setup ConfigMap, and the setup Job. |
 | postgres.image | string | `"ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0"` | Collector image for the injected sidecar. |
+| sqlserver.databases | list | `[{"host":"","name":"sqlserver","namespace":"","port":1433,"pwd":"","sidecar-name":"sqlserver-dbm-sidecar","user":""}]` | SQL Server instances to monitor. Each entry produces its own sidecar collector, monitor secret, and setup Job. |
+| sqlserver.databases[0] | object | `{"host":"","name":"sqlserver","namespace":"","port":1433,"pwd":"","sidecar-name":"sqlserver-dbm-sidecar","user":""}` | Name for this instance. Used as the prefix of the monitor secret and setup Job names, and set as the `opentelemetry-database-monitoring/database` label on every resource. |
+| sqlserver.databases[0].host | string | "" | Host the setup Job connects to, normally the SQL Server Service name. A value containing a dot is used as-is; otherwise, when the instance runs in another namespace, it is expanded to `<host>.<namespace>.svc.cluster.local`. |
+| sqlserver.databases[0].namespace | string | "" | Namespace where the annotated SQL Server Pod runs. Replicates the monitor secret into that namespace and sets the expected inject annotation to `<releaseNamespace>/<sidecar-name>` when it differs from the release namespace. Empty means the release namespace. |
+| sqlserver.databases[0].port | int | `1433` | Port the setup Job connects to. The sidecar's receiver port is fixed at 1433 in assets/sqlserver-monitoring-config.yaml; override that asset to change the port the collector uses. |
+| sqlserver.databases[0].pwd | string | "" | Password for the administrative login. Interpolated into the setup Job spec, so it is readable by anyone who can read Jobs in the release namespace. It is not written to a secret. |
+| sqlserver.databases[0].sidecar-name | string | `"sqlserver-dbm-sidecar"` | Name of the OpenTelemetryCollector resource for this instance. This is the value the target Pod's `sidecar.opentelemetry.io/inject` annotation must carry for the operator to inject the sidecar. |
+| sqlserver.databases[0].user | string | "" | Administrative login the setup Job connects as. Needs sysadmin, or CREATE LOGIN plus GRANT OPTION on the server-state permissions the setup SQL grants. |
+| sqlserver.enabled | bool | false | Deploy Microsoft SQL Server monitoring: the injected sidecar collector, the monitor credentials secret, the setup ConfigMap, and the setup Job. |
+| sqlserver.image | string | `"ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0"` | Collector image for the injected sidecar. |
+| sqlserver.setupImage | string | `"mcr.microsoft.com/mssql-tools:latest"` | Image for the setup Job. Must provide `sqlcmd` at /opt/mssql-tools/bin/sqlcmd. |

--- a/charts/opentelemetry-database-monitoring/README.md.gotmpl
+++ b/charts/opentelemetry-database-monitoring/README.md.gotmpl
@@ -27,6 +27,7 @@ gets, and the metrics collected.
 |----------|-----------|-------|
 | PostgreSQL | `postgres` | [PostgreSQL](#postgresql) |
 
+| Microsoft SQL Server | `sqlserver` | [Microsoft SQL Server](#microsoft-sql-server) |
 All databases export **metrics only**. See [Query collection](#query-collection)
 for how per-query data is collected and why.
 
@@ -310,6 +311,97 @@ postgres:
 Annotate the PostgreSQL Pod with
 `sidecar.opentelemetry.io/inject: postgres-dbm-sidecar`.
 
+## Microsoft SQL Server
+
+Enable with `sqlserver.enabled=true`.
+
+### Requirements
+
+- SQL Server 2016 or later. The top-query view reads `total_grant_kb`, which was
+  added in 2016.
+- The admin credentials in `sqlserver.databases[*].user` / `pwd` must be `sysadmin`,
+  or hold `CREATE LOGIN` plus `GRANT OPTION` on the server-state permissions the
+  setup SQL grants.
+
+### Setup
+
+The setup Job runs `assets/sqlserver-monitoring-setup.sql` with `sqlcmd`,
+idempotently. It:
+
+1. Creates the `otel_monitor` login.
+2. Grants permission to read the server-state DMVs. **SQL Server 2022 (major version
+   16) introduced `VIEW SERVER PERFORMANCE STATE`** as the granular replacement for
+   `VIEW SERVER STATE`. The new name does not exist on earlier versions, so the
+   script selects the grant from the server's major version.
+3. Grants `VIEW ANY DATABASE`, plus `CONNECT ANY DATABASE` and `VIEW ANY DEFINITION`
+   which the per-index physical stats metrics (`sqlserver.index.*`) require.
+4. Creates the `otel` database and the views below, and grants the monitor login
+   `SELECT` on them.
+5. Rotates the `otel_monitor` password to match the Secret.
+
+| View | Description |
+|------|-------------|
+| `dbo.sqlserver_top_queries` | Top 50 cached plans by total elapsed time, from `sys.dm_exec_query_stats`, with calls, CPU and elapsed time, logical and physical reads, logical writes, and rows returned. |
+| `dbo.sqlserver_blocking` | Sessions currently blocked on another session, counted per database and wait type, with the longest wait. |
+
+`sqlserver_top_queries` resolves the database from `sys.dm_exec_plan_attributes`
+rather than from `sys.dm_exec_sql_text`, which reports a NULL `dbid` for ad-hoc
+batches and would leave `db.namespace` empty for them. It excludes system databases,
+because the Collector's own DMV queries execute in the `master` context, and bounds
+the window on `last_execution_time`, because `sys.dm_exec_query_stats` accumulates
+for as long as a plan stays cached.
+
+### Metrics
+
+`server`, `port`, `username`, and `password` must all be set together to enable the
+receiver's **direct-connection mode**, which reads the dynamic management views.
+This chart always sets all four. Without them the receiver collects Windows
+performance counters instead, which are only available when the Collector itself
+runs on Windows.
+
+| Receiver | Interval | Metrics |
+|----------|----------|---------|
+| `sqlserver` | 30 s | 78 metrics — the 71 DMV-backed optional metrics enabled by this chart (database I/O, latency and operations, tempdb space and version store, index fragmentation, size and page counts, locks, latches, memory areas and grants, OS waits, page lookups and allocation, plan and recompilation rates, resource pool disk throttling, tasks and workers, blocked processes, deadlock and error rates, cursors, logins and logouts) plus the 7 default-enabled ones that report data in this mode |
+| `sqlquery/sqlserver_top_queries` | 60 s | `sqlserver.query.calls`, `.cpu_time`, `.elapsed_time`, `.logical_reads`, `.physical_reads`, `.logical_writes`, `.rows` — attributed by `db.namespace`, `db.query.hash`, `db.query.text` |
+| `sqlquery/sqlserver_blocking` | 30 s | `sqlserver.blocking.session.count`, `sqlserver.blocking.wait_time.max` — attributed by `db.namespace`, `db.mssql.wait.type` |
+
+**13 of the receiver's 20 default-enabled metrics report no data in
+direct-connection mode**, because they are Windows performance counters:
+`lock.wait_time.avg`, `page.checkpoint.flush.rate`, `page.lazy_write.rate`,
+`page.operation.rate`, `page.split.rate`, `transaction.rate`,
+`transaction.write.rate`, and the six `transaction_log.*` metrics. They are left at
+their upstream defaults rather than force-disabled, so a Windows deployment still
+collects them. `sqlserver.page.compression.rate` is the one optional metric this
+chart leaves disabled, having reported no data on SQL Server 2022 on Linux.
+
+### TLS
+
+This receiver exposes **no TLS settings**. Encryption is whatever the underlying
+`go-mssqldb` driver negotiates by default, and the only way to control it is the
+`datasource` connection string, which cannot be combined with
+`server`/`port`/`username`/`password`. To reach a SQL Server outside the Pod,
+override the asset config and replace those four settings with a single `datasource`
+that sets the encryption parameters explicitly.
+
+### Example
+
+See `examples/sqlserver-single-db/`.
+
+```yaml
+sqlserver:
+  enabled: true
+  databases:
+    - name: sqlserver
+      sidecar-name: sqlserver-dbm-sidecar
+      user: sa
+      pwd: otel
+      port: 1433
+      host: sqlserver
+```
+
+Annotate the SQL Server Pod with
+`sidecar.opentelemetry.io/inject: sqlserver-dbm-sidecar`.
+
 ## Query collection
 
 Several database receivers can report per-query data through a native
@@ -323,6 +415,7 @@ against a view or function installed by the setup script.
 |----------|------------------|-----------|
 | PostgreSQL | yes | `sqlquery` over `otel.pg_top_queries()` |
 
+| Microsoft SQL Server | yes | `sqlquery` over `otel.dbo.sqlserver_top_queries` |
 The native blocks are functional, so this is a choice about signal type rather than
 a workaround. To use the native events instead, enable them on the receiver and add
 a `logs` pipeline by overriding the engine's asset config. Do not run both: they

--- a/charts/opentelemetry-database-monitoring/assets/sqlserver-monitoring-config.yaml
+++ b/charts/opentelemetry-database-monitoring/assets/sqlserver-monitoring-config.yaml
@@ -1,0 +1,294 @@
+receivers:
+  # The collector runs as a sidecar inside the SQL Server Pod and reaches the
+  # server over the Pod's own network namespace, so this traffic does not leave
+  # the Pod.
+  #
+  # This receiver exposes no TLS settings. Encryption is whatever the underlying
+  # go-mssqldb driver negotiates by default, and the only way to control it is
+  # the `datasource` connection string, which cannot be combined with the
+  # server/port/username/password settings used below. To reach a SQL Server
+  # outside the Pod, replace those four settings with a single `datasource` that
+  # sets the encryption parameters explicitly.
+  sqlserver:
+    server: ${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME}
+    port: 1433
+    username: otel_monitor
+    password: ${env:OTEL_MONITOR_PASSWORD}
+    collection_interval: 30s
+    # server, port, username and password must all be set together to enable the
+    # direct-connection mode, which reads the server's dynamic management views.
+    # Without all four the receiver collects Windows performance counters
+    # instead, which are only available when the collector runs on Windows.
+    #
+    # 13 of the receiver's 20 default-enabled metrics are Windows performance
+    # counters and report no data in this mode: lock.wait_time.avg,
+    # page.checkpoint.flush.rate, page.lazy_write.rate, page.operation.rate,
+    # page.split.rate, transaction.rate, transaction.write.rate, and the six
+    # transaction_log.* metrics. They are left at their upstream defaults so a
+    # Windows deployment still collects them.
+    #
+    # The metrics enabled below are the DMV-backed ones, each verified to report
+    # data on SQL Server 2022 running on Linux.
+    metrics:
+      sqlserver.access.scan.rate:
+        enabled: true
+      sqlserver.attention.rate:
+        enabled: true
+      sqlserver.clr.execution.time:
+        enabled: true
+      sqlserver.computer.uptime:
+        enabled: true
+      sqlserver.connection.reset.rate:
+        enabled: true
+      sqlserver.cpu.count:
+        enabled: true
+      sqlserver.cursor.count:
+        enabled: true
+      sqlserver.cursor.memory.usage:
+        enabled: true
+      sqlserver.cursor.plan.count:
+        enabled: true
+      sqlserver.cursor.request.rate:
+        enabled: true
+      sqlserver.database.backup_or_restore.rate:
+        enabled: true
+      sqlserver.database.count:
+        enabled: true
+      sqlserver.database.execution.errors:
+        enabled: true
+      sqlserver.database.full_scan.rate:
+        enabled: true
+      sqlserver.database.io:
+        enabled: true
+      sqlserver.database.latency:
+        enabled: true
+      sqlserver.database.operations:
+        enabled: true
+      sqlserver.database.tempdb.space:
+        enabled: true
+      sqlserver.database.tempdb.version_store.size:
+        enabled: true
+      sqlserver.deadlock.rate:
+        enabled: true
+      sqlserver.error.rate:
+        enabled: true
+      sqlserver.extent.operation.rate:
+        enabled: true
+      sqlserver.ghost_record.skipped.rate:
+        enabled: true
+      sqlserver.index.fragmentation:
+        enabled: true
+      sqlserver.index.page.count:
+        enabled: true
+      sqlserver.index.page.utilization:
+        enabled: true
+      sqlserver.index.record.count:
+        enabled: true
+      sqlserver.index.search.rate:
+        enabled: true
+      sqlserver.index.size:
+        enabled: true
+      sqlserver.latch.superlatch.count:
+        enabled: true
+      sqlserver.latch.superlatch.transition.rate:
+        enabled: true
+      sqlserver.latch.wait.rate:
+        enabled: true
+      sqlserver.latch.wait_time.avg:
+        enabled: true
+      sqlserver.latch.wait_time.total:
+        enabled: true
+      sqlserver.lock.block.count:
+        enabled: true
+      sqlserver.lock.escalation.rate:
+        enabled: true
+      sqlserver.lock.memory:
+        enabled: true
+      sqlserver.lock.request.rate:
+        enabled: true
+      sqlserver.lock.timeout.rate:
+        enabled: true
+      sqlserver.lock.wait.count:
+        enabled: true
+      sqlserver.lock.wait_time.total:
+        enabled: true
+      sqlserver.login.rate:
+        enabled: true
+      sqlserver.logout.rate:
+        enabled: true
+      sqlserver.memory.area:
+        enabled: true
+      sqlserver.memory.cache.object.count:
+        enabled: true
+      sqlserver.memory.grants.pending.count:
+        enabled: true
+      sqlserver.memory.page.count:
+        enabled: true
+      sqlserver.memory.usage:
+        enabled: true
+      sqlserver.os.wait.duration:
+        enabled: true
+      sqlserver.page.allocation.rate:
+        enabled: true
+      sqlserver.page.buffer_cache.free_list.stalls.rate:
+        enabled: true
+      sqlserver.page.lookup.rate:
+        enabled: true
+      sqlserver.page.read_ahead.rate:
+        enabled: true
+      sqlserver.parameterization.rate:
+        enabled: true
+      sqlserver.plan.execution.rate:
+        enabled: true
+      sqlserver.processes.blocked:
+        enabled: true
+      sqlserver.recompilation.ratio:
+        enabled: true
+      sqlserver.replica.data.rate:
+        enabled: true
+      sqlserver.resource_pool.disk.operations:
+        enabled: true
+      sqlserver.resource_pool.disk.throttled.read.rate:
+        enabled: true
+      sqlserver.resource_pool.disk.throttled.write.rate:
+        enabled: true
+      sqlserver.scan_point.revalidation.rate:
+        enabled: true
+      sqlserver.stored_procedure.invocation.rate:
+        enabled: true
+      sqlserver.table.count:
+        enabled: true
+      sqlserver.task.count:
+        enabled: true
+      sqlserver.task.rate:
+        enabled: true
+      sqlserver.transaction.delay:
+        enabled: true
+      sqlserver.transaction.mirror_write.rate:
+        enabled: true
+      sqlserver.worker.request.count:
+        enabled: true
+      sqlserver.worker.thread.count:
+        enabled: true
+      sqlserver.worktable.cache.hit_ratio:
+        enabled: true
+  # Top queries are collected as metrics through sqlquery. The receiver's native
+  # top_query_collection block reports the same data as log records through the
+  # db.server.top_query event, at Development stability; this chart exports
+  # metrics only. See the chart README.
+  sqlquery/sqlserver_top_queries:
+    collection_interval: 60s
+    driver: sqlserver
+    datasource: server=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME};user id=otel_monitor;password=${env:OTEL_MONITOR_PASSWORD};port=1433;database=otel
+    queries:
+      - sql: SELECT * FROM dbo.sqlserver_top_queries
+        metrics:
+          - attribute_columns:
+              - db.namespace
+              - db.query.hash
+              - db.query.text
+            data_type: gauge
+            metric_name: sqlserver.query.calls
+            unit: "{query}"
+            value_column: calls
+            value_type: int
+          - attribute_columns:
+              - db.namespace
+              - db.query.hash
+              - db.query.text
+            data_type: gauge
+            metric_name: sqlserver.query.cpu_time
+            unit: ms
+            value_column: total_cpu_time_ms
+            value_type: double
+          - attribute_columns:
+              - db.namespace
+              - db.query.hash
+              - db.query.text
+            data_type: gauge
+            metric_name: sqlserver.query.elapsed_time
+            unit: ms
+            value_column: total_elapsed_time_ms
+            value_type: double
+          - attribute_columns:
+              - db.namespace
+              - db.query.hash
+              - db.query.text
+            data_type: gauge
+            metric_name: sqlserver.query.logical_reads
+            unit: "{page}"
+            value_column: logical_reads
+            value_type: int
+          - attribute_columns:
+              - db.namespace
+              - db.query.hash
+              - db.query.text
+            data_type: gauge
+            metric_name: sqlserver.query.physical_reads
+            unit: "{page}"
+            value_column: physical_reads
+            value_type: int
+          - attribute_columns:
+              - db.namespace
+              - db.query.hash
+              - db.query.text
+            data_type: gauge
+            metric_name: sqlserver.query.logical_writes
+            unit: "{page}"
+            value_column: logical_writes
+            value_type: int
+          - attribute_columns:
+              - db.namespace
+              - db.query.hash
+              - db.query.text
+            data_type: gauge
+            metric_name: sqlserver.query.rows
+            unit: "{row}"
+            value_column: rows_returned
+            value_type: int
+  sqlquery/sqlserver_blocking:
+    collection_interval: 30s
+    driver: sqlserver
+    datasource: server=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME};user id=otel_monitor;password=${env:OTEL_MONITOR_PASSWORD};port=1433;database=otel
+    queries:
+      - sql: SELECT * FROM dbo.sqlserver_blocking
+        metrics:
+          - attribute_columns:
+              - db.namespace
+              - db.mssql.wait.type
+            data_type: gauge
+            metric_name: sqlserver.blocking.session.count
+            unit: "{session}"
+            value_column: blocked_session_count
+            value_type: int
+          - attribute_columns:
+              - db.namespace
+              - db.mssql.wait.type
+            data_type: gauge
+            metric_name: sqlserver.blocking.wait_time.max
+            unit: ms
+            value_column: max_wait_time_ms
+            value_type: double
+processors:
+  batch:
+    send_batch_max_size: 5000
+    send_batch_size: 5000
+exporters:
+  # otlp_grpc is the canonical exporter type. The shorter `otlp` spelling is a
+  # deprecated alias that logs a warning on every collector startup.
+  otlp_grpc:
+    compression: gzip
+    endpoint: ${env:K8S_NODE_IP}:4317
+    tls:
+      insecure: true
+service:
+  pipelines:
+    metrics:
+      exporters:
+        - otlp_grpc
+      processors:
+        - batch
+      receivers:
+        - sqlserver
+        - sqlquery/sqlserver_top_queries
+        - sqlquery/sqlserver_blocking

--- a/charts/opentelemetry-database-monitoring/assets/sqlserver-monitoring-setup.sql
+++ b/charts/opentelemetry-database-monitoring/assets/sqlserver-monitoring-setup.sql
@@ -1,0 +1,114 @@
+-- Microsoft SQL Server monitoring setup for OpenTelemetry
+-- Run as a login with sysadmin (or CREATE LOGIN + GRANT OPTION on the grants below).
+-- Safe to re-run (all statements are idempotent).
+--
+-- The password below is a placeholder: the setup Job rewrites it with the
+-- generated value from the monitor secret immediately after running this script,
+-- so the literal never survives setup. It still has to satisfy the server's
+-- password policy for CREATE LOGIN to succeed.
+
+-- ---------------------------------------------------------------------------
+-- 1. Monitoring login
+-- ---------------------------------------------------------------------------
+
+IF NOT EXISTS (SELECT 1 FROM sys.server_principals WHERE name = 'otel_monitor')
+    CREATE LOGIN otel_monitor WITH PASSWORD = 'Pl4ceholder!Rotated', CHECK_POLICY = ON;
+GO
+
+-- Permission to read the server-state DMVs the receiver scrapes.
+--
+-- SQL Server 2022 (major version 16) introduced VIEW SERVER PERFORMANCE STATE as
+-- the granular replacement for VIEW SERVER STATE. The new name does not exist on
+-- earlier versions, so the grant is selected from the server's major version.
+DECLARE @major int = CONVERT(int, SERVERPROPERTY('ProductMajorVersion'));
+IF @major >= 16
+    EXEC('GRANT VIEW SERVER PERFORMANCE STATE TO otel_monitor');
+ELSE
+    EXEC('GRANT VIEW SERVER STATE TO otel_monitor');
+GO
+
+-- Required by the receiver to enumerate databases.
+GRANT VIEW ANY DATABASE TO otel_monitor;
+GO
+
+-- Required only for the per-index physical stats metrics (sqlserver.index.*):
+-- the receiver enters each user database to read them.
+GRANT CONNECT ANY DATABASE TO otel_monitor;
+GRANT VIEW ANY DEFINITION TO otel_monitor;
+GO
+
+-- ---------------------------------------------------------------------------
+-- 2. Monitoring database
+-- ---------------------------------------------------------------------------
+
+IF DB_ID('otel') IS NULL CREATE DATABASE otel;
+GO
+
+USE otel;
+GO
+
+-- ---------------------------------------------------------------------------
+-- 3. Monitoring views
+--
+-- Attribute columns use OTel semconv names where defined:
+--   db.namespace     → database name  (stable semconv)
+--   db.query.text    → statement text (stable semconv)
+--   db.query.hash    → query_hash     (experimental)
+-- ---------------------------------------------------------------------------
+
+-- Top queries by total elapsed time, from the plan cache.
+--
+-- Three details in this query the metric depends on:
+--   * The database is resolved from sys.dm_exec_plan_attributes rather than from
+--     sys.dm_exec_sql_text, which reports a NULL dbid for ad-hoc batches and
+--     would leave db.namespace empty for them.
+--   * System databases are excluded. The collector's own DMV queries execute in
+--     the master context and would otherwise occupy the top-N.
+--   * last_execution_time bounds the window to recent activity.
+--     sys.dm_exec_query_stats accumulates for as long as a plan stays cached, so
+--     an unbounded query reports the highest all-time totals on every scrape and
+--     stops reflecting current load. 300s covers the 60s collection interval.
+CREATE OR ALTER VIEW dbo.sqlserver_top_queries AS
+SELECT TOP 50
+    DB_NAME(CONVERT(int, pa.value))          AS [db.namespace],
+    CONVERT(varchar(64), qs.query_hash, 1)   AS [db.query.hash],
+    LEFT(COALESCE(t.text, ''), 1024)         AS [db.query.text],
+    qs.execution_count                       AS calls,
+    qs.total_worker_time  / 1000.0           AS total_cpu_time_ms,
+    qs.total_elapsed_time / 1000.0           AS total_elapsed_time_ms,
+    qs.total_logical_reads                   AS logical_reads,
+    qs.total_physical_reads                  AS physical_reads,
+    qs.total_logical_writes                  AS logical_writes,
+    qs.total_rows                            AS rows_returned
+FROM sys.dm_exec_query_stats qs
+CROSS APPLY sys.dm_exec_sql_text(qs.sql_handle) t
+CROSS APPLY sys.dm_exec_plan_attributes(qs.plan_handle) pa
+WHERE pa.attribute = 'dbid'
+  AND DB_NAME(CONVERT(int, pa.value)) IS NOT NULL
+  AND DB_NAME(CONVERT(int, pa.value)) NOT IN ('master', 'tempdb', 'model', 'msdb', 'otel')
+  AND qs.last_execution_time > DATEADD(second, -300, GETDATE())
+ORDER BY qs.total_elapsed_time DESC;
+GO
+
+-- Sessions currently blocked on another session, with the blocking chain.
+CREATE OR ALTER VIEW dbo.sqlserver_blocking AS
+SELECT
+    COALESCE(DB_NAME(r.database_id), '')     AS [db.namespace],
+    COALESCE(r.wait_type, '')                AS [db.mssql.wait.type],
+    COUNT(*)                                 AS blocked_session_count,
+    COALESCE(MAX(r.wait_time), 0) / 1000.0   AS max_wait_time_ms
+FROM sys.dm_exec_requests r
+WHERE r.blocking_session_id <> 0
+GROUP BY DB_NAME(r.database_id), r.wait_type;
+GO
+
+-- ---------------------------------------------------------------------------
+-- 4. Grant the monitor login read access to the views
+-- ---------------------------------------------------------------------------
+
+IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = 'otel_monitor')
+    CREATE USER otel_monitor FOR LOGIN otel_monitor;
+GO
+
+GRANT SELECT ON SCHEMA::dbo TO otel_monitor;
+GO

--- a/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/argo-eventbus.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/argo-eventbus.yaml
@@ -1,0 +1,17 @@
+---
+# Source: opentelemetry-database-monitoring/templates/argo-eventbus.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: EventBus
+metadata:
+  name: default
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  nats:
+    native:
+      replicas: 1
+      auth: none

--- a/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/argo-events-rbac.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/argo-events-rbac.yaml
@@ -1,0 +1,97 @@
+---
+# Source: opentelemetry-database-monitoring/templates/argo-events-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-opentelemetry-database-monitoring-argo-eventsource
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: opentelemetry-database-monitoring/templates/argo-events-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-opentelemetry-database-monitoring-argo-sensor
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: opentelemetry-database-monitoring/templates/argo-events-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: example-opentelemetry-database-monitoring-argo-eventsource
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+# Source: opentelemetry-database-monitoring/templates/argo-events-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: example-opentelemetry-database-monitoring-argo-sensor
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create"]
+---
+# Source: opentelemetry-database-monitoring/templates/argo-events-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: example-opentelemetry-database-monitoring-argo-eventsource
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+subjects:
+  - kind: ServiceAccount
+    name: example-opentelemetry-database-monitoring-argo-eventsource
+    namespace: default
+roleRef:
+  kind: Role
+  name: example-opentelemetry-database-monitoring-argo-eventsource
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: opentelemetry-database-monitoring/templates/argo-events-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: example-opentelemetry-database-monitoring-argo-sensor
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+subjects:
+  - kind: ServiceAccount
+    name: example-opentelemetry-database-monitoring-argo-sensor
+roleRef:
+  kind: Role
+  name: example-opentelemetry-database-monitoring-argo-sensor
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/argo-events/argo-events-controller/config.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/argo-events/argo-events-controller/config.yaml
@@ -1,0 +1,86 @@
+---
+# Source: opentelemetry-database-monitoring/charts/argo-events/templates/argo-events-controller/config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-argo-events-controller-manager
+  namespace: "default"
+  labels:
+    helm.sh/chart: argo-events-2.4.22
+    app.kubernetes.io/name: argo-events-controller-manager
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-events
+data:
+  controller-config.yaml: |
+    eventBus:
+      nats:
+        versions:
+        - version: latest
+          natsStreamingImage: nats-streaming:latest
+          metricsExporterImage: natsio/prometheus-nats-exporter:latest
+        - version: 0.22.1
+          natsStreamingImage: nats-streaming:0.22.1
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.8.0
+      jetstream:
+        # Default JetStream settings, could be overridden by EventBus JetStream specs
+        settings: |
+          # https://docs.nats.io/running-a-nats-service/configuration#jetstream
+          # Only configure "max_memory_store" or "max_file_store", do not set "store_dir" as it has been hardcoded.
+          max_memory_store: -1
+          max_file_store: -1
+        # The default properties of the streams to be created in this JetStream service
+        streamConfig: |
+          maxMsgs: 1e+06
+          maxAge: 72h
+          maxBytes: 1GB
+          replicas: 3
+          duplicates: 300s
+          retention: 0
+          discard: 0
+        versions:
+        - version: latest
+          natsImage: nats:2.10.10
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
+          configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+          startCommand: /nats-server
+        - version: 2.8.1
+          natsImage: nats:2.8.1
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+        - version: 2.8.1-alpine
+          natsImage: nats:2.8.1-alpine
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: nats-server
+        - version: 2.8.2
+          natsImage: nats:2.8.2
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+        - version: 2.8.2-alpine
+          natsImage: nats:2.8.2-alpine
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: nats-server
+        - version: 2.9.1
+          natsImage: nats:2.9.1
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+        - version: 2.9.12
+          natsImage: nats:2.9.12
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+        - version: 2.9.16
+          natsImage: nats:2.9.16
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.9.1
+          configReloaderImage: natsio/nats-server-config-reloader:0.7.0
+          startCommand: /nats-server
+        - version: 2.10.10
+          natsImage: nats:2.10.10
+          metricsExporterImage: natsio/prometheus-nats-exporter:0.14.0
+          configReloaderImage: natsio/nats-server-config-reloader:0.14.0
+          startCommand: /nats-server

--- a/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/argo-events/argo-events-controller/deployment.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/argo-events/argo-events-controller/deployment.yaml
@@ -1,0 +1,84 @@
+---
+# Source: opentelemetry-database-monitoring/charts/argo-events/templates/argo-events-controller/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-argo-events-controller-manager
+  namespace: "default"
+  labels:
+    helm.sh/chart: argo-events-2.4.22
+    app.kubernetes.io/name: argo-events-controller-manager
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-events
+    app.kubernetes.io/version: "v1.9.10"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argo-events-controller-manager
+      app.kubernetes.io/instance: example
+  revisionHistoryLimit: 5
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: e582d4d24cbef623004e1fa804eb237a2c123cfb72fb4fa0424a6d46d28bff50
+      labels:
+        helm.sh/chart: argo-events-2.4.22
+        app.kubernetes.io/name: argo-events-controller-manager
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/component: controller-manager
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: argo-events
+        app.kubernetes.io/version: "v1.9.10"
+    spec:
+      containers:
+      - name: controller-manager
+        image: quay.io/argoproj/argo-events:v1.9.10
+        imagePullPolicy: IfNotPresent
+        args:
+        - controller
+        - --leader-election=false
+        env:
+        - name: ARGO_EVENTS_IMAGE
+          value: quay.io/argoproj/argo-events:v1.9.10
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - name: config
+          mountPath: /etc/argo-events
+        ports:
+        - name: metrics
+          containerPort: 7777
+          protocol: TCP
+        - name: probe
+          containerPort: 8081
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            port: probe
+            path: /healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            port: probe
+            path: /readyz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 3
+      serviceAccountName: example-argo-events-controller-manager
+      volumes:
+      - name: config
+        configMap:
+          name: example-argo-events-controller-manager

--- a/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/argo-events/argo-events-controller/rbac.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/argo-events/argo-events-controller/rbac.yaml
@@ -1,0 +1,115 @@
+---
+# Source: opentelemetry-database-monitoring/charts/argo-events/templates/argo-events-controller/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: example-argo-events-controller-manager
+  labels:
+    helm.sh/chart: argo-events-2.4.22
+    app.kubernetes.io/name: argo-events-controller-manager
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-events
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - sensors
+  - sensors/finalizers
+  - sensors/status
+  - eventsources
+  - eventsources/finalizers
+  - eventsources/status
+  - eventbus
+  - eventbus/finalizers
+  - eventbus/status
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/exec
+  - configmaps
+  - services
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+---
+# Source: opentelemetry-database-monitoring/charts/argo-events/templates/argo-events-controller/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: example-argo-events-controller-manager
+  labels:
+    helm.sh/chart: argo-events-2.4.22
+    app.kubernetes.io/name: argo-events-controller-manager
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-events
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: example-argo-events-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: example-argo-events-controller-manager
+  namespace: "default"

--- a/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/argo-events/argo-events-controller/serviceaccount.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/argo-events/argo-events-controller/serviceaccount.yaml
@@ -1,0 +1,15 @@
+---
+# Source: opentelemetry-database-monitoring/charts/argo-events/templates/argo-events-controller/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: example-argo-events-controller-manager
+  namespace: "default"
+  labels:
+    helm.sh/chart: argo-events-2.4.22
+    app.kubernetes.io/name: argo-events-controller-manager
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: controller-manager
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-events

--- a/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/argo-events/argo-events-webhook/serviceaccount.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/argo-events/argo-events-webhook/serviceaccount.yaml
@@ -1,0 +1,15 @@
+---
+# Source: opentelemetry-database-monitoring/charts/argo-events/templates/argo-events-webhook/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: example-argo-events-events-webhook
+  namespace: "default"
+  labels:
+    helm.sh/chart: argo-events-2.4.22
+    app.kubernetes.io/name: argo-events-events-webhook
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/component: events-webhook
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: argo-events

--- a/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/argo-eventsource.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/argo-eventsource.yaml
@@ -1,0 +1,26 @@
+---
+# Source: opentelemetry-database-monitoring/templates/argo-eventsource.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: EventSource
+metadata:
+  name: example-opentelemetry-database-monitoring-pod-created
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  eventBusName: default
+  template:
+    serviceAccountName: example-opentelemetry-database-monitoring-argo-eventsource
+  resource:
+    target-pod-created-default:
+      namespace: default
+      group: ""
+      version: v1
+      resource: pods
+      eventTypes:
+        - ADD
+      filter:
+        afterStart: true

--- a/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/argo-sensor.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/argo-sensor.yaml
@@ -1,0 +1,102 @@
+---
+# Source: opentelemetry-database-monitoring/templates/argo-sensor.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  
+  name: example-opentelemetry-database-monitoring-sqlserver-sqlserver-setup
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: argo-sensor
+    opentelemetry-database-monitoring/database: sqlserver
+spec:
+  eventBusName: default
+  template:
+    serviceAccountName: example-opentelemetry-database-monitoring-argo-sensor
+  dependencies:
+    - name: target-pod-created-default
+      eventSourceName: example-opentelemetry-database-monitoring-pod-created
+      eventName: target-pod-created-default
+      filters:
+        data:
+          - path: body.metadata.annotations.sidecar\.opentelemetry\.io\/inject
+            type: string
+            value:
+              - "sqlserver-dbm-sidecar"
+  triggers:
+    - template:
+        name: create-sqlserver-sqlserver-monitoring-setup-job
+        k8s:
+          operation: create
+          source:
+            resource:
+              apiVersion: batch/v1
+              kind: Job
+              metadata:
+                generateName: sqlserver-sqlserver-monitoring-setup-
+                namespace: default
+                labels:
+                  helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+                  app.kubernetes.io/name: opentelemetry-database-monitoring
+                  app.kubernetes.io/instance: example
+                  app.kubernetes.io/version: "1.16.0"
+                  app.kubernetes.io/managed-by: Helm
+                  app.kubernetes.io/component: db-monitoring-setup
+                  opentelemetry-database-monitoring/database: sqlserver
+              spec:
+                backoffLimit: 3
+                template:
+                  metadata:
+                    labels:
+                      app.kubernetes.io/name: opentelemetry-database-monitoring
+                      app.kubernetes.io/instance: example
+                      app.kubernetes.io/component: db-monitoring-setup
+                      opentelemetry-database-monitoring/database: sqlserver
+                  spec:
+                    restartPolicy: OnFailure
+                    containers:
+                      - name: setup
+                        image: mcr.microsoft.com/mssql-tools:latest
+                        command:
+                          - /bin/sh
+                          - -c
+                          - |
+                            set -e
+                            SQLCMD=/opt/mssql-tools/bin/sqlcmd
+                            # -b makes sqlcmd exit non-zero on a SQL error, so `set -e` can act on it.
+                            until $SQLCMD -b -S sqlserver,1433 -U "$ADMIN_USER" -P "$ADMIN_PASSWORD" \
+                              -Q "SELECT 1" > /dev/null 2>&1; do sleep 2; done
+                            $SQLCMD -b -S sqlserver,1433 -U "$ADMIN_USER" -P "$ADMIN_PASSWORD" \
+                              -i /scripts/monitoring-setup.sql
+                            $SQLCMD -b -S sqlserver,1433 -U "$ADMIN_USER" -P "$ADMIN_PASSWORD" \
+                              -Q "ALTER LOGIN otel_monitor WITH PASSWORD = N'$OTEL_MONITOR_PASSWORD'"
+                            # Confirm the monitor login is usable on the endpoint the collector
+                            # connects to, and that it can read the views the sidecar scrapes.
+                            # Failing here lets backoffLimit retry rather than leaving a sidecar
+                            # that cannot authenticate.
+                            $SQLCMD -b -S sqlserver,1433 -U otel_monitor -P "$OTEL_MONITOR_PASSWORD" \
+                              -d otel -Q "SELECT TOP 0 1 FROM dbo.sqlserver_top_queries" > /dev/null
+                        env:
+                          - name: ADMIN_USER
+                            value: "sa"
+                          # Passed as an env var so the admin password stays off the container's
+                          # process list. It is still visible in the Job spec, because it comes
+                          # from values.
+                          - name: ADMIN_PASSWORD
+                            value: "otel"
+                          - name: OTEL_MONITOR_PASSWORD
+                            valueFrom:
+                              secretKeyRef:
+                                name: sqlserver-sqlserver-monitor-credentials
+                                key: password
+                        volumeMounts:
+                          - name: monitoring-setup
+                            mountPath: /scripts
+                    volumes:
+                      - name: monitoring-setup
+                        configMap:
+                          name: sqlserver-monitoring-setup

--- a/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/configmap-sqlserver-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/configmap-sqlserver-monitoring.yaml
@@ -1,0 +1,122 @@
+---
+# Source: opentelemetry-database-monitoring/templates/configmap-sqlserver-monitoring.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sqlserver-monitoring-setup
+data:
+  monitoring-setup.sql: |
+    -- Microsoft SQL Server monitoring setup for OpenTelemetry
+    -- Run as a login with sysadmin (or CREATE LOGIN + GRANT OPTION on the grants below).
+    -- Safe to re-run (all statements are idempotent).
+    --
+    -- The password below is a placeholder: the setup Job rewrites it with the
+    -- generated value from the monitor secret immediately after running this script,
+    -- so the literal never survives setup. It still has to satisfy the server's
+    -- password policy for CREATE LOGIN to succeed.
+    
+    -- ---------------------------------------------------------------------------
+    -- 1. Monitoring login
+    -- ---------------------------------------------------------------------------
+    
+    IF NOT EXISTS (SELECT 1 FROM sys.server_principals WHERE name = 'otel_monitor')
+        CREATE LOGIN otel_monitor WITH PASSWORD = 'Pl4ceholder!Rotated', CHECK_POLICY = ON;
+    GO
+    
+    -- Permission to read the server-state DMVs the receiver scrapes.
+    --
+    -- SQL Server 2022 (major version 16) introduced VIEW SERVER PERFORMANCE STATE as
+    -- the granular replacement for VIEW SERVER STATE. The new name does not exist on
+    -- earlier versions, so the grant is selected from the server's major version.
+    DECLARE @major int = CONVERT(int, SERVERPROPERTY('ProductMajorVersion'));
+    IF @major >= 16
+        EXEC('GRANT VIEW SERVER PERFORMANCE STATE TO otel_monitor');
+    ELSE
+        EXEC('GRANT VIEW SERVER STATE TO otel_monitor');
+    GO
+    
+    -- Required by the receiver to enumerate databases.
+    GRANT VIEW ANY DATABASE TO otel_monitor;
+    GO
+    
+    -- Required only for the per-index physical stats metrics (sqlserver.index.*):
+    -- the receiver enters each user database to read them.
+    GRANT CONNECT ANY DATABASE TO otel_monitor;
+    GRANT VIEW ANY DEFINITION TO otel_monitor;
+    GO
+    
+    -- ---------------------------------------------------------------------------
+    -- 2. Monitoring database
+    -- ---------------------------------------------------------------------------
+    
+    IF DB_ID('otel') IS NULL CREATE DATABASE otel;
+    GO
+    
+    USE otel;
+    GO
+    
+    -- ---------------------------------------------------------------------------
+    -- 3. Monitoring views
+    --
+    -- Attribute columns use OTel semconv names where defined:
+    --   db.namespace     → database name  (stable semconv)
+    --   db.query.text    → statement text (stable semconv)
+    --   db.query.hash    → query_hash     (experimental)
+    -- ---------------------------------------------------------------------------
+    
+    -- Top queries by total elapsed time, from the plan cache.
+    --
+    -- Three details in this query the metric depends on:
+    --   * The database is resolved from sys.dm_exec_plan_attributes rather than from
+    --     sys.dm_exec_sql_text, which reports a NULL dbid for ad-hoc batches and
+    --     would leave db.namespace empty for them.
+    --   * System databases are excluded. The collector's own DMV queries execute in
+    --     the master context and would otherwise occupy the top-N.
+    --   * last_execution_time bounds the window to recent activity.
+    --     sys.dm_exec_query_stats accumulates for as long as a plan stays cached, so
+    --     an unbounded query reports the highest all-time totals on every scrape and
+    --     stops reflecting current load. 300s covers the 60s collection interval.
+    CREATE OR ALTER VIEW dbo.sqlserver_top_queries AS
+    SELECT TOP 50
+        DB_NAME(CONVERT(int, pa.value))          AS [db.namespace],
+        CONVERT(varchar(64), qs.query_hash, 1)   AS [db.query.hash],
+        LEFT(COALESCE(t.text, ''), 1024)         AS [db.query.text],
+        qs.execution_count                       AS calls,
+        qs.total_worker_time  / 1000.0           AS total_cpu_time_ms,
+        qs.total_elapsed_time / 1000.0           AS total_elapsed_time_ms,
+        qs.total_logical_reads                   AS logical_reads,
+        qs.total_physical_reads                  AS physical_reads,
+        qs.total_logical_writes                  AS logical_writes,
+        qs.total_rows                            AS rows_returned
+    FROM sys.dm_exec_query_stats qs
+    CROSS APPLY sys.dm_exec_sql_text(qs.sql_handle) t
+    CROSS APPLY sys.dm_exec_plan_attributes(qs.plan_handle) pa
+    WHERE pa.attribute = 'dbid'
+      AND DB_NAME(CONVERT(int, pa.value)) IS NOT NULL
+      AND DB_NAME(CONVERT(int, pa.value)) NOT IN ('master', 'tempdb', 'model', 'msdb', 'otel')
+      AND qs.last_execution_time > DATEADD(second, -300, GETDATE())
+    ORDER BY qs.total_elapsed_time DESC;
+    GO
+    
+    -- Sessions currently blocked on another session, with the blocking chain.
+    CREATE OR ALTER VIEW dbo.sqlserver_blocking AS
+    SELECT
+        COALESCE(DB_NAME(r.database_id), '')     AS [db.namespace],
+        COALESCE(r.wait_type, '')                AS [db.mssql.wait.type],
+        COUNT(*)                                 AS blocked_session_count,
+        COALESCE(MAX(r.wait_time), 0) / 1000.0   AS max_wait_time_ms
+    FROM sys.dm_exec_requests r
+    WHERE r.blocking_session_id <> 0
+    GROUP BY DB_NAME(r.database_id), r.wait_type;
+    GO
+    
+    -- ---------------------------------------------------------------------------
+    -- 4. Grant the monitor login read access to the views
+    -- ---------------------------------------------------------------------------
+    
+    IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = 'otel_monitor')
+        CREATE USER otel_monitor FOR LOGIN otel_monitor;
+    GO
+    
+    GRANT SELECT ON SCHEMA::dbo TO otel_monitor;
+    GO

--- a/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/secret-sqlserver-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/secret-sqlserver-monitoring.yaml
@@ -1,0 +1,17 @@
+---
+# Source: opentelemetry-database-monitoring/templates/secret-sqlserver-monitoring.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sqlserver-sqlserver-monitor-credentials
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+    opentelemetry-database-monitoring/database: sqlserver
+type: Opaque
+data:
+  password: "<your-password>"

--- a/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/sqlserver-dbm-sidecar.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/rendered/sqlserver-dbm-sidecar.yaml
@@ -1,0 +1,324 @@
+---
+# Source: opentelemetry-database-monitoring/templates/sqlserver-dbm-sidecar.yaml
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: sqlserver-dbm-sidecar
+  annotations:
+    meta.helm.sh/release-name: "example"
+    meta.helm.sh/release-namespace: "default"
+  labels:
+    helm.sh/chart: opentelemetry-database-monitoring-0.2.0
+    app.kubernetes.io/name: opentelemetry-database-monitoring
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/managed-by: Helm
+    opentelemetry-database-monitoring/database: sqlserver
+spec:
+  mode: sidecar
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0
+  env:
+    - name: K8S_NODE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: OTEL_MONITOR_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: sqlserver-sqlserver-monitor-credentials
+          key: password
+  config:
+    receivers:
+      # The collector runs as a sidecar inside the SQL Server Pod and reaches the
+      # server over the Pod's own network namespace, so this traffic does not leave
+      # the Pod.
+      #
+      # This receiver exposes no TLS settings. Encryption is whatever the underlying
+      # go-mssqldb driver negotiates by default, and the only way to control it is
+      # the `datasource` connection string, which cannot be combined with the
+      # server/port/username/password settings used below. To reach a SQL Server
+      # outside the Pod, replace those four settings with a single `datasource` that
+      # sets the encryption parameters explicitly.
+      sqlserver:
+        server: ${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME}
+        port: 1433
+        username: otel_monitor
+        password: ${env:OTEL_MONITOR_PASSWORD}
+        collection_interval: 30s
+        # server, port, username and password must all be set together to enable the
+        # direct-connection mode, which reads the server's dynamic management views.
+        # Without all four the receiver collects Windows performance counters
+        # instead, which are only available when the collector runs on Windows.
+        #
+        # 13 of the receiver's 20 default-enabled metrics are Windows performance
+        # counters and report no data in this mode: lock.wait_time.avg,
+        # page.checkpoint.flush.rate, page.lazy_write.rate, page.operation.rate,
+        # page.split.rate, transaction.rate, transaction.write.rate, and the six
+        # transaction_log.* metrics. They are left at their upstream defaults so a
+        # Windows deployment still collects them.
+        #
+        # The metrics enabled below are the DMV-backed ones, each verified to report
+        # data on SQL Server 2022 running on Linux.
+        metrics:
+          sqlserver.access.scan.rate:
+            enabled: true
+          sqlserver.attention.rate:
+            enabled: true
+          sqlserver.clr.execution.time:
+            enabled: true
+          sqlserver.computer.uptime:
+            enabled: true
+          sqlserver.connection.reset.rate:
+            enabled: true
+          sqlserver.cpu.count:
+            enabled: true
+          sqlserver.cursor.count:
+            enabled: true
+          sqlserver.cursor.memory.usage:
+            enabled: true
+          sqlserver.cursor.plan.count:
+            enabled: true
+          sqlserver.cursor.request.rate:
+            enabled: true
+          sqlserver.database.backup_or_restore.rate:
+            enabled: true
+          sqlserver.database.count:
+            enabled: true
+          sqlserver.database.execution.errors:
+            enabled: true
+          sqlserver.database.full_scan.rate:
+            enabled: true
+          sqlserver.database.io:
+            enabled: true
+          sqlserver.database.latency:
+            enabled: true
+          sqlserver.database.operations:
+            enabled: true
+          sqlserver.database.tempdb.space:
+            enabled: true
+          sqlserver.database.tempdb.version_store.size:
+            enabled: true
+          sqlserver.deadlock.rate:
+            enabled: true
+          sqlserver.error.rate:
+            enabled: true
+          sqlserver.extent.operation.rate:
+            enabled: true
+          sqlserver.ghost_record.skipped.rate:
+            enabled: true
+          sqlserver.index.fragmentation:
+            enabled: true
+          sqlserver.index.page.count:
+            enabled: true
+          sqlserver.index.page.utilization:
+            enabled: true
+          sqlserver.index.record.count:
+            enabled: true
+          sqlserver.index.search.rate:
+            enabled: true
+          sqlserver.index.size:
+            enabled: true
+          sqlserver.latch.superlatch.count:
+            enabled: true
+          sqlserver.latch.superlatch.transition.rate:
+            enabled: true
+          sqlserver.latch.wait.rate:
+            enabled: true
+          sqlserver.latch.wait_time.avg:
+            enabled: true
+          sqlserver.latch.wait_time.total:
+            enabled: true
+          sqlserver.lock.block.count:
+            enabled: true
+          sqlserver.lock.escalation.rate:
+            enabled: true
+          sqlserver.lock.memory:
+            enabled: true
+          sqlserver.lock.request.rate:
+            enabled: true
+          sqlserver.lock.timeout.rate:
+            enabled: true
+          sqlserver.lock.wait.count:
+            enabled: true
+          sqlserver.lock.wait_time.total:
+            enabled: true
+          sqlserver.login.rate:
+            enabled: true
+          sqlserver.logout.rate:
+            enabled: true
+          sqlserver.memory.area:
+            enabled: true
+          sqlserver.memory.cache.object.count:
+            enabled: true
+          sqlserver.memory.grants.pending.count:
+            enabled: true
+          sqlserver.memory.page.count:
+            enabled: true
+          sqlserver.memory.usage:
+            enabled: true
+          sqlserver.os.wait.duration:
+            enabled: true
+          sqlserver.page.allocation.rate:
+            enabled: true
+          sqlserver.page.buffer_cache.free_list.stalls.rate:
+            enabled: true
+          sqlserver.page.lookup.rate:
+            enabled: true
+          sqlserver.page.read_ahead.rate:
+            enabled: true
+          sqlserver.parameterization.rate:
+            enabled: true
+          sqlserver.plan.execution.rate:
+            enabled: true
+          sqlserver.processes.blocked:
+            enabled: true
+          sqlserver.recompilation.ratio:
+            enabled: true
+          sqlserver.replica.data.rate:
+            enabled: true
+          sqlserver.resource_pool.disk.operations:
+            enabled: true
+          sqlserver.resource_pool.disk.throttled.read.rate:
+            enabled: true
+          sqlserver.resource_pool.disk.throttled.write.rate:
+            enabled: true
+          sqlserver.scan_point.revalidation.rate:
+            enabled: true
+          sqlserver.stored_procedure.invocation.rate:
+            enabled: true
+          sqlserver.table.count:
+            enabled: true
+          sqlserver.task.count:
+            enabled: true
+          sqlserver.task.rate:
+            enabled: true
+          sqlserver.transaction.delay:
+            enabled: true
+          sqlserver.transaction.mirror_write.rate:
+            enabled: true
+          sqlserver.worker.request.count:
+            enabled: true
+          sqlserver.worker.thread.count:
+            enabled: true
+          sqlserver.worktable.cache.hit_ratio:
+            enabled: true
+      # Top queries are collected as metrics through sqlquery. The receiver's native
+      # top_query_collection block reports the same data as log records through the
+      # db.server.top_query event, at Development stability; this chart exports
+      # metrics only. See the chart README.
+      sqlquery/sqlserver_top_queries:
+        collection_interval: 60s
+        driver: sqlserver
+        datasource: server=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME};user id=otel_monitor;password=${env:OTEL_MONITOR_PASSWORD};port=1433;database=otel
+        queries:
+          - sql: SELECT * FROM dbo.sqlserver_top_queries
+            metrics:
+              - attribute_columns:
+                  - db.namespace
+                  - db.query.hash
+                  - db.query.text
+                data_type: gauge
+                metric_name: sqlserver.query.calls
+                unit: "{query}"
+                value_column: calls
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.query.hash
+                  - db.query.text
+                data_type: gauge
+                metric_name: sqlserver.query.cpu_time
+                unit: ms
+                value_column: total_cpu_time_ms
+                value_type: double
+              - attribute_columns:
+                  - db.namespace
+                  - db.query.hash
+                  - db.query.text
+                data_type: gauge
+                metric_name: sqlserver.query.elapsed_time
+                unit: ms
+                value_column: total_elapsed_time_ms
+                value_type: double
+              - attribute_columns:
+                  - db.namespace
+                  - db.query.hash
+                  - db.query.text
+                data_type: gauge
+                metric_name: sqlserver.query.logical_reads
+                unit: "{page}"
+                value_column: logical_reads
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.query.hash
+                  - db.query.text
+                data_type: gauge
+                metric_name: sqlserver.query.physical_reads
+                unit: "{page}"
+                value_column: physical_reads
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.query.hash
+                  - db.query.text
+                data_type: gauge
+                metric_name: sqlserver.query.logical_writes
+                unit: "{page}"
+                value_column: logical_writes
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.query.hash
+                  - db.query.text
+                data_type: gauge
+                metric_name: sqlserver.query.rows
+                unit: "{row}"
+                value_column: rows_returned
+                value_type: int
+      sqlquery/sqlserver_blocking:
+        collection_interval: 30s
+        driver: sqlserver
+        datasource: server=${env:OTEL_RESOURCE_ATTRIBUTES_POD_NAME};user id=otel_monitor;password=${env:OTEL_MONITOR_PASSWORD};port=1433;database=otel
+        queries:
+          - sql: SELECT * FROM dbo.sqlserver_blocking
+            metrics:
+              - attribute_columns:
+                  - db.namespace
+                  - db.mssql.wait.type
+                data_type: gauge
+                metric_name: sqlserver.blocking.session.count
+                unit: "{session}"
+                value_column: blocked_session_count
+                value_type: int
+              - attribute_columns:
+                  - db.namespace
+                  - db.mssql.wait.type
+                data_type: gauge
+                metric_name: sqlserver.blocking.wait_time.max
+                unit: ms
+                value_column: max_wait_time_ms
+                value_type: double
+    processors:
+      batch:
+        send_batch_max_size: 5000
+        send_batch_size: 5000
+    exporters:
+      # otlp_grpc is the canonical exporter type. The shorter `otlp` spelling is a
+      # deprecated alias that logs a warning on every collector startup.
+      otlp_grpc:
+        compression: gzip
+        endpoint: ${env:K8S_NODE_IP}:4317
+        tls:
+          insecure: true
+    service:
+      pipelines:
+        metrics:
+          exporters:
+            - otlp_grpc
+          processors:
+            - batch
+          receivers:
+            - sqlserver
+            - sqlquery/sqlserver_top_queries
+            - sqlquery/sqlserver_blocking

--- a/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/values.yaml
+++ b/charts/opentelemetry-database-monitoring/examples/sqlserver-single-db/values.yaml
@@ -1,0 +1,10 @@
+---
+sqlserver:
+  enabled: true
+  databases:
+    - name: sqlserver
+      sidecar-name: sqlserver-dbm-sidecar
+      user: sa
+      pwd: otel
+      port: 1433
+      host: sqlserver

--- a/charts/opentelemetry-database-monitoring/templates/NOTES.txt
+++ b/charts/opentelemetry-database-monitoring/templates/NOTES.txt
@@ -10,6 +10,16 @@ PostgreSQL monitoring deployed for {{ len .Values.postgres.databases }} database
 {{ end }}
 {{- end }}
 
+{{- if .Values.sqlserver.enabled }}
+Microsoft SQL Server monitoring deployed for {{ len .Values.sqlserver.databases }} database(s).
+
+{{- range .Values.sqlserver.databases }}
+  Database : {{ .name }} ({{ .host }}:{{ .port }})
+  Secret   : {{ .name }}-sqlserver-monitor-credentials
+  Sidecar  : {{ index . "sidecar-name" }}
+  Inject   : {{ include "opentelemetry-database-monitoring.sidecarInjectValue" (dict "root" $ "db" .) }}
+{{ end }}
+{{- end }}
 {{- if and .Values.argoEvents.enabled .Values.argoEvents.triggerSetupJob }}
 Argo Events will create setup Jobs when a new Pod is added with the inject annotation above.
 Existing Pods are ignored (afterStart filter). Restart the target database Pod after install:

--- a/charts/opentelemetry-database-monitoring/templates/_helpers.tpl
+++ b/charts/opentelemetry-database-monitoring/templates/_helpers.tpl
@@ -62,7 +62,7 @@ The shared Argo Events plumbing is derived from this list, so adding an engine h
 is what brings it into the EventBus, EventSource and RBAC gating.
 */}}
 {{- define "opentelemetry-database-monitoring.engines" -}}
-postgres
+postgres sqlserver
 {{- end }}
 
 {{/*
@@ -117,6 +117,15 @@ Monitor credentials secret name for a PostgreSQL database entry.
 */}}
 {{- define "opentelemetry-database-monitoring.monitorSecretName" -}}
 {{- printf "%s-pg-monitor-credentials" .name -}}
+{{- end }}
+
+{{/*
+Monitor credentials secret name for a Microsoft SQL Server database entry.
+Kept separate per engine so two engines can never collide on a secret name
+when both are enabled with the same database entry name.
+*/}}
+{{- define "opentelemetry-database-monitoring.sqlserverMonitorSecretName" -}}
+{{- printf "%s-sqlserver-monitor-credentials" .name -}}
 {{- end }}
 
 {{/*

--- a/charts/opentelemetry-database-monitoring/templates/_job.tpl
+++ b/charts/opentelemetry-database-monitoring/templates/_job.tpl
@@ -62,3 +62,92 @@ spec:
           configMap:
             name: postgresql-monitoring-setup
 {{- end }}
+
+{{/*
+Render the Microsoft SQL Server monitoring setup Job.
+
+Context:
+  .root             - root Helm context
+  .db               - database entry from sqlserver.databases
+  .useName          - bool: use metadata.name
+  .useGenerateName  - bool: use metadata.generateName
+  .helmHook         - bool: add Helm post-install/post-upgrade hook annotations.
+                      Set when Helm owns the Job; leave unset when the Argo
+                      Events sensor creates it, which is not a Helm operation.
+*/}}
+{{- define "opentelemetry-database-monitoring.sqlserverSetupJob" -}}
+{{- $root := .root -}}
+{{- $db := .db -}}
+{{- $dbHost := include "opentelemetry-database-monitoring.databaseHost" (dict "root" $root "db" $db) -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  {{- if .useGenerateName }}
+  generateName: {{ $db.name }}-sqlserver-monitoring-setup-
+  {{- else }}
+  name: {{ $db.name }}-sqlserver-monitoring-setup
+  {{- end }}
+  {{- if .helmHook }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    {{- include "opentelemetry-database-monitoring.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: db-monitoring-setup
+    opentelemetry-database-monitoring/database: {{ $db.name }}
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "opentelemetry-database-monitoring.selectorLabels" $root | nindent 8 }}
+        app.kubernetes.io/component: db-monitoring-setup
+        opentelemetry-database-monitoring/database: {{ $db.name }}
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: setup
+          image: {{ $root.Values.sqlserver.setupImage | default "mcr.microsoft.com/mssql-tools:latest" }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              SQLCMD=/opt/mssql-tools/bin/sqlcmd
+              # -b makes sqlcmd exit non-zero on a SQL error, so `set -e` can act on it.
+              until $SQLCMD -b -S {{ $dbHost }},{{ $db.port }} -U "$ADMIN_USER" -P "$ADMIN_PASSWORD" \
+                -Q "SELECT 1" > /dev/null 2>&1; do sleep 2; done
+              $SQLCMD -b -S {{ $dbHost }},{{ $db.port }} -U "$ADMIN_USER" -P "$ADMIN_PASSWORD" \
+                -i /scripts/monitoring-setup.sql
+              $SQLCMD -b -S {{ $dbHost }},{{ $db.port }} -U "$ADMIN_USER" -P "$ADMIN_PASSWORD" \
+                -Q "ALTER LOGIN otel_monitor WITH PASSWORD = N'$OTEL_MONITOR_PASSWORD'"
+              # Confirm the monitor login is usable on the endpoint the collector
+              # connects to, and that it can read the views the sidecar scrapes.
+              # Failing here lets backoffLimit retry rather than leaving a sidecar
+              # that cannot authenticate.
+              $SQLCMD -b -S {{ $dbHost }},{{ $db.port }} -U otel_monitor -P "$OTEL_MONITOR_PASSWORD" \
+                -d otel -Q "SELECT TOP 0 1 FROM dbo.sqlserver_top_queries" > /dev/null
+          env:
+            - name: ADMIN_USER
+              value: {{ $db.user | quote }}
+            # Passed as an env var so the admin password stays off the container's
+            # process list. It is still visible in the Job spec, because it comes
+            # from values.
+            - name: ADMIN_PASSWORD
+              value: {{ $db.pwd | quote }}
+            - name: OTEL_MONITOR_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opentelemetry-database-monitoring.sqlserverMonitorSecretName" $db }}
+                  key: password
+          volumeMounts:
+            - name: monitoring-setup
+              mountPath: /scripts
+      volumes:
+        - name: monitoring-setup
+          configMap:
+            name: sqlserver-monitoring-setup
+{{- end }}

--- a/charts/opentelemetry-database-monitoring/templates/argo-sensor.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/argo-sensor.yaml
@@ -44,4 +44,45 @@ spec:
 {{ include "opentelemetry-database-monitoring.setupJob" (dict "root" $root "db" $db "useName" false "useGenerateName" true) | indent 14 }}
 {{- end }}
 {{- end }}
+{{- if .Values.sqlserver.enabled }}
+{{- range $db := .Values.sqlserver.databases }}
+{{- $sidecarInjectValue := include "opentelemetry-database-monitoring.sidecarInjectValue" (dict "root" $root "db" $db) }}
+{{- $targetNamespace := include "opentelemetry-database-monitoring.databaseNamespace" (merge (dict) $db (dict "Release" $root.Release)) }}
+{{- $eventName := printf "target-pod-created-%s" (include "opentelemetry-database-monitoring.argoResourceSuffix" $targetNamespace) }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  {{/* -sqlserver- keeps this from colliding with another engine's entry of the same name. */}}
+  name: {{ include "opentelemetry-database-monitoring.fullname" $root }}-{{ $db.name }}-sqlserver-setup
+  labels:
+    {{- include "opentelemetry-database-monitoring.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: argo-sensor
+    opentelemetry-database-monitoring/database: {{ $db.name }}
+spec:
+  {{- with $root.Values.argoEvents.eventBusName }}
+  eventBusName: {{ . }}
+  {{- end }}
+  template:
+    serviceAccountName: {{ $sensorSa }}
+  dependencies:
+    - name: {{ $eventName }}
+      eventSourceName: {{ $eventSourceName }}
+      eventName: {{ $eventName }}
+      filters:
+        data:
+          - path: body.metadata.annotations.{{ $annotationPath }}
+            type: string
+            value:
+              - {{ $sidecarInjectValue | quote }}
+  triggers:
+    - template:
+        name: create-{{ $db.name }}-sqlserver-monitoring-setup-job
+        k8s:
+          operation: create
+          source:
+            resource:
+{{ include "opentelemetry-database-monitoring.sqlserverSetupJob" (dict "root" $root "db" $db "useName" false "useGenerateName" true) | indent 14 }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/opentelemetry-database-monitoring/templates/configmap-sqlserver-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/configmap-sqlserver-monitoring.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.sqlserver.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sqlserver-monitoring-setup
+data:
+  monitoring-setup.sql: |
+{{ .Files.Get "assets/sqlserver-monitoring-setup.sql" | indent 4 }}
+{{- end }}

--- a/charts/opentelemetry-database-monitoring/templates/job-sqlserver-monitoring-setup.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/job-sqlserver-monitoring-setup.yaml
@@ -1,0 +1,7 @@
+{{- if and .Values.sqlserver.enabled (not (and .Values.argoEvents.enabled .Values.argoEvents.triggerSetupJob)) }}
+{{- $root := . }}
+{{- range $db := .Values.sqlserver.databases }}
+---
+{{ include "opentelemetry-database-monitoring.sqlserverSetupJob" (dict "root" $root "db" $db "useName" true "useGenerateName" false "helmHook" true) }}
+{{- end }}
+{{- end }}

--- a/charts/opentelemetry-database-monitoring/templates/secret-sqlserver-monitoring.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/secret-sqlserver-monitoring.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.sqlserver.enabled }}
+{{- $root := . }}
+{{- range $db := .Values.sqlserver.databases }}
+{{- $secretName := include "opentelemetry-database-monitoring.sqlserverMonitorSecretName" $db }}
+{{- $targetNamespace := include "opentelemetry-database-monitoring.databaseNamespace" (merge (dict) $db (dict "Release" $root.Release)) }}
+{{- $password := include "opentelemetry-database-monitoring.monitorPassword" (dict "root" $root "db" $db "secretName" $secretName) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ $root.Release.Namespace }}
+  labels:
+    {{- include "opentelemetry-database-monitoring.labels" $root | nindent 4 }}
+    opentelemetry-database-monitoring/database: {{ $db.name }}
+type: Opaque
+data:
+  password: {{ $password | b64enc | quote }}
+{{- if ne $targetNamespace $root.Release.Namespace }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ $targetNamespace }}
+  labels:
+    {{- include "opentelemetry-database-monitoring.labels" $root | nindent 4 }}
+    opentelemetry-database-monitoring/database: {{ $db.name }}
+type: Opaque
+data:
+  password: {{ $password | b64enc | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/opentelemetry-database-monitoring/templates/sqlserver-dbm-sidecar.yaml
+++ b/charts/opentelemetry-database-monitoring/templates/sqlserver-dbm-sidecar.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.sqlserver.enabled}}
+{{- $root := . }}
+{{- range $db := .Values.sqlserver.databases }}
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: {{ index $db "sidecar-name" }}
+  annotations:
+    meta.helm.sh/release-name: {{ $root.Release.Name | quote }}
+    meta.helm.sh/release-namespace: {{ $root.Release.Namespace | quote }}
+  labels:
+    {{- include "opentelemetry-database-monitoring.labels" $root | nindent 4 }}
+    opentelemetry-database-monitoring/database: {{ $db.name }}
+spec:
+  mode: sidecar
+  image: {{ $root.Values.sqlserver.image | default "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0" }}
+  env:
+    - name: K8S_NODE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: OTEL_MONITOR_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: {{ include "opentelemetry-database-monitoring.sqlserverMonitorSecretName" $db }}
+          key: password
+  config:
+{{ $root.Files.Get "assets/sqlserver-monitoring-config.yaml" | trimPrefix "---" | trim | indent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/opentelemetry-database-monitoring/tests/sqlserver_test.yaml
+++ b/charts/opentelemetry-database-monitoring/tests/sqlserver_test.yaml
@@ -1,0 +1,191 @@
+---
+suite: sqlserver monitoring tests
+templates:
+  - sqlserver-dbm-sidecar.yaml
+  - secret-sqlserver-monitoring.yaml
+  - configmap-sqlserver-monitoring.yaml
+  - job-sqlserver-monitoring-setup.yaml
+tests:
+  - it: should render nothing when sqlserver is disabled
+    set:
+      sqlserver.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create the sidecar collector with a pinned image
+    template: sqlserver-dbm-sidecar.yaml
+    set:
+      sqlserver.enabled: true
+    release:
+      name: "test-release"
+    asserts:
+      - isKind:
+          of: OpenTelemetryCollector
+      - equal:
+          path: metadata.name
+          value: "sqlserver-dbm-sidecar"
+      - equal:
+          path: spec.mode
+          value: sidecar
+      # An untagged image resolves to :latest and lets the collector version
+      # change under the receiver configuration.
+      - matchRegex:
+          path: spec.image
+          pattern: ":[0-9]+\\.[0-9]+\\.[0-9]+$"
+
+  - it: should wire the monitor password from the sqlserver secret
+    template: sqlserver-dbm-sidecar.yaml
+    set:
+      sqlserver.enabled: true
+    asserts:
+      - equal:
+          path: spec.env[1].name
+          value: OTEL_MONITOR_PASSWORD
+      - equal:
+          path: spec.env[1].valueFrom.secretKeyRef.name
+          value: "sqlserver-sqlserver-monitor-credentials"
+
+  - it: should set all four connection settings that enable direct-connection mode
+    template: sqlserver-dbm-sidecar.yaml
+    set:
+      sqlserver.enabled: true
+    asserts:
+      # Without all four, the receiver collects Windows performance counters
+      # instead, which are unavailable when the collector runs on Linux.
+      - exists:
+          path: spec.config.receivers.sqlserver.server
+      - equal:
+          path: spec.config.receivers.sqlserver.port
+          value: 1433
+      - equal:
+          path: spec.config.receivers.sqlserver.username
+          value: otel_monitor
+      - exists:
+          path: spec.config.receivers.sqlserver.password
+      # This receiver exposes no TLS settings; encryption is driver-negotiated.
+      - notExists:
+          path: spec.config.receivers.sqlserver.tls
+
+  - it: should enable the DMV-backed metrics that report data on linux
+    template: sqlserver-dbm-sidecar.yaml
+    set:
+      sqlserver.enabled: true
+    asserts:
+      - equal:
+          path: spec.config.receivers.sqlserver.metrics["sqlserver.database.io"].enabled
+          value: true
+      - equal:
+          path: spec.config.receivers.sqlserver.metrics["sqlserver.index.fragmentation"].enabled
+          value: true
+      - equal:
+          path: spec.config.receivers.sqlserver.metrics["sqlserver.processes.blocked"].enabled
+          value: true
+
+  - it: should collect top queries and blocking as metrics through sqlquery
+    template: sqlserver-dbm-sidecar.yaml
+    set:
+      sqlserver.enabled: true
+    asserts:
+      - equal:
+          path: spec.config.receivers["sqlquery/sqlserver_top_queries"].driver
+          value: sqlserver
+      - contains:
+          path: spec.config.service.pipelines.metrics.receivers
+          content: "sqlquery/sqlserver_top_queries"
+      - contains:
+          path: spec.config.service.pipelines.metrics.receivers
+          content: "sqlquery/sqlserver_blocking"
+      # The native top_query_collection block reports log records; this chart
+      # exports metrics only.
+      - notExists:
+          path: spec.config.service.pipelines.logs
+
+  - it: should create the monitor secret in the release namespace
+    template: secret-sqlserver-monitoring.yaml
+    set:
+      sqlserver.enabled: true
+    release:
+      namespace: "otel"
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: "sqlserver-sqlserver-monitor-credentials"
+      - equal:
+          path: metadata.namespace
+          value: "otel"
+      - exists:
+          path: data.password
+
+  - it: should replicate the secret into a cross-namespace target
+    template: secret-sqlserver-monitoring.yaml
+    set:
+      sqlserver.enabled: true
+      sqlserver.databases:
+        - name: sqlserver
+          namespace: databases
+          sidecar-name: sqlserver-dbm-sidecar
+          user: sa
+          pwd: otel
+          port: 1433
+          host: sqlserver
+    release:
+      namespace: "otel"
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.namespace
+          value: "otel"
+        documentIndex: 0
+      - equal:
+          path: metadata.namespace
+          value: "databases"
+        documentIndex: 1
+
+  - it: should mount setup sql that selects the grant by server version
+    template: configmap-sqlserver-monitoring.yaml
+    set:
+      sqlserver.enabled: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: "sqlserver-monitoring-setup"
+      # VIEW SERVER PERFORMANCE STATE does not exist before SQL Server 2022, so
+      # both grants must be present and chosen by major version.
+      - matchRegex:
+          path: data["monitoring-setup.sql"]
+          pattern: "VIEW SERVER PERFORMANCE STATE"
+      - matchRegex:
+          path: data["monitoring-setup.sql"]
+          pattern: "VIEW SERVER STATE"
+
+  - it: should create a Helm-hooked setup job when argo events is disabled
+    template: job-sqlserver-monitoring-setup.yaml
+    set:
+      sqlserver.enabled: true
+      argoEvents.enabled: false
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: metadata.name
+          value: "sqlserver-sqlserver-monitoring-setup"
+      # Without the hook annotations, an upgrade fails on the Job's immutable fields.
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: "post-install,post-upgrade"
+
+  - it: should not create a Helm setup job when argo events drives it
+    template: job-sqlserver-monitoring-setup.yaml
+    set:
+      sqlserver.enabled: true
+      argoEvents.enabled: true
+      argoEvents.triggerSetupJob: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/opentelemetry-database-monitoring/values.schema.json
+++ b/charts/opentelemetry-database-monitoring/values.schema.json
@@ -134,6 +134,49 @@
                     "type": "string"
                 }
             }
+        },
+        "sqlserver": {
+            "type": "object",
+            "properties": {
+                "databases": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "host": {
+                                "type": "string"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "type": "string"
+                            },
+                            "port": {
+                                "type": "integer"
+                            },
+                            "pwd": {
+                                "type": "string"
+                            },
+                            "sidecar-name": {
+                                "type": "string"
+                            },
+                            "user": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "image": {
+                    "type": "string"
+                },
+                "setupImage": {
+                    "type": "string"
+                }
+            }
         }
     }
 }

--- a/charts/opentelemetry-database-monitoring/values.yaml
+++ b/charts/opentelemetry-database-monitoring/values.yaml
@@ -49,6 +49,59 @@ postgres:
       host: ""
 
 # =============================================================================
+# MICROSOFT SQL SERVER
+# =============================================================================
+sqlserver:
+  # -- Deploy Microsoft SQL Server monitoring: the injected sidecar collector, the
+  # monitor credentials secret, the setup ConfigMap, and the setup Job.
+  # @default -- false
+  enabled: false
+  # Keep the tag. An untagged image resolves to :latest, which forces
+  # imagePullPolicy: Always and lets the collector version change under the
+  # receiver configuration in assets/sqlserver-monitoring-config.yaml.
+  # -- Collector image for the injected sidecar.
+  image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.157.0"
+  # -- Image for the setup Job. Must provide `sqlcmd` at
+  # /opt/mssql-tools/bin/sqlcmd.
+  setupImage: "mcr.microsoft.com/mssql-tools:latest"
+  # -- SQL Server instances to monitor. Each entry produces its own sidecar
+  # collector, monitor secret, and setup Job.
+  databases:
+      # -- Name for this instance. Used as the prefix of the monitor secret and
+      # setup Job names, and set as the
+      # `opentelemetry-database-monitoring/database` label on every resource.
+    - name: sqlserver
+      # -- Namespace where the annotated SQL Server Pod runs. Replicates the
+      # monitor secret into that namespace and sets the expected inject annotation
+      # to `<releaseNamespace>/<sidecar-name>` when it differs from the release
+      # namespace. Empty means the release namespace.
+      # @default -- ""
+      namespace: ""
+      # -- Name of the OpenTelemetryCollector resource for this instance. This is
+      # the value the target Pod's `sidecar.opentelemetry.io/inject` annotation
+      # must carry for the operator to inject the sidecar.
+      sidecar-name: sqlserver-dbm-sidecar
+      # -- Administrative login the setup Job connects as. Needs sysadmin, or
+      # CREATE LOGIN plus GRANT OPTION on the server-state permissions the setup
+      # SQL grants.
+      # @default -- ""
+      user: ""
+      # -- Password for the administrative login. Interpolated into the setup Job
+      # spec, so it is readable by anyone who can read Jobs in the release
+      # namespace. It is not written to a secret.
+      # @default -- ""
+      pwd: ""
+      # -- Port the setup Job connects to. The sidecar's receiver port is fixed at
+      # 1433 in assets/sqlserver-monitoring-config.yaml; override that asset to
+      # change the port the collector uses.
+      port: 1433
+      # -- Host the setup Job connects to, normally the SQL Server Service name. A
+      # value containing a dot is used as-is; otherwise, when the instance runs in
+      # another namespace, it is expanded to `<host>.<namespace>.svc.cluster.local`.
+      # @default -- ""
+      host: ""
+
+# =============================================================================
 # ARGO EVENTS SUBCHART
 # =============================================================================
 # Installs the Argo Events controller. The CRDs are shipped in this chart's crds/


### PR DESCRIPTION
Stacked on #147, which carries the shared scaffolding. **Base is `dbm/base`, so this
diff shows only SQL Server.**

## What this adds

A `sqlserver:` engine block: a sidecar `OpenTelemetryCollector`, a monitor credentials
secret, a setup ConfigMap and Job, an Argo Events sensor, an example with rendered
output, and a helm-unittest suite. Disabled by default. Requires SQL Server 2016+.

## Setup

The setup SQL creates a read-only `otel_monitor` login and installs two views in an
`otel` database. It **selects the server-state grant from the server's major
version**: SQL Server 2022 introduced `VIEW SERVER PERFORMANCE STATE` as the granular
replacement for `VIEW SERVER STATE`, and the new name does not exist on earlier
versions, so a single hard-coded grant would fail on one side or the other.

| View | Purpose |
|------|---------|
| `dbo.sqlserver_top_queries` | Top 50 cached plans by total elapsed time |
| `dbo.sqlserver_blocking` | Sessions blocked on another session, per database and wait type |

The top-queries view resolves the database from `sys.dm_exec_plan_attributes` rather
than `sys.dm_exec_sql_text`, which reports a NULL `dbid` for ad-hoc batches and would
leave `db.namespace` empty for exactly the queries you most want attributed. It also
excludes system databases, because the collector's own DMV queries run in the `master`
context, and bounds its window on `last_execution_time`.

## The Windows performance counter problem

This is the part most worth a reviewer's attention.

`server`, `port`, `username` and `password` must all be set together to enable the
receiver's **direct-connection mode**, which reads the dynamic management views.
Without all four, the receiver collects Windows performance counters, which are only
available when the collector itself runs on Windows.

**Only 7 of the receiver's 20 default-enabled metrics report data in that mode.** The
other 13 are Windows performance counters: `lock.wait_time.avg`,
`page.checkpoint.flush.rate`, `page.lazy_write.rate`, `page.operation.rate`,
`page.split.rate`, `transaction.rate`, `transaction.write.rate`, and the six
`transaction_log.*` metrics.

I enabled all 72 optional metrics against a live server to find which actually work:
**71 of 72 do**, taking this from 7 to **78 metrics**. The 13 Windows metrics are left
at their upstream defaults rather than force-disabled, so a Windows deployment still
collects them. `sqlserver.page.compression.rate` is the one optional metric left
disabled, having reported no data on SQL Server 2022 on Linux.

## TLS

This receiver exposes **no TLS settings at all**. Encryption is whatever the
underlying `go-mssqldb` driver negotiates, and the only way to control it is the
`datasource` connection string, which cannot be combined with
`server`/`port`/`username`/`password`. Documented in the README's SQL Server section.

## Metrics

Top queries and blocking sessions are collected as metrics with `sqlquery` over the
two views. The native `top_query_collection` block reports the same data as **log
records** at Development stability, and this chart exports metrics only.

## Testing

- `helm lint` clean; **25 helm-unittest tests**; `make check-examples` exit 0.
- Verified against **real SQL Server 2022 (16.0.4265.3)** on collector `0.157.0`, with
  the collector sharing the database container's network namespace. The setup SQL was
  run from scratch through `sqlcmd -b` in the same `mcr.microsoft.com/mssql-tools`
  image the Job uses, and the 2022 grant branch was confirmed by reading back
  `sys.server_permissions`.
- The blocking view was verified under **real blocking** (a session waiting on
  `LCK_M_X`), not from an empty result.

## Note on Chart.yaml

Deliberately not bumped, to avoid a three-way conflict with the sibling engine PRs and
12 files of `helm.sh/chart` label churn. Bump once when these land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
